### PR TITLE
Fix outdated template file to match code generator

### DIFF
--- a/src/Templates/ODataT4CodeGenerator.cs
+++ b/src/Templates/ODataT4CodeGenerator.cs
@@ -333,8 +333,8 @@ public bool IgnoreUnexpectedElementsAndAttributes
 /// </summary>
 public bool MakeTypesInternal
 {
-	get;
-	set;
+    get;
+    set;
 }
 
 /// <summary>
@@ -828,11 +828,11 @@ public class CodeGenerationContext
 	/// true to use internal access modifier for generated classes, otherwise they will be made public.
 	/// This is useful if you don't want the generated classes to be visible outside the assembly
 	/// </summary>
-	public bool MakeTypesInternal
-	{
-		get;
-		set;
-	}
+    public bool MakeTypesInternal
+    {
+        get;
+        set;
+    }
 
     /// <summary>
     /// Specifies which specific .Net Framework language the generated code will target.

--- a/src/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Templates/ODataT4CodeGenerator.ttinclude
@@ -3208,7 +3208,7 @@ namespace <#= fullNamespace #>
         /// Initialize a new <#= containerName #> object.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-        <#= ClassAccessModifier #> <#= fixedContainerName #>(global::System.Uri serviceRoot) : 
+        public <#= fixedContainerName #>(global::System.Uri serviceRoot) : 
                 base(serviceRoot, global::Microsoft.OData.Client.ODataProtocolVersion.V4)
         {
 <#+
@@ -3348,19 +3348,19 @@ namespace <#= fullNamespace #>
         /// <summary>
         /// Initialize a new <#= singleTypeName #> object.
         /// </summary>
-        <#= ClassAccessModifier #> <#= singleTypeName #>(global::Microsoft.OData.Client.DataServiceContext context, string path)
+        public <#= singleTypeName #>(global::Microsoft.OData.Client.DataServiceContext context, string path)
             : base(context, path) {}
 
         /// <summary>
         /// Initialize a new <#= singleTypeName #> object.
         /// </summary>
-        <#= ClassAccessModifier #> <#= singleTypeName #>(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
+        public <#= singleTypeName #>(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
             : base(context, path, isComposable) {}
 
         /// <summary>
         /// Initialize a new <#= singleTypeName #> object.
         /// </summary>
-        <#= ClassAccessModifier #> <#= singleTypeName #>(<#= baseTypeName #> query)
+        public <#= singleTypeName #>(<#= baseTypeName #> query)
             : base(query) {}
 
 <#+
@@ -3381,7 +3381,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> global::Microsoft.OData.Client.DataServiceQuery<<#= entitySetElementTypeName #>> <#= entitySetFixedName #>
+        public global::Microsoft.OData.Client.DataServiceQuery<<#= entitySetElementTypeName #>> <#= entitySetFixedName #>
         {
             get
             {
@@ -3423,7 +3423,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> <#= singletonElementTypeName #> <#= singletonFixedName #>
+        public <#= singletonElementTypeName #> <#= singletonFixedName #>
         {
             get
             {
@@ -3457,7 +3457,7 @@ namespace <#= fullNamespace #>
         /// There are no comments for <#= entitySetName #> in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-        <#= ClassAccessModifier #> void AddTo<#= entitySetName #>(<#= typeName #> <#= parameterName #>)
+        public void AddTo<#= entitySetName #>(<#= typeName #> <#= parameterName #>)
         {
             base.AddObject("<#= originalEntitySetName #>", <#= parameterName #>);
         }
@@ -3494,7 +3494,7 @@ namespace <#= fullNamespace #>
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
             private const string Edmx = @"<#= escapedEdmxString #>";
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-            <#= ClassAccessModifier #> static global::Microsoft.OData.Edm.IEdmModel GetInstance()
+            public static global::Microsoft.OData.Edm.IEdmModel GetInstance()
             {
                 return ParsedModel;
             }
@@ -3644,7 +3644,7 @@ namespace <#= fullNamespace #>
     {
 #>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-        <#= ClassAccessModifier #> static <#= fixedTypeName #> Create<#= typeName #>(<#+
+        public static <#= fixedTypeName #> Create<#= typeName #>(<#+
     }
 
     internal override void WriteParameterForStaticCreateMethod(string parameterTypeName, string parameterName, string parameterSeparater)
@@ -3700,7 +3700,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> <#= propertyType #> <#= fixedPropertyName #>
+        public <#= propertyType #> <#= fixedPropertyName #>
         {
             get
             {
@@ -3735,7 +3735,7 @@ namespace <#= fullNamespace #>
         /// This event is raised when the value of the property is changed
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-        <#= ClassAccessModifier #> event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
         /// <summary>
         /// The value of the property is changed
         /// </summary>
@@ -3822,7 +3822,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> global::Microsoft.OData.Client.DataServiceQuery<<#= returnTypeName #>> <#= functionName #>(<#= parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
+        public global::Microsoft.OData.Client.DataServiceQuery<<#= returnTypeName #>> <#= functionName #>(<#= parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
         {
             return this.CreateFunctionQuery<<#= returnTypeName #>>("", "<#= originalFunctionName #>", <#= isComposable.ToString().ToLower(CultureInfo.InvariantCulture) #><#= string.IsNullOrEmpty(parameterValues) ? string.Empty : ", " + parameterValues #>);
         }
@@ -3843,7 +3843,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> <#= isReturnEntity ? returnTypeName + this.singleSuffix : string.Format(CultureInfo.InvariantCulture, this.DataServiceQuerySingleStructureTemplate, returnTypeName) #> <#= functionName #>(<#= parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
+        public <#= isReturnEntity ? returnTypeName + this.singleSuffix : string.Format(CultureInfo.InvariantCulture, this.DataServiceQuerySingleStructureTemplate, returnTypeName) #> <#= functionName #>(<#= parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
         {
             return <#= isReturnEntity ? "new " + returnTypeName + this.singleSuffix + "(" : string.Empty #>this.CreateFunctionQuerySingle<<#= returnTypeName #>>("", "<#= originalFunctionName #>", <#= isComposable.ToString().ToLower(CultureInfo.InvariantCulture) #><#= string.IsNullOrEmpty(parameterValues) ? string.Empty : ", " + parameterValues #>)<#= isReturnEntity ? ")" : string.Empty #>;
         }
@@ -3864,7 +3864,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> <#= hideBaseMethod ? this.OverloadsModifier : string.Empty #>global::Microsoft.OData.Client.DataServiceQuery<<#= returnTypeName #>> <#= functionName #>(<#= parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
+        public <#= hideBaseMethod ? this.OverloadsModifier : string.Empty #>global::Microsoft.OData.Client.DataServiceQuery<<#= returnTypeName #>> <#= functionName #>(<#= parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
         {
             global::System.Uri requestUri;
             Context.TryGetUri(this, out requestUri);
@@ -3887,7 +3887,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> <#= hideBaseMethod ? this.OverloadsModifier : string.Empty #> <#= isReturnEntity ? returnTypeName + this.singleSuffix : string.Format(CultureInfo.InvariantCulture, this.DataServiceQuerySingleStructureTemplate, returnTypeName) #> <#= functionName #>(<#= parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
+        public <#= hideBaseMethod ? this.OverloadsModifier : string.Empty #> <#= isReturnEntity ? returnTypeName + this.singleSuffix : string.Format(CultureInfo.InvariantCulture, this.DataServiceQuerySingleStructureTemplate, returnTypeName) #> <#= functionName #>(<#= parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
         {
             global::System.Uri requestUri;
             Context.TryGetUri(this, out requestUri);
@@ -3911,7 +3911,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> <#= returnTypeName #> <#= actionName #>(<#= parameters #>)
+        public <#= returnTypeName #> <#= actionName #>(<#= parameters #>)
         {
             return new <#= returnTypeName #>(this, this.BaseUri.OriginalString.Trim('/') + "/<#= originalActionName #>"<#= string.IsNullOrEmpty(parameterValues) ? string.Empty : ", " + parameterValues #>);
         }
@@ -3932,7 +3932,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> <#= hideBaseMethod ? this.OverloadsModifier : string.Empty #><#= returnTypeName #> <#= actionName #>(<#= parameters #>)
+        public <#= hideBaseMethod ? this.OverloadsModifier : string.Empty #><#= returnTypeName #> <#= actionName #>(<#= parameters #>)
         {
             global::Microsoft.OData.Client.EntityDescriptor resource = Context.EntityTracker.TryGetEntityDescriptor(this);
             if (resource == null)
@@ -3971,7 +3971,7 @@ namespace <#= fullNamespace #>
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        <#= ClassAccessModifier #> static <#= returnTypeName #> ByKey(this global::Microsoft.OData.Client.DataServiceQuery<<#= entityTypeName #>> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static <#= returnTypeName #> ByKey(this global::Microsoft.OData.Client.DataServiceQuery<<#= entityTypeName #>> source, global::System.Collections.Generic.Dictionary<string, object> keys)
         {
             return new <#= returnTypeName #>(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -3987,7 +3987,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> static <#= returnTypeName #> ByKey(this global::Microsoft.OData.Client.DataServiceQuery<<#= entityTypeName #>> source,
+        public static <#= returnTypeName #> ByKey(this global::Microsoft.OData.Client.DataServiceQuery<<#= entityTypeName #>> source,
             <#= keyParameters #>)
         {
             global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
@@ -4006,7 +4006,7 @@ namespace <#= fullNamespace #>
         /// Cast an entity of type <#= baseTypeName #> to its derived type <#= derivedTypeFullName #>
         /// </summary>
         /// <param name="source">source entity</param>
-        <#= ClassAccessModifier #> static <#= returnTypeName #> CastTo<#= derivedTypeName #>(this global::Microsoft.OData.Client.DataServiceQuerySingle<<#= baseTypeName #>> source)
+        public static <#= returnTypeName #> CastTo<#= derivedTypeName #>(this global::Microsoft.OData.Client.DataServiceQuerySingle<<#= baseTypeName #>> source)
         {
             global::Microsoft.OData.Client.DataServiceQuerySingle<<#= derivedTypeFullName #>> query = source.CastTo<<#= derivedTypeFullName #>>();
             return new <#= returnTypeName #>(source.Context, query.GetPath(null));
@@ -4028,7 +4028,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> static <#= isReturnEntity ? returnTypeName + this.singleSuffix : string.Format(CultureInfo.InvariantCulture, this.DataServiceQuerySingleStructureTemplate, returnTypeName) #> <#= functionName #>(this <#= boundTypeName #> source<#= string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
+        public static <#= isReturnEntity ? returnTypeName + this.singleSuffix : string.Format(CultureInfo.InvariantCulture, this.DataServiceQuerySingleStructureTemplate, returnTypeName) #> <#= functionName #>(this <#= boundTypeName #> source<#= string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters #><#= useEntityReference ? ", bool useEntityReference = false" : string.Empty #>)
         {
             if (!source.IsComposable)
             {
@@ -4054,7 +4054,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> static global::Microsoft.OData.Client.DataServiceQuery<<#= returnTypeName #>> <#= functionName #>(this <#= boundTypeName #> source<#= string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters #><#= useEntityReference ? ", bool useEntityReference = true" : string.Empty #>)
+        public static global::Microsoft.OData.Client.DataServiceQuery<<#= returnTypeName #>> <#= functionName #>(this <#= boundTypeName #> source<#= string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters #><#= useEntityReference ? ", bool useEntityReference = true" : string.Empty #>)
         {
             if (!source.IsComposable)
             {
@@ -4080,7 +4080,7 @@ namespace <#= fullNamespace #>
 <#+
         }
 #>
-        <#= ClassAccessModifier #> static <#= returnTypeName #> <#= actionName #>(this <#= boundSourceType #> source<#= string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters #>)
+        public static <#= returnTypeName #> <#= actionName #>(this <#= boundSourceType #> source<#= string.IsNullOrEmpty(parameters) ? string.Empty : ", " + parameters #>)
         {
             if (!source.IsComposable)
             {


### PR DESCRIPTION
The template file in the codebase (`ODataT4CodeGenerator.ttinclude`) was incorrect, it's an outdated version from an old commit that added the `internal` modifier to both method and classes when `MakeTypesInternal` is set to true. However, this generated code that had build errors because internal methods can't implement interfaces (e.g. `INotifyChanged`), this was fixed by a later commit. But it appears that during a rebase, the outdated template fail was retained instead of the corrected one. This PR fixes that issue, removing the internal class modifier from methods that should be public.

Note the `ODataT4CodeGenerator.cs` file was still correct, and that's why tests were still passing.