### PR TITLE
upgrade Microsoft.OData.Client to version 7.6.3

### DIFF
--- a/src/ODataConnectedService.csproj
+++ b/src/ODataConnectedService.csproj
@@ -87,17 +87,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\external\Binaries\V3\Microsoft.Data.Services.Design.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Client, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Client.7.4.0\lib\net45\Microsoft.OData.Client.dll</HintPath>
+    <Reference Include="Microsoft.OData.Client, Version=7.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Client.7.6.3\lib\net45\Microsoft.OData.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Core.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Core.7.6.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Edm.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Edm.7.6.3\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.4.0.20119, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Spatial.7.4.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.6.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.7.6.3\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.VisualStudio.ComponentModelHost.15.7.27703\lib\net45\Microsoft.VisualStudio.ComponentModelHost.dll</HintPath>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.OData.Client" version="7.4.0" targetFramework="net472" />
-  <package id="Microsoft.OData.Core" version="7.4.0" targetFramework="net472" />
-  <package id="Microsoft.OData.Edm" version="7.4.0" targetFramework="net472" />
-  <package id="Microsoft.Spatial" version="7.4.0" targetFramework="net472" />
+  <package id="Microsoft.OData.Client" version="7.6.3" targetFramework="net472" />
+  <package id="Microsoft.OData.Core" version="7.6.3" targetFramework="net472" />
+  <package id="Microsoft.OData.Edm" version="7.6.3" targetFramework="net472" />
+  <package id="Microsoft.Spatial" version="7.6.3" targetFramework="net472" />
   <package id="Microsoft.VisualStudio.ComponentModelHost" version="15.7.27703" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.ConnectedServices" version="2.0.0" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26201" targetFramework="net45" />

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -75,7 +75,7 @@
       <Version>2.0.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.OData.Client">
-      <Version>7.4.0</Version>
+      <Version>7.6.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ConnectedServices">
       <Version>2.0.0</Version>


### PR DESCRIPTION
This pull requests upgrades  `Microsoft.OData.Client` library to the latest version `7.6.3`