### PR TITLE
Upgrade Microsoft.OData.Client lib to version 7.4.0

### DIFF
--- a/src/ODataConnectedService.csproj
+++ b/src/ODataConnectedService.csproj
@@ -87,17 +87,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\external\Binaries\V3\Microsoft.Data.Services.Design.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Client, Version=6.17.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Client.6.17.0\lib\net40\Microsoft.OData.Client.dll</HintPath>
+    <Reference Include="Microsoft.OData.Client, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Client.7.4.0\lib\net45\Microsoft.OData.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=6.17.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Core.6.17.0\lib\portable-net45+win+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Core.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=6.17.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Edm.6.17.0\lib\portable-net45+win+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Edm.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=6.17.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Spatial.6.17.0\lib\portable-net45+win+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.ComponentModelHost.15.7.27703\lib\net45\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>

--- a/src/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Templates/ODataT4CodeGenerator.ttinclude
@@ -30,10 +30,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 <#@ Import Namespace="System.Collections.Generic" #>
 <#@ Import Namespace="Microsoft.OData.Edm.Csdl" #>
 <#@ Import Namespace="Microsoft.OData.Edm" #>
-<#@ Import Namespace="Microsoft.OData.Edm.Annotations" #>
-<#@ Import Namespace="Microsoft.OData.Edm.Expressions" #>
-<#@ Import Namespace="Microsoft.OData.Edm.Library" #>
-<#@ Import Namespace="Microsoft.OData.Edm.Values" #>
+<#@ Import Namespace="Microsoft.OData.Edm.Vocabularies" #>
 <#@ Import Namespace="Microsoft.OData.Edm.Vocabularies.V1" #>
 <#@ Import Namespace="Microsoft.OData.Edm.Vocabularies.Community.V1" #>
 <#@ Import Namespace="System.Text"#>
@@ -410,12 +407,12 @@ private void ApplyParametersFromCommandLine()
 public class CodeGenerationContext
 {
     /// <summary>
-    /// The namespace of the term to use when building value annotations for indicating the conventions used.
+    /// The namespace of the term to use when building annotations for indicating the conventions used.
     /// </summary>
     private const string ConventionTermNamespace = "Com.Microsoft.OData.Service.Conventions.V1";
 
     /// <summary>
-    /// The name of the term to use when building value annotations for indicating the conventions used.
+    /// The name of the term to use when building annotations for indicating the conventions used.
     /// </summary>
     private const string ConventionTermName = "UrlConventions";
 
@@ -514,12 +511,12 @@ public class CodeGenerationContext
                 Debug.Assert(this.edmx != null, "this.edmx != null");
 
                 IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors;
-                EdmxReaderSettings edmxReaderSettings = new EdmxReaderSettings()
+                CsdlReaderSettings csdlReaderSettings = new CsdlReaderSettings()
                 {
                     GetReferencedModelReaderFunc = this.GetReferencedModelReaderFuncWrapper,
                     IgnoreUnexpectedAttributesAndElements = this.IgnoreUnexpectedElementsAndAttributes
                 };
-                if (!EdmxReader.TryParse(this.edmx.CreateReader(ReaderOptions.None), Enumerable.Empty<IEdmModel>(), edmxReaderSettings, out this.edmModel, out errors))
+                if (!CsdlReader.TryParse(this.edmx.CreateReader(ReaderOptions.None), Enumerable.Empty<IEdmModel>(), csdlReaderSettings, out this.edmModel, out errors))
                 {
                     Debug.Assert(errors != null, "errors != null");
                     throw new InvalidOperationException(errors.FirstOrDefault().ErrorMessage);
@@ -629,7 +626,9 @@ public class CodeGenerationContext
             if (!this.modelHasInheritance.HasValue)
             {
                 Debug.Assert(this.EdmModel != null, "this.EdmModel != null");
-                this.modelHasInheritance = this.EdmModel.SchemaElementsAcrossModels().OfType<IEdmStructuredType>().Any(t => t.BaseType != null);
+                this.modelHasInheritance = this.EdmModel.SchemaElementsAcrossModels().OfType<IEdmStructuredType>().Any(t => !t.FullTypeName().StartsWith("Org.OData.Authorization.V1") && 
+                            !t.FullTypeName().StartsWith("Org.OData.Capabilities.V1") && 
+                            !t.FullTypeName().StartsWith("Org.OData.Core.V1") && t.BaseType != null);
             }
 
             return this.modelHasInheritance.Value;
@@ -770,10 +769,10 @@ public class CodeGenerationContext
             this.keyAsSegmentContainers = new HashSet<string>();
             Debug.Assert(this.EdmModel != null, "this.EdmModel != null");
             IEnumerable<IEdmVocabularyAnnotation> annotations = this.EdmModel.VocabularyAnnotations;
-            foreach(IEdmValueAnnotation valueAnnotation in annotations.OfType<IEdmValueAnnotation>())
+            foreach(IEdmVocabularyAnnotation valueAnnotation in annotations)
             {
                 IEdmEntityContainer container = valueAnnotation.Target as IEdmEntityContainer;
-                IEdmValueTerm valueTerm = valueAnnotation.Term as IEdmValueTerm;
+                IEdmTerm valueTerm = valueAnnotation.Term as IEdmTerm;
                 IEdmStringConstantExpression expression = valueAnnotation.Value as IEdmStringConstantExpression;
                 if (container != null && valueTerm != null && expression != null)
                 {
@@ -927,7 +926,7 @@ public class CodeGenerationContext
     private static IEnumerable<T> GetElementsFromModelTree<T>(IEdmModel mainModel, Func<IEdmModel, IEnumerable<T>> getElementFromOneModelFunc)
     {
         List<T> ret = new List<T>();
-        if(mainModel is EdmCoreModel || mainModel.FindDeclaredValueTerm(CoreVocabularyConstants.OptimisticConcurrencyControl) != null)
+        if(mainModel is EdmCoreModel || mainModel.FindDeclaredTerm(CoreVocabularyConstants.OptimisticConcurrency) != null)
         {
             return ret;
         }
@@ -936,9 +935,10 @@ public class CodeGenerationContext
         foreach (var tmp in mainModel.ReferencedModels)
         {
             if (tmp is EdmCoreModel ||
-                tmp.FindDeclaredValueTerm(CoreVocabularyConstants.OptimisticConcurrencyControl) != null ||
-                tmp.FindDeclaredValueTerm(CapabilitiesVocabularyConstants.ChangeTracking) != null ||
-                tmp.FindDeclaredValueTerm(AlternateKeysVocabularyConstants.AlternateKeys) != null)
+                tmp.FindDeclaredTerm(CoreVocabularyConstants.OptimisticConcurrency) != null ||
+                tmp.FindDeclaredTerm(CapabilitiesVocabularyConstants.ChangeTracking) != null ||
+                tmp.FindDeclaredTerm(AlternateKeysVocabularyConstants.AlternateKeys) != null ||
+                tmp.FindDeclaredTerm("Org.OData.Authorization.V1.Authorizations") != null)
             {
                 continue;
             }
@@ -1648,7 +1648,7 @@ public abstract class ODataClientTemplate : TemplateBase
         {
             string propertyType;
             string propertyName = this.context.EnableNamingAlias ? Customization.CustomizeNaming(property.Name) : property.Name;
-            if (property.Type is Microsoft.OData.Edm.Library.EdmCollectionTypeReference)
+            if (property.Type is Microsoft.OData.Edm.EdmCollectionTypeReference)
             {
                 propertyType = GetSourceOrReturnTypeName(property.Type);
                 WriteContextEntitySetProperty(propertyName, GetFixedName(propertyName), property.Name, propertyType, false);
@@ -2220,7 +2220,7 @@ public abstract class ODataClientTemplate : TemplateBase
             string value = string.Empty;
             if (member.Value != null)
             {
-                IEdmIntegerValue integerValue = member.Value as IEdmIntegerValue;
+                IEdmEnumMemberValue integerValue = member.Value as IEdmEnumMemberValue;
                 if (integerValue != null)
                 {
                     value = " = " + integerValue.Value.ToString(CultureInfo.InvariantCulture);
@@ -3132,10 +3132,10 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
     internal override string GeometryMultiPolygonTypeName { get { return "global::Microsoft.Spatial.GeometryMultiPolygon"; } }
     internal override string GeometryMultiLineStringTypeName { get { return "global::Microsoft.Spatial.GeometryMultiLineString"; } }
     internal override string GeometryMultiPointTypeName { get { return "global::Microsoft.Spatial.GeometryMultiPoint"; } }
-    internal override string DateTypeName { get { return "global::Microsoft.OData.Edm.Library.Date"; } }
+    internal override string DateTypeName { get { return "global::Microsoft.OData.Edm.Date"; } }
     internal override string DateTimeOffsetTypeName { get { return "global::System.DateTimeOffset"; } }
     internal override string DurationTypeName { get { return "global::System.TimeSpan"; } }
-    internal override string TimeOfDayTypeName { get { return "global::Microsoft.OData.Edm.Library.TimeOfDay"; } }
+    internal override string TimeOfDayTypeName { get { return "global::Microsoft.OData.Edm.TimeOfDay"; } }
     internal override string XmlConvertClassName { get { return "global::System.Xml.XmlConvert"; } }
     internal override string EnumTypeName { get { return "global::System.Enum"; } }
     internal override string FixPattern { get { return "@{0}"; } }
@@ -3147,7 +3147,7 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
     internal override string BodyOperationParameterConstructor { get { return "new global::Microsoft.OData.Client.BodyOperationParameter(\"{0}\", {1})"; } }
     internal override string BaseEntityType { get { return " : global::Microsoft.OData.Client.BaseEntityType"; } }
     internal override string OverloadsModifier { get { return "new "; } }
-    internal override string ODataVersion { get { return "global::Microsoft.OData.Core.ODataVersion.V4"; } }
+    internal override string ODataVersion { get { return "global::Microsoft.OData.ODataVersion.V4"; } }
     internal override string ParameterDeclarationTemplate { get { return "{0} {1}"; } }
     internal override string DictionaryItemConstructor { get { return "{{ {0}, {1} }}"; } }
     internal override HashSet<string> LanguageKeywords { get {
@@ -3227,7 +3227,7 @@ namespace <#= fullNamespace #>
     internal override void WriteKeyAsSegmentUrlConvention()
     {
 #>
-            this.UrlConventions = global::Microsoft.OData.Client.DataServiceUrlConventions.KeyAsSegment;
+            this.UrlKeyDelimiter = global::Microsoft.OData.Client.DataServiceUrlKeyDelimiter.Slash;
 <#+
     }
 
@@ -3529,7 +3529,7 @@ namespace <#= fullNamespace #>
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader, getReferencedModelFromMap);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, getReferencedModelFromMap);
                 }
                 finally
                 {
@@ -3547,7 +3547,7 @@ namespace <#= fullNamespace #>
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {
@@ -4173,10 +4173,10 @@ public sealed class ODataClientVBTemplate : ODataClientTemplate
     internal override string GeometryMultiPolygonTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiPolygon"; } }
     internal override string GeometryMultiLineStringTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiLineString"; } }
     internal override string GeometryMultiPointTypeName { get { return "Global.Microsoft.Spatial.GeometryMultiPoint"; } }
-    internal override string DateTypeName { get { return "Global.Microsoft.OData.Edm.Library.Date"; } }
+    internal override string DateTypeName { get { return "Global.Microsoft.OData.Edm.Date"; } }
     internal override string DateTimeOffsetTypeName { get { return "Global.System.DateTimeOffset"; } }
     internal override string DurationTypeName { get { return "Global.System.TimeSpan"; } }
-    internal override string TimeOfDayTypeName { get { return "Global.Microsoft.OData.Edm.Library.TimeOfDay"; } }
+    internal override string TimeOfDayTypeName { get { return "Global.Microsoft.OData.Edm.TimeOfDay"; } }
     internal override string XmlConvertClassName { get { return "Global.System.Xml.XmlConvert"; } }
     internal override string EnumTypeName { get { return "Global.System.Enum"; } }
     internal override string FixPattern { get { return "[{0}]"; } }
@@ -4188,7 +4188,7 @@ public sealed class ODataClientVBTemplate : ODataClientTemplate
     internal override string BodyOperationParameterConstructor { get { return "New Global.Microsoft.OData.Client.BodyOperationParameter(\"{0}\", {1})"; } }
     internal override string BaseEntityType { get { return "\r\n        Inherits Global.Microsoft.OData.Client.BaseEntityType"; } }
     internal override string OverloadsModifier { get { return "Overloads "; } }
-    internal override string ODataVersion { get { return "Global.Microsoft.OData.Core.ODataVersion.V4"; } }
+    internal override string ODataVersion { get { return "Global.Microsoft.OData.ODataVersion.V4"; } }
     internal override string ParameterDeclarationTemplate { get { return "{1} As {0}"; } }
     internal override string DictionaryItemConstructor { get { return "{{ {0}, {1} }}"; } }
     internal override HashSet<string> LanguageKeywords { get { 
@@ -4279,7 +4279,7 @@ Namespace <#= fullNamespace #>
     internal override void WriteKeyAsSegmentUrlConvention()
     {
 #>
-            Me.UrlConventions = Global.Microsoft.OData.Client.DataServiceUrlConventions.KeyAsSegment
+            Me.UrlKeyDelimiter = Global.Microsoft.OData.Client.DataServiceUrlKeyDelimiter.Slash
 <#+
     }
 
@@ -4580,7 +4580,7 @@ Namespace <#= fullNamespace #>
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader, AddressOf getReferencedModelFromMap)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, AddressOf getReferencedModelFromMap)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try
@@ -4594,7 +4594,7 @@ Namespace <#= fullNamespace #>
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/src/app.config
+++ b/src/app.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="EnvDTE" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0"/>
+        <assemblyIdentity name="EnvDTE" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.VisualStudio.ComponentModelHost" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0"/>
+        <assemblyIdentity name="Microsoft.VisualStudio.ComponentModelHost" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-	<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+	<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.OData.Client" version="6.17.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Core" version="6.17.0" targetFramework="net45" />
-  <package id="Microsoft.OData.Edm" version="6.17.0" targetFramework="net45" />
-  <package id="Microsoft.Spatial" version="6.17.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Client" version="7.4.0" targetFramework="net472" />
+  <package id="Microsoft.OData.Core" version="7.4.0" targetFramework="net472" />
+  <package id="Microsoft.OData.Edm" version="7.4.0" targetFramework="net472" />
+  <package id="Microsoft.Spatial" version="7.4.0" targetFramework="net472" />
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="15.7.27703" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.ConnectedServices" version="2.0.0" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net45" />

--- a/test/ODataConnectedService.Tests/CodeGenReferences/AbstractEntityTypeWithoutKey.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/AbstractEntityTypeWithoutKey.vb
@@ -184,7 +184,7 @@ Namespace AbstractEntityTypeWithoutKey
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/AbstractEntityTypeWithoutKeyDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/AbstractEntityTypeWithoutKeyDSC.cs
@@ -166,7 +166,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/DupNames.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/DupNames.cs
@@ -137,7 +137,7 @@ namespace DupNames
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/DupNamesDSC.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/DupNamesDSC.vb
@@ -128,7 +128,7 @@ Namespace DupNames.DSC
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/DupNamesWithCamelCase.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/DupNamesWithCamelCase.vb
@@ -165,7 +165,7 @@ Namespace DupNames
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/DupNamesWithCamelCaseDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/DupNamesWithCamelCaseDSC.cs
@@ -176,7 +176,7 @@ namespace DupNames.DSC
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctions.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctions.cs
@@ -228,7 +228,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsDSC.cs
@@ -228,7 +228,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsDSCWithInternalTypes.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsDSCWithInternalTypes.cs
@@ -228,7 +228,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsWithInternalTypes.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsWithInternalTypes.cs
@@ -228,7 +228,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntityHierarchyWithIDAndIdDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntityHierarchyWithIDAndIdDSC.cs
@@ -99,7 +99,7 @@ namespace Namespace1.DSC
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/KeywordsAsNames.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/KeywordsAsNames.cs
@@ -106,7 +106,7 @@ namespace Namespace1
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/KeywordsAsNames.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/KeywordsAsNames.vb
@@ -101,7 +101,7 @@ Namespace Namespace1
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTest.cs
@@ -23,7 +23,7 @@ namespace MergedFunctionalTest
         public TestContainer(global::System.Uri serviceRoot) : 
                 base(serviceRoot, global::Microsoft.OData.Client.ODataProtocolVersion.V4)
         {
-            this.UrlConventions = global::Microsoft.OData.Client.DataServiceUrlConventions.KeyAsSegment;
+            this.UrlKeyDelimiter = global::Microsoft.OData.Client.DataServiceUrlKeyDelimiter.Slash;
             this.ResolveName = new global::System.Func<global::System.Type, string>(this.ResolveNameFromType);
             this.OnContextCreated();
             this.Format.LoadServiceModel = GeneratedEdmModel.GetInstance;
@@ -552,14 +552,14 @@ namespace MergedFunctionalTest
         <Property Name=""ValueProp"" Type=""Edm.String"" Nullable=""false"" />
       </EntityType>
       <EntityType Name=""Child"" BaseType=""MergedFunctionalTest.Person"">
-        <Property Name=""Description"" Type=""Edm.String"" ConcurrencyMode=""Fixed"" />
+        <Property Name=""Description"" Type=""Edm.String"" />
       </EntityType>
       <EntityType Name=""Person"">
         <Key>
           <PropertyRef Name=""ID"" />
         </Key>
         <Property Name=""ID"" Type=""Edm.Guid"" Nullable=""false"" />
-        <Property Name=""Name"" Type=""Edm.String"" ConcurrencyMode=""Fixed"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
       </EntityType>
       <EntityType Name=""TestType"">
         <Key>
@@ -1032,7 +1032,7 @@ namespace MergedFunctionalTest
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {
@@ -2705,8 +2705,8 @@ namespace MergedFunctionalTest
                     string nonNullableStringProp, 
                     global::System.TimeSpan nonNullableDurationProp, 
                     global::System.DateTimeOffset nonNullableDateTimeOffsetProp, 
-                    global::Microsoft.OData.Edm.Library.Date nonNullableDateProp, 
-                    global::Microsoft.OData.Edm.Library.TimeOfDay nonNullableTimeOfDayProp, 
+                    global::Microsoft.OData.Edm.Date nonNullableDateProp, 
+                    global::Microsoft.OData.Edm.TimeOfDay nonNullableTimeOfDayProp, 
                     global::Microsoft.OData.Client.DataServiceStreamLink nonNullableStreamProp, 
                     sbyte nonNullableSByteProp, 
                     global::Microsoft.Spatial.Geography nonNullableGeography, 
@@ -3635,7 +3635,7 @@ namespace MergedFunctionalTest
         /// There are no comments for Property NonNullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::Microsoft.OData.Edm.Library.Date NonNullableDateProp
+        public global::Microsoft.OData.Edm.Date NonNullableDateProp
         {
             get
             {
@@ -3649,14 +3649,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::Microsoft.OData.Edm.Library.Date _NonNullableDateProp;
-        partial void OnNonNullableDatePropChanging(global::Microsoft.OData.Edm.Library.Date value);
+        private global::Microsoft.OData.Edm.Date _NonNullableDateProp;
+        partial void OnNonNullableDatePropChanging(global::Microsoft.OData.Edm.Date value);
         partial void OnNonNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property ExplicitlyNullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> ExplicitlyNullableDateProp
+        public global::System.Nullable<global::Microsoft.OData.Edm.Date> ExplicitlyNullableDateProp
         {
             get
             {
@@ -3670,14 +3670,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> _ExplicitlyNullableDateProp;
-        partial void OnExplicitlyNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> value);
+        private global::System.Nullable<global::Microsoft.OData.Edm.Date> _ExplicitlyNullableDateProp;
+        partial void OnExplicitlyNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Date> value);
         partial void OnExplicitlyNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property NullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> NullableDateProp
+        public global::System.Nullable<global::Microsoft.OData.Edm.Date> NullableDateProp
         {
             get
             {
@@ -3691,14 +3691,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> _NullableDateProp;
-        partial void OnNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> value);
+        private global::System.Nullable<global::Microsoft.OData.Edm.Date> _NullableDateProp;
+        partial void OnNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Date> value);
         partial void OnNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property NonNullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::Microsoft.OData.Edm.Library.TimeOfDay NonNullableTimeOfDayProp
+        public global::Microsoft.OData.Edm.TimeOfDay NonNullableTimeOfDayProp
         {
             get
             {
@@ -3712,14 +3712,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::Microsoft.OData.Edm.Library.TimeOfDay _NonNullableTimeOfDayProp;
-        partial void OnNonNullableTimeOfDayPropChanging(global::Microsoft.OData.Edm.Library.TimeOfDay value);
+        private global::Microsoft.OData.Edm.TimeOfDay _NonNullableTimeOfDayProp;
+        partial void OnNonNullableTimeOfDayPropChanging(global::Microsoft.OData.Edm.TimeOfDay value);
         partial void OnNonNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property ExplicitlyNullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> ExplicitlyNullableTimeOfDayProp
+        public global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> ExplicitlyNullableTimeOfDayProp
         {
             get
             {
@@ -3733,14 +3733,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> _ExplicitlyNullableTimeOfDayProp;
-        partial void OnExplicitlyNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> value);
+        private global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> _ExplicitlyNullableTimeOfDayProp;
+        partial void OnExplicitlyNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> value);
         partial void OnExplicitlyNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property NullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> NullableTimeOfDayProp
+        public global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> NullableTimeOfDayProp
         {
             get
             {
@@ -3754,8 +3754,8 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> _NullableTimeOfDayProp;
-        partial void OnNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> value);
+        private global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> _NullableTimeOfDayProp;
+        partial void OnNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> value);
         partial void OnNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property NonNullableStreamProp in the schema.
@@ -5297,7 +5297,7 @@ namespace MergedFunctionalTest
         /// There are no comments for Property BagOfDate in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Library.Date> BagOfDate
+        public global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Date> BagOfDate
         {
             get
             {
@@ -5311,14 +5311,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Library.Date> _BagOfDate = new global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Library.Date>();
-        partial void OnBagOfDateChanging(global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Library.Date> value);
+        private global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Date> _BagOfDate = new global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Date>();
+        partial void OnBagOfDateChanging(global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Date> value);
         partial void OnBagOfDateChanged();
         /// <summary>
         /// There are no comments for Property BagOfTimeOfDay in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Library.TimeOfDay> BagOfTimeOfDay
+        public global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.TimeOfDay> BagOfTimeOfDay
         {
             get
             {
@@ -5332,8 +5332,8 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Library.TimeOfDay> _BagOfTimeOfDay = new global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Library.TimeOfDay>();
-        partial void OnBagOfTimeOfDayChanging(global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.Library.TimeOfDay> value);
+        private global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.TimeOfDay> _BagOfTimeOfDay = new global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.TimeOfDay>();
+        partial void OnBagOfTimeOfDayChanging(global::System.Collections.ObjectModel.Collection<global::Microsoft.OData.Edm.TimeOfDay> value);
         partial void OnBagOfTimeOfDayChanged();
         /// <summary>
         /// There are no comments for Property BagOfStream in the schema.
@@ -6108,7 +6108,7 @@ namespace MergedFunctionalTest
         /// There are no comments for Property DateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::Microsoft.OData.Edm.Library.Date DateProp
+        public global::Microsoft.OData.Edm.Date DateProp
         {
             get
             {
@@ -6122,14 +6122,14 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::Microsoft.OData.Edm.Library.Date _DateProp = global::Microsoft.OData.Edm.Library.Date.Parse("2014-10-08");
-        partial void OnDatePropChanging(global::Microsoft.OData.Edm.Library.Date value);
+        private global::Microsoft.OData.Edm.Date _DateProp = global::Microsoft.OData.Edm.Date.Parse("2014-10-08");
+        partial void OnDatePropChanging(global::Microsoft.OData.Edm.Date value);
         partial void OnDatePropChanged();
         /// <summary>
         /// There are no comments for Property TimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::Microsoft.OData.Edm.Library.TimeOfDay TimeOfDayProp
+        public global::Microsoft.OData.Edm.TimeOfDay TimeOfDayProp
         {
             get
             {
@@ -6143,8 +6143,8 @@ namespace MergedFunctionalTest
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::Microsoft.OData.Edm.Library.TimeOfDay _TimeOfDayProp = global::Microsoft.OData.Edm.Library.TimeOfDay.Parse("12:34:56");
-        partial void OnTimeOfDayPropChanging(global::Microsoft.OData.Edm.Library.TimeOfDay value);
+        private global::Microsoft.OData.Edm.TimeOfDay _TimeOfDayProp = global::Microsoft.OData.Edm.TimeOfDay.Parse("12:34:56");
+        partial void OnTimeOfDayPropChanging(global::Microsoft.OData.Edm.TimeOfDay value);
         partial void OnTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property GeographyProp in the schema.

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTest.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTest.vb
@@ -25,7 +25,7 @@ Namespace MergedFunctionalTest
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
         Public Sub New(ByVal serviceRoot As Global.System.Uri)
             MyBase.New(serviceRoot, Global.Microsoft.OData.Client.ODataProtocolVersion.V4)
-            Me.UrlConventions = Global.Microsoft.OData.Client.DataServiceUrlConventions.KeyAsSegment
+            Me.UrlKeyDelimiter = Global.Microsoft.OData.Client.DataServiceUrlKeyDelimiter.Slash
             Me.ResolveName = AddressOf Me.ResolveNameFromType
             Me.OnContextCreated
             Me.Format.LoadServiceModel = AddressOf GeneratedEdmModel.GetInstance
@@ -412,7 +412,7 @@ Namespace MergedFunctionalTest
         Private MustInherit Class GeneratedEdmModel
             <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
             Private Shared ParsedModel As Global.Microsoft.OData.Edm.IEdmModel = LoadModelFromString
-            <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
+            <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")>  _
             Private Const Edmx As String = "<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">" & _
  "  <edmx:DataServices>" & _
  "    <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""MergedFunctionalTest"">" & _
@@ -485,14 +485,14 @@ Namespace MergedFunctionalTest
  "        <Property Name=""ValueProp"" Type=""Edm.String"" Nullable=""false"" />" & _
  "      </EntityType>" & _
  "      <EntityType Name=""Child"" BaseType=""MergedFunctionalTest.Person"">" & _
- "        <Property Name=""Description"" Type=""Edm.String"" ConcurrencyMode=""Fixed"" />" & _
+ "        <Property Name=""Description"" Type=""Edm.String"" />" & _
  "      </EntityType>" & _
  "      <EntityType Name=""Person"">" & _
  "        <Key>" & _
  "          <PropertyRef Name=""ID"" />" & _
  "        </Key>" & _
  "        <Property Name=""ID"" Type=""Edm.Guid"" Nullable=""false"" />" & _
- "        <Property Name=""Name"" Type=""Edm.String"" ConcurrencyMode=""Fixed"" />" & _
+ "        <Property Name=""Name"" Type=""Edm.String"" />" & _
  "      </EntityType>" & _
  "      <EntityType Name=""TestType"">" & _
  "        <Key>" & _
@@ -962,7 +962,7 @@ Namespace MergedFunctionalTest
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try
@@ -2545,8 +2545,8 @@ Namespace MergedFunctionalTest
                     ByVal nonNullableStringProp As String,  _
                     ByVal nonNullableDurationProp As Global.System.TimeSpan,  _
                     ByVal nonNullableDateTimeOffsetProp As Global.System.DateTimeOffset,  _
-                    ByVal nonNullableDateProp As Global.Microsoft.OData.Edm.Library.Date,  _
-                    ByVal nonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.Library.TimeOfDay,  _
+                    ByVal nonNullableDateProp As Global.Microsoft.OData.Edm.Date,  _
+                    ByVal nonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay,  _
                     ByVal nonNullableStreamProp As Global.Microsoft.OData.Client.DataServiceStreamLink,  _
                     ByVal nonNullableSByteProp As SByte,  _
                     ByVal nonNullableGeography As Global.Microsoft.Spatial.Geography,  _
@@ -3432,7 +3432,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property NonNullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property NonNullableDateProp() As Global.Microsoft.OData.Edm.Library.Date
+        Public Property NonNullableDateProp() As Global.Microsoft.OData.Edm.Date
             Get
                 Return Me._NonNullableDateProp
             End Get
@@ -3443,8 +3443,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _NonNullableDateProp As Global.Microsoft.OData.Edm.Library.Date
-        Partial Private Sub OnNonNullableDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Library.Date)
+        Private _NonNullableDateProp As Global.Microsoft.OData.Edm.Date
+        Partial Private Sub OnNonNullableDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Date)
         End Sub
         Partial Private Sub OnNonNullableDatePropChanged()
         End Sub
@@ -3452,7 +3452,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property ExplicitlyNullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property ExplicitlyNullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date)
+        Public Property ExplicitlyNullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
             Get
                 Return Me._ExplicitlyNullableDateProp
             End Get
@@ -3463,8 +3463,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _ExplicitlyNullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date)
-        Partial Private Sub OnExplicitlyNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date))
+        Private _ExplicitlyNullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
+        Partial Private Sub OnExplicitlyNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date))
         End Sub
         Partial Private Sub OnExplicitlyNullableDatePropChanged()
         End Sub
@@ -3472,7 +3472,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property NullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property NullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date)
+        Public Property NullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
             Get
                 Return Me._NullableDateProp
             End Get
@@ -3483,8 +3483,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _NullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date)
-        Partial Private Sub OnNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date))
+        Private _NullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
+        Partial Private Sub OnNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date))
         End Sub
         Partial Private Sub OnNullableDatePropChanged()
         End Sub
@@ -3492,7 +3492,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property NonNullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property NonNullableTimeOfDayProp() As Global.Microsoft.OData.Edm.Library.TimeOfDay
+        Public Property NonNullableTimeOfDayProp() As Global.Microsoft.OData.Edm.TimeOfDay
             Get
                 Return Me._NonNullableTimeOfDayProp
             End Get
@@ -3503,8 +3503,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _NonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.Library.TimeOfDay
-        Partial Private Sub OnNonNullableTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Private _NonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay
+        Partial Private Sub OnNonNullableTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.TimeOfDay)
         End Sub
         Partial Private Sub OnNonNullableTimeOfDayPropChanged()
         End Sub
@@ -3512,7 +3512,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property ExplicitlyNullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property ExplicitlyNullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Public Property ExplicitlyNullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
             Get
                 Return Me._ExplicitlyNullableTimeOfDayProp
             End Get
@@ -3523,8 +3523,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _ExplicitlyNullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
-        Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay))
+        Private _ExplicitlyNullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay))
         End Sub
         Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanged()
         End Sub
@@ -3532,7 +3532,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property NullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property NullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Public Property NullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
             Get
                 Return Me._NullableTimeOfDayProp
             End Get
@@ -3543,8 +3543,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _NullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
-        Partial Private Sub OnNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay))
+        Private _NullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Partial Private Sub OnNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay))
         End Sub
         Partial Private Sub OnNullableTimeOfDayPropChanged()
         End Sub
@@ -5018,7 +5018,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property BagOfDate in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property BagOfDate() As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Library.Date)
+        Public Property BagOfDate() As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Date)
             Get
                 Return Me._BagOfDate
             End Get
@@ -5029,8 +5029,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _BagOfDate As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Library.Date) = New Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Library.Date)()
-        Partial Private Sub OnBagOfDateChanging(ByVal value As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Library.Date))
+        Private _BagOfDate As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Date) = New Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Date)()
+        Partial Private Sub OnBagOfDateChanging(ByVal value As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Date))
         End Sub
         Partial Private Sub OnBagOfDateChanged()
         End Sub
@@ -5038,7 +5038,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property BagOfTimeOfDay in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property BagOfTimeOfDay() As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Public Property BagOfTimeOfDay() As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.TimeOfDay)
             Get
                 Return Me._BagOfTimeOfDay
             End Get
@@ -5049,8 +5049,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _BagOfTimeOfDay As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Library.TimeOfDay) = New Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)()
-        Partial Private Sub OnBagOfTimeOfDayChanging(ByVal value As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.Library.TimeOfDay))
+        Private _BagOfTimeOfDay As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.TimeOfDay) = New Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.TimeOfDay)()
+        Partial Private Sub OnBagOfTimeOfDayChanging(ByVal value As Global.System.Collections.ObjectModel.Collection(Of Global.Microsoft.OData.Edm.TimeOfDay))
         End Sub
         Partial Private Sub OnBagOfTimeOfDayChanged()
         End Sub
@@ -5794,7 +5794,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property DateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property DateProp() As Global.Microsoft.OData.Edm.Library.Date
+        Public Property DateProp() As Global.Microsoft.OData.Edm.Date
             Get
                 Return Me._DateProp
             End Get
@@ -5805,8 +5805,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _DateProp As Global.Microsoft.OData.Edm.Library.Date = Global.Microsoft.OData.Edm.Library.Date.Parse("2014-10-08")
-        Partial Private Sub OnDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Library.Date)
+        Private _DateProp As Global.Microsoft.OData.Edm.Date = Global.Microsoft.OData.Edm.Date.Parse("2014-10-08")
+        Partial Private Sub OnDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Date)
         End Sub
         Partial Private Sub OnDatePropChanged()
         End Sub
@@ -5814,7 +5814,7 @@ Namespace MergedFunctionalTest
         '''There are no comments for Property TimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property TimeOfDayProp() As Global.Microsoft.OData.Edm.Library.TimeOfDay
+        Public Property TimeOfDayProp() As Global.Microsoft.OData.Edm.TimeOfDay
             Get
                 Return Me._TimeOfDayProp
             End Get
@@ -5825,8 +5825,8 @@ Namespace MergedFunctionalTest
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _TimeOfDayProp As Global.Microsoft.OData.Edm.Library.TimeOfDay = Global.Microsoft.OData.Edm.Library.TimeOfDay.Parse("12:34:56")
-        Partial Private Sub OnTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Private _TimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay = Global.Microsoft.OData.Edm.TimeOfDay.Parse("12:34:56")
+        Partial Private Sub OnTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.TimeOfDay)
         End Sub
         Partial Private Sub OnTimeOfDayPropChanged()
         End Sub

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTest.xml
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTest.xml
@@ -72,14 +72,14 @@
         <Property Name="ValueProp" Type="Edm.String" Nullable="false" />
       </EntityType>
       <EntityType Name="Child" BaseType="MergedFunctionalTest.Person">
-        <Property Name="Description" Type="Edm.String" ConcurrencyMode="Fixed" />
+        <Property Name="Description" Type="Edm.String" />
       </EntityType>
       <EntityType Name="Person">
         <Key>
           <PropertyRef Name="ID" />
         </Key>
         <Property Name="ID" Type="Edm.Guid" Nullable="false" />
-        <Property Name="Name" Type="Edm.String" ConcurrencyMode="Fixed" />
+        <Property Name="Name" Type="Edm.String"  />
       </EntityType>
       <EntityType Name="TestType">
         <Key>

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTestDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTestDSC.cs
@@ -23,7 +23,7 @@ namespace MergedFunctionalTest.DSC
         public TestContainer(global::System.Uri serviceRoot) : 
                 base(serviceRoot, global::Microsoft.OData.Client.ODataProtocolVersion.V4)
         {
-            this.UrlConventions = global::Microsoft.OData.Client.DataServiceUrlConventions.KeyAsSegment;
+            this.UrlKeyDelimiter = global::Microsoft.OData.Client.DataServiceUrlKeyDelimiter.Slash;
             this.ResolveName = new global::System.Func<global::System.Type, string>(this.ResolveNameFromType);
             this.OnContextCreated();
             this.Format.LoadServiceModel = GeneratedEdmModel.GetInstance;
@@ -552,14 +552,14 @@ namespace MergedFunctionalTest.DSC
         <Property Name=""ValueProp"" Type=""Edm.String"" Nullable=""false"" />
       </EntityType>
       <EntityType Name=""Child"" BaseType=""MergedFunctionalTest.DSC.Person"">
-        <Property Name=""Description"" Type=""Edm.String"" ConcurrencyMode=""Fixed"" />
+        <Property Name=""Description"" Type=""Edm.String"" />
       </EntityType>
       <EntityType Name=""Person"">
         <Key>
           <PropertyRef Name=""ID"" />
         </Key>
         <Property Name=""ID"" Type=""Edm.Guid"" Nullable=""false"" />
-        <Property Name=""Name"" Type=""Edm.String"" ConcurrencyMode=""Fixed"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
       </EntityType>
       <EntityType Name=""TestType"">
         <Key>
@@ -1032,7 +1032,7 @@ namespace MergedFunctionalTest.DSC
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {
@@ -2898,8 +2898,8 @@ namespace MergedFunctionalTest.DSC
                     string nonNullableStringProp, 
                     global::System.TimeSpan nonNullableDurationProp, 
                     global::System.DateTimeOffset nonNullableDateTimeOffsetProp, 
-                    global::Microsoft.OData.Edm.Library.Date nonNullableDateProp, 
-                    global::Microsoft.OData.Edm.Library.TimeOfDay nonNullableTimeOfDayProp, 
+                    global::Microsoft.OData.Edm.Date nonNullableDateProp, 
+                    global::Microsoft.OData.Edm.TimeOfDay nonNullableTimeOfDayProp, 
                     global::Microsoft.OData.Client.DataServiceStreamLink nonNullableStreamProp, 
                     sbyte nonNullableSByteProp, 
                     global::Microsoft.Spatial.Geography nonNullableGeography, 
@@ -3869,7 +3869,7 @@ namespace MergedFunctionalTest.DSC
         /// There are no comments for Property NonNullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::Microsoft.OData.Edm.Library.Date NonNullableDateProp
+        public global::Microsoft.OData.Edm.Date NonNullableDateProp
         {
             get
             {
@@ -3884,14 +3884,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::Microsoft.OData.Edm.Library.Date _NonNullableDateProp;
-        partial void OnNonNullableDatePropChanging(global::Microsoft.OData.Edm.Library.Date value);
+        private global::Microsoft.OData.Edm.Date _NonNullableDateProp;
+        partial void OnNonNullableDatePropChanging(global::Microsoft.OData.Edm.Date value);
         partial void OnNonNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property ExplicitlyNullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> ExplicitlyNullableDateProp
+        public global::System.Nullable<global::Microsoft.OData.Edm.Date> ExplicitlyNullableDateProp
         {
             get
             {
@@ -3906,14 +3906,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> _ExplicitlyNullableDateProp;
-        partial void OnExplicitlyNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> value);
+        private global::System.Nullable<global::Microsoft.OData.Edm.Date> _ExplicitlyNullableDateProp;
+        partial void OnExplicitlyNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Date> value);
         partial void OnExplicitlyNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property NullableDateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> NullableDateProp
+        public global::System.Nullable<global::Microsoft.OData.Edm.Date> NullableDateProp
         {
             get
             {
@@ -3928,14 +3928,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> _NullableDateProp;
-        partial void OnNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Library.Date> value);
+        private global::System.Nullable<global::Microsoft.OData.Edm.Date> _NullableDateProp;
+        partial void OnNullableDatePropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Date> value);
         partial void OnNullableDatePropChanged();
         /// <summary>
         /// There are no comments for Property NonNullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::Microsoft.OData.Edm.Library.TimeOfDay NonNullableTimeOfDayProp
+        public global::Microsoft.OData.Edm.TimeOfDay NonNullableTimeOfDayProp
         {
             get
             {
@@ -3950,14 +3950,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::Microsoft.OData.Edm.Library.TimeOfDay _NonNullableTimeOfDayProp;
-        partial void OnNonNullableTimeOfDayPropChanging(global::Microsoft.OData.Edm.Library.TimeOfDay value);
+        private global::Microsoft.OData.Edm.TimeOfDay _NonNullableTimeOfDayProp;
+        partial void OnNonNullableTimeOfDayPropChanging(global::Microsoft.OData.Edm.TimeOfDay value);
         partial void OnNonNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property ExplicitlyNullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> ExplicitlyNullableTimeOfDayProp
+        public global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> ExplicitlyNullableTimeOfDayProp
         {
             get
             {
@@ -3972,14 +3972,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> _ExplicitlyNullableTimeOfDayProp;
-        partial void OnExplicitlyNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> value);
+        private global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> _ExplicitlyNullableTimeOfDayProp;
+        partial void OnExplicitlyNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> value);
         partial void OnExplicitlyNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property NullableTimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> NullableTimeOfDayProp
+        public global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> NullableTimeOfDayProp
         {
             get
             {
@@ -3994,8 +3994,8 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> _NullableTimeOfDayProp;
-        partial void OnNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.Library.TimeOfDay> value);
+        private global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> _NullableTimeOfDayProp;
+        partial void OnNullableTimeOfDayPropChanging(global::System.Nullable<global::Microsoft.OData.Edm.TimeOfDay> value);
         partial void OnNullableTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property NonNullableStreamProp in the schema.
@@ -5626,7 +5626,7 @@ namespace MergedFunctionalTest.DSC
         /// There are no comments for Property BagOfDate in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Library.Date> BagOfDate
+        public global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Date> BagOfDate
         {
             get
             {
@@ -5641,14 +5641,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Library.Date> _BagOfDate = new global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Library.Date>();
-        partial void OnBagOfDateChanging(global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Library.Date> value);
+        private global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Date> _BagOfDate = new global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Date>();
+        partial void OnBagOfDateChanging(global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Date> value);
         partial void OnBagOfDateChanged();
         /// <summary>
         /// There are no comments for Property BagOfTimeOfDay in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Library.TimeOfDay> BagOfTimeOfDay
+        public global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.TimeOfDay> BagOfTimeOfDay
         {
             get
             {
@@ -5663,8 +5663,8 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Library.TimeOfDay> _BagOfTimeOfDay = new global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Library.TimeOfDay>();
-        partial void OnBagOfTimeOfDayChanging(global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.Library.TimeOfDay> value);
+        private global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.TimeOfDay> _BagOfTimeOfDay = new global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.TimeOfDay>();
+        partial void OnBagOfTimeOfDayChanging(global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Edm.TimeOfDay> value);
         partial void OnBagOfTimeOfDayChanged();
         /// <summary>
         /// There are no comments for Property BagOfStream in the schema.
@@ -6491,7 +6491,7 @@ namespace MergedFunctionalTest.DSC
         /// There are no comments for Property DateProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::Microsoft.OData.Edm.Library.Date DateProp
+        public global::Microsoft.OData.Edm.Date DateProp
         {
             get
             {
@@ -6506,14 +6506,14 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::Microsoft.OData.Edm.Library.Date _DateProp = global::Microsoft.OData.Edm.Library.Date.Parse("2014-10-08");
-        partial void OnDatePropChanging(global::Microsoft.OData.Edm.Library.Date value);
+        private global::Microsoft.OData.Edm.Date _DateProp = global::Microsoft.OData.Edm.Date.Parse("2014-10-08");
+        partial void OnDatePropChanging(global::Microsoft.OData.Edm.Date value);
         partial void OnDatePropChanged();
         /// <summary>
         /// There are no comments for Property TimeOfDayProp in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        public global::Microsoft.OData.Edm.Library.TimeOfDay TimeOfDayProp
+        public global::Microsoft.OData.Edm.TimeOfDay TimeOfDayProp
         {
             get
             {
@@ -6528,8 +6528,8 @@ namespace MergedFunctionalTest.DSC
             }
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
-        private global::Microsoft.OData.Edm.Library.TimeOfDay _TimeOfDayProp = global::Microsoft.OData.Edm.Library.TimeOfDay.Parse("12:34:56");
-        partial void OnTimeOfDayPropChanging(global::Microsoft.OData.Edm.Library.TimeOfDay value);
+        private global::Microsoft.OData.Edm.TimeOfDay _TimeOfDayProp = global::Microsoft.OData.Edm.TimeOfDay.Parse("12:34:56");
+        partial void OnTimeOfDayPropChanging(global::Microsoft.OData.Edm.TimeOfDay value);
         partial void OnTimeOfDayPropChanged();
         /// <summary>
         /// There are no comments for Property GeographyProp in the schema.

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTestDSC.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTestDSC.vb
@@ -25,7 +25,7 @@ Namespace MergedFunctionalTest.DSC
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
         Public Sub New(ByVal serviceRoot As Global.System.Uri)
             MyBase.New(serviceRoot, Global.Microsoft.OData.Client.ODataProtocolVersion.V4)
-            Me.UrlConventions = Global.Microsoft.OData.Client.DataServiceUrlConventions.KeyAsSegment
+            Me.UrlKeyDelimiter = Global.Microsoft.OData.Client.DataServiceUrlKeyDelimiter.Slash
             Me.ResolveName = AddressOf Me.ResolveNameFromType
             Me.OnContextCreated
             Me.Format.LoadServiceModel = AddressOf GeneratedEdmModel.GetInstance
@@ -412,7 +412,7 @@ Namespace MergedFunctionalTest.DSC
         Private MustInherit Class GeneratedEdmModel
             <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
             Private Shared ParsedModel As Global.Microsoft.OData.Edm.IEdmModel = LoadModelFromString
-            <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
+            <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")>  _
             Private Const Edmx As String = "<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">" & _
  "  <edmx:DataServices>" & _
  "    <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""MergedFunctionalTest.DSC"">" & _
@@ -485,14 +485,14 @@ Namespace MergedFunctionalTest.DSC
  "        <Property Name=""ValueProp"" Type=""Edm.String"" Nullable=""false"" />" & _
  "      </EntityType>" & _
  "      <EntityType Name=""Child"" BaseType=""MergedFunctionalTest.DSC.Person"">" & _
- "        <Property Name=""Description"" Type=""Edm.String"" ConcurrencyMode=""Fixed"" />" & _
+ "        <Property Name=""Description"" Type=""Edm.String"" />" & _
  "      </EntityType>" & _
  "      <EntityType Name=""Person"">" & _
  "        <Key>" & _
  "          <PropertyRef Name=""ID"" />" & _
  "        </Key>" & _
  "        <Property Name=""ID"" Type=""Edm.Guid"" Nullable=""false"" />" & _
- "        <Property Name=""Name"" Type=""Edm.String"" ConcurrencyMode=""Fixed"" />" & _
+ "        <Property Name=""Name"" Type=""Edm.String"" />" & _
  "      </EntityType>" & _
  "      <EntityType Name=""TestType"">" & _
  "        <Key>" & _
@@ -962,7 +962,7 @@ Namespace MergedFunctionalTest.DSC
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try
@@ -2730,8 +2730,8 @@ Namespace MergedFunctionalTest.DSC
                     ByVal nonNullableStringProp As String,  _
                     ByVal nonNullableDurationProp As Global.System.TimeSpan,  _
                     ByVal nonNullableDateTimeOffsetProp As Global.System.DateTimeOffset,  _
-                    ByVal nonNullableDateProp As Global.Microsoft.OData.Edm.Library.Date,  _
-                    ByVal nonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.Library.TimeOfDay,  _
+                    ByVal nonNullableDateProp As Global.Microsoft.OData.Edm.Date,  _
+                    ByVal nonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay,  _
                     ByVal nonNullableStreamProp As Global.Microsoft.OData.Client.DataServiceStreamLink,  _
                     ByVal nonNullableSByteProp As SByte,  _
                     ByVal nonNullableGeography As Global.Microsoft.Spatial.Geography,  _
@@ -3658,7 +3658,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property NonNullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property NonNullableDateProp() As Global.Microsoft.OData.Edm.Library.Date
+        Public Property NonNullableDateProp() As Global.Microsoft.OData.Edm.Date
             Get
                 Return Me._NonNullableDateProp
             End Get
@@ -3670,8 +3670,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _NonNullableDateProp As Global.Microsoft.OData.Edm.Library.Date
-        Partial Private Sub OnNonNullableDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Library.Date)
+        Private _NonNullableDateProp As Global.Microsoft.OData.Edm.Date
+        Partial Private Sub OnNonNullableDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Date)
         End Sub
         Partial Private Sub OnNonNullableDatePropChanged()
         End Sub
@@ -3679,7 +3679,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property ExplicitlyNullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property ExplicitlyNullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date)
+        Public Property ExplicitlyNullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
             Get
                 Return Me._ExplicitlyNullableDateProp
             End Get
@@ -3691,8 +3691,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _ExplicitlyNullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date)
-        Partial Private Sub OnExplicitlyNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date))
+        Private _ExplicitlyNullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
+        Partial Private Sub OnExplicitlyNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date))
         End Sub
         Partial Private Sub OnExplicitlyNullableDatePropChanged()
         End Sub
@@ -3700,7 +3700,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property NullableDateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property NullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date)
+        Public Property NullableDateProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
             Get
                 Return Me._NullableDateProp
             End Get
@@ -3712,8 +3712,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _NullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date)
-        Partial Private Sub OnNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.Date))
+        Private _NullableDateProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date)
+        Partial Private Sub OnNullableDatePropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Date))
         End Sub
         Partial Private Sub OnNullableDatePropChanged()
         End Sub
@@ -3721,7 +3721,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property NonNullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property NonNullableTimeOfDayProp() As Global.Microsoft.OData.Edm.Library.TimeOfDay
+        Public Property NonNullableTimeOfDayProp() As Global.Microsoft.OData.Edm.TimeOfDay
             Get
                 Return Me._NonNullableTimeOfDayProp
             End Get
@@ -3733,8 +3733,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _NonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.Library.TimeOfDay
-        Partial Private Sub OnNonNullableTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Private _NonNullableTimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay
+        Partial Private Sub OnNonNullableTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.TimeOfDay)
         End Sub
         Partial Private Sub OnNonNullableTimeOfDayPropChanged()
         End Sub
@@ -3742,7 +3742,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property ExplicitlyNullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property ExplicitlyNullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Public Property ExplicitlyNullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
             Get
                 Return Me._ExplicitlyNullableTimeOfDayProp
             End Get
@@ -3754,8 +3754,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _ExplicitlyNullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
-        Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay))
+        Private _ExplicitlyNullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay))
         End Sub
         Partial Private Sub OnExplicitlyNullableTimeOfDayPropChanged()
         End Sub
@@ -3763,7 +3763,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property NullableTimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property NullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Public Property NullableTimeOfDayProp() As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
             Get
                 Return Me._NullableTimeOfDayProp
             End Get
@@ -3775,8 +3775,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _NullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
-        Partial Private Sub OnNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.Library.TimeOfDay))
+        Private _NullableTimeOfDayProp As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay)
+        Partial Private Sub OnNullableTimeOfDayPropChanging(ByVal value As Global.System.Nullable(Of Global.Microsoft.OData.Edm.TimeOfDay))
         End Sub
         Partial Private Sub OnNullableTimeOfDayPropChanged()
         End Sub
@@ -5338,7 +5338,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property BagOfDate in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property BagOfDate() As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Library.Date)
+        Public Property BagOfDate() As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Date)
             Get
                 Return Me._BagOfDate
             End Get
@@ -5350,8 +5350,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _BagOfDate As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Library.Date) = New Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Library.Date)()
-        Partial Private Sub OnBagOfDateChanging(ByVal value As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Library.Date))
+        Private _BagOfDate As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Date) = New Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Date)()
+        Partial Private Sub OnBagOfDateChanging(ByVal value As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Date))
         End Sub
         Partial Private Sub OnBagOfDateChanged()
         End Sub
@@ -5359,7 +5359,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property BagOfTimeOfDay in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property BagOfTimeOfDay() As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Public Property BagOfTimeOfDay() As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.TimeOfDay)
             Get
                 Return Me._BagOfTimeOfDay
             End Get
@@ -5371,8 +5371,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _BagOfTimeOfDay As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Library.TimeOfDay) = New Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Library.TimeOfDay)()
-        Partial Private Sub OnBagOfTimeOfDayChanging(ByVal value As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.Library.TimeOfDay))
+        Private _BagOfTimeOfDay As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.TimeOfDay) = New Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.TimeOfDay)()
+        Partial Private Sub OnBagOfTimeOfDayChanging(ByVal value As Global.System.Collections.ObjectModel.ObservableCollection(Of Global.Microsoft.OData.Edm.TimeOfDay))
         End Sub
         Partial Private Sub OnBagOfTimeOfDayChanged()
         End Sub
@@ -6167,7 +6167,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property DateProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property DateProp() As Global.Microsoft.OData.Edm.Library.Date
+        Public Property DateProp() As Global.Microsoft.OData.Edm.Date
             Get
                 Return Me._DateProp
             End Get
@@ -6179,8 +6179,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _DateProp As Global.Microsoft.OData.Edm.Library.Date = Global.Microsoft.OData.Edm.Library.Date.Parse("2014-10-08")
-        Partial Private Sub OnDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Library.Date)
+        Private _DateProp As Global.Microsoft.OData.Edm.Date = Global.Microsoft.OData.Edm.Date.Parse("2014-10-08")
+        Partial Private Sub OnDatePropChanging(ByVal value As Global.Microsoft.OData.Edm.Date)
         End Sub
         Partial Private Sub OnDatePropChanged()
         End Sub
@@ -6188,7 +6188,7 @@ Namespace MergedFunctionalTest.DSC
         '''There are no comments for Property TimeOfDayProp in the schema.
         '''</summary>
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Public Property TimeOfDayProp() As Global.Microsoft.OData.Edm.Library.TimeOfDay
+        Public Property TimeOfDayProp() As Global.Microsoft.OData.Edm.TimeOfDay
             Get
                 Return Me._TimeOfDayProp
             End Get
@@ -6200,8 +6200,8 @@ Namespace MergedFunctionalTest.DSC
             End Set
         End Property
         <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")>  _
-        Private _TimeOfDayProp As Global.Microsoft.OData.Edm.Library.TimeOfDay = Global.Microsoft.OData.Edm.Library.TimeOfDay.Parse("12:34:56")
-        Partial Private Sub OnTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.Library.TimeOfDay)
+        Private _TimeOfDayProp As Global.Microsoft.OData.Edm.TimeOfDay = Global.Microsoft.OData.Edm.TimeOfDay.Parse("12:34:56")
+        Partial Private Sub OnTimeOfDayPropChanging(ByVal value As Global.Microsoft.OData.Edm.TimeOfDay)
         End Sub
         Partial Private Sub OnTimeOfDayPropChanged()
         End Sub

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MultiReferenceModel.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MultiReferenceModel.cs
@@ -361,7 +361,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader, getReferencedModelFromMap);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, getReferencedModelFromMap);
                 }
                 finally
                 {
@@ -1332,7 +1332,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.GPS
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader, getReferencedModelFromMap);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, getReferencedModelFromMap);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MultiReferenceModel.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MultiReferenceModel.vb
@@ -342,7 +342,7 @@ Namespace Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader, AddressOf getReferencedModelFromMap)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, AddressOf getReferencedModelFromMap)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try
@@ -1263,7 +1263,7 @@ Namespace Microsoft.OData.SampleService.Models.ModelRefDemo.GPS
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader, AddressOf getReferencedModelFromMap)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, AddressOf getReferencedModelFromMap)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywords.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywords.cs
@@ -284,7 +284,7 @@ namespace NamespaceInKeywords.@double
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywords.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywords.vb
@@ -269,7 +269,7 @@ Namespace NamespaceInKeywords.[double]
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywordsWithRefModel.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywordsWithRefModel.cs
@@ -364,7 +364,7 @@ namespace Simple.Double
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader, getReferencedModelFromMap);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, getReferencedModelFromMap);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywordsWithRefModel.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywordsWithRefModel.vb
@@ -341,7 +341,7 @@ Namespace Simple.[Double]
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader, AddressOf getReferencedModelFromMap)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, AddressOf getReferencedModelFromMap)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixRepeatWithSchemaNameSpace.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixRepeatWithSchemaNameSpace.cs
@@ -161,7 +161,7 @@ namespace NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePre
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithDoubleNamespaces.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithDoubleNamespaces.cs
@@ -167,7 +167,7 @@ namespace Foo.NamespacePrefixWithDoubleNamespaces
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithDoubleNamespaces.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithDoubleNamespaces.vb
@@ -154,7 +154,7 @@ Namespace Foo.NamespacePrefixWithDoubleNamespaces
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithInheritence.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithInheritence.cs
@@ -119,7 +119,7 @@ namespace Foo
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithInheritence.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithInheritence.vb
@@ -112,7 +112,7 @@ Namespace Foo
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithSingleNamespace.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithSingleNamespace.cs
@@ -117,7 +117,7 @@ namespace NamespacePrefixWithSingleNamespace
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithSingleNamespace.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithSingleNamespace.vb
@@ -110,7 +110,7 @@ Namespace NamespacePrefixWithSingleNamespace
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/OverrideOperations.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/OverrideOperations.vb
@@ -169,7 +169,7 @@ Namespace OverrideOperations
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/OverrideOperationsDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/OverrideOperationsDSC.cs
@@ -145,7 +145,7 @@ namespace OverrideOperations.DSC
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/PrefixConflict.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/PrefixConflict.cs
@@ -88,7 +88,7 @@ namespace PrefixConflict
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/PrefixConflictDSC.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/PrefixConflictDSC.vb
@@ -83,7 +83,7 @@ Namespace PrefixConflict.DSC
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithNamespacePrefix.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithNamespacePrefix.cs
@@ -762,7 +762,7 @@ namespace namespacePrefix.Namespace.Bar
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithNamespacePrefix.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithNamespacePrefix.vb
@@ -718,7 +718,7 @@ Namespace namespacePrefix.[Namespace].Bar
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefix.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefix.cs
@@ -657,7 +657,7 @@ namespace Namespace.Bar
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefix.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefix.vb
@@ -620,7 +620,7 @@ Namespace [Namespace].Bar
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefixDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefixDSC.cs
@@ -696,7 +696,7 @@ namespace Namespace.Bar.DSC
                 global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
                 try
                 {
-                    return global::Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader);
+                    return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader);
                 }
                 finally
                 {

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefixDSC.vb
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefixDSC.vb
@@ -657,7 +657,7 @@ Namespace [Namespace].Bar.DSC
             Private Shared Function LoadModelFromString() As Global.Microsoft.OData.Edm.IEdmModel
                 Dim reader As Global.System.Xml.XmlReader = CreateXmlReader(Edmx)
                 Try
-                    Return Global.Microsoft.OData.Edm.Csdl.EdmxReader.Parse(reader)
+                    Return Global.Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader)
                 Finally
                     CType(reader,Global.System.IDisposable).Dispose
                 End Try

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -75,7 +75,7 @@
       <Version>2.0.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.OData.Client">
-      <Version>6.17.0</Version>
+      <Version>7.4.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ConnectedServices">
       <Version>2.0.0</Version>

--- a/test/ODataConnectedService.Tests/Templates/ODataClientTemplateUnitTests.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataClientTemplateUnitTests.cs
@@ -373,7 +373,7 @@ namespace ODataConnectedService.Tests
 
             internal override string ODataVersion
             {
-                get { return "global::Microsoft.OData.Core.ODataVersion.V4"; }
+                get { return "global::Microsoft.OData.ODataVersion.V4"; }
             }
 
             internal override string ParameterDeclarationTemplate

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
@@ -21,7 +21,7 @@ using System.Xml;
 namespace ODataConnectedService.Tests
 {
     using System.Reflection;
-    using Microsoft.OData.Core;
+    using Microsoft.OData;
     using System.Text.RegularExpressions;
     using Microsoft.OData.ConnectedService.Templates;
     using Microsoft.OData.Client;

--- a/test/ODataConnectedService.Tests/Templates/UtilsTests.cs
+++ b/test/ODataConnectedService.Tests/Templates/UtilsTests.cs
@@ -8,8 +8,6 @@ using System;
 using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.OData.Edm;
-using Microsoft.OData.Edm.Library;
-using Microsoft.OData.Edm.Library.Values;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.OData.ConnectedService.Templates;
 
@@ -304,8 +302,8 @@ namespace ODataConnectedService.Tests
         public void GetClrTypeNameShouldReturnICollectionStructureTemplateForCollectionOfEnumType()
         {
             EdmEnumType gender = new EdmEnumType("Namespace", "Gender", EdmPrimitiveTypeKind.Byte, true);
-            gender.AddMember("Male", new EdmIntegerConstant(1));
-            gender.AddMember("Female", new EdmIntegerConstant(2));
+            gender.AddMember("Male", new EdmEnumMemberValue(1));
+            gender.AddMember("Female", new EdmEnumMemberValue(2));
 
             IEdmTypeReference elementTypeReference = new EdmTypeReferenceForTest(gender, false);
             IEdmCollectionType collectionType = new EdmCollectionType(elementTypeReference);
@@ -567,13 +565,13 @@ namespace ODataConnectedService.Tests
         [TestMethod]
         public void GetClrTypeNameDateShouldBeGlobalMicrosoftODataEdmLibraryDate()
         {
-            ODataT4CodeGenerator.Utils.GetClrTypeName(new EdmPrimitiveType(EdmPrimitiveTypeKind.Date), template).Should().Be("global::Microsoft.OData.Edm.Library.Date");
+            ODataT4CodeGenerator.Utils.GetClrTypeName(new EdmPrimitiveType(EdmPrimitiveTypeKind.Date), template).Should().Be("global::Microsoft.OData.Edm.Date");
         }
 
         [TestMethod]
         public void GetClrTypeNameTimeOfDayShouldBeGlobalMicrosoftODataEdmLibraryTimeOfDay()
         {
-            ODataT4CodeGenerator.Utils.GetClrTypeName(new EdmPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), template).Should().Be("global::Microsoft.OData.Edm.Library.TimeOfDay");
+            ODataT4CodeGenerator.Utils.GetClrTypeName(new EdmPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), template).Should().Be("global::Microsoft.OData.Edm.TimeOfDay");
         }
 
         [TestMethod]


### PR DESCRIPTION
Upgrading `Microsoft.OData.Client` lib to version 7.4.0 to facilitate migration of code gen. The intention is to finally have the latest version 7.6.3 but to make migration easier, upgrade is being done in stages.