### PR TITLE
Replace Dictionary with IDictionary

### DIFF
--- a/src/Templates/ODataT4CodeGenerator.cs
+++ b/src/Templates/ODataT4CodeGenerator.cs
@@ -4944,8 +4944,8 @@ this.Write(" ByKey(this global::Microsoft.OData.Client.DataServiceQuery<");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(entityTypeName));
 
-this.Write("> source, global::System.Collections.Generic.Dictionary<string, object> keys)\r\n  " +
-        "      {\r\n            return new ");
+this.Write("> source, global::System.Collections.Generic.IDictionary<string, object> keys)\r\n " +
+        "       {\r\n            return new ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
@@ -4991,9 +4991,9 @@ this.Write("> source,\r\n            ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(keyParameters));
 
-this.Write(")\r\n        {\r\n            global::System.Collections.Generic.Dictionary<string, o" +
-        "bject> keys = new global::System.Collections.Generic.Dictionary<string, object>\r" +
-        "\n            {\r\n                ");
+this.Write(")\r\n        {\r\n            global::System.Collections.Generic.IDictionary<string, " +
+        "object> keys = new global::System.Collections.Generic.Dictionary<string, object>" +
+        "\r\n            {\r\n                ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(keyDictionaryItems));
 

--- a/src/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Templates/ODataT4CodeGenerator.ttinclude
@@ -4079,7 +4079,7 @@ namespace <#= fullNamespace #>
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static <#= returnTypeName #> ByKey(this global::Microsoft.OData.Client.DataServiceQuery<<#= entityTypeName #>> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static <#= returnTypeName #> ByKey(this global::Microsoft.OData.Client.DataServiceQuery<<#= entityTypeName #>> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new <#= returnTypeName #>(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -4098,7 +4098,7 @@ namespace <#= fullNamespace #>
         public static <#= returnTypeName #> ByKey(this global::Microsoft.OData.Client.DataServiceQuery<<#= entityTypeName #>> source,
             <#= keyParameters #>)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 <#= keyDictionaryItems #>
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/AbstractEntityTypeWithoutKeyDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/AbstractEntityTypeWithoutKeyDSC.cs
@@ -600,7 +600,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::AbstractEntityTypeWithoutKey.DSC.DerivedBaseETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedBaseET> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::AbstractEntityTypeWithoutKey.DSC.DerivedBaseETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedBaseET> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::AbstractEntityTypeWithoutKey.DSC.DerivedBaseETSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -612,7 +612,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
         public static global::AbstractEntityTypeWithoutKey.DSC.DerivedBaseETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedBaseET> source,
             string id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -641,7 +641,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::AbstractEntityTypeWithoutKey.DSC.DerivedETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedET> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::AbstractEntityTypeWithoutKey.DSC.DerivedETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedET> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::AbstractEntityTypeWithoutKey.DSC.DerivedETSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -653,7 +653,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
         public static global::AbstractEntityTypeWithoutKey.DSC.DerivedETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedET> source,
             string id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -691,7 +691,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::AbstractEntityTypeWithoutKey.DSC.DerivedAbstractETWithKeySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedAbstractETWithKey> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::AbstractEntityTypeWithoutKey.DSC.DerivedAbstractETWithKeySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedAbstractETWithKey> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::AbstractEntityTypeWithoutKey.DSC.DerivedAbstractETWithKeySingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -703,7 +703,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
         public static global::AbstractEntityTypeWithoutKey.DSC.DerivedAbstractETWithKeySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedAbstractETWithKey> source,
             string id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -723,7 +723,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::AbstractEntityTypeWithoutKey.DSC.DerivedET2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedET2> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::AbstractEntityTypeWithoutKey.DSC.DerivedET2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedET2> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::AbstractEntityTypeWithoutKey.DSC.DerivedET2Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -735,7 +735,7 @@ namespace AbstractEntityTypeWithoutKey.DSC
         public static global::AbstractEntityTypeWithoutKey.DSC.DerivedET2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::AbstractEntityTypeWithoutKey.DSC.DerivedET2> source,
             string id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/DupNames.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/DupNames.cs
@@ -688,7 +688,7 @@ namespace DupNames
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::DupNames.DupWithTypeNameSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DupWithTypeName> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::DupNames.DupWithTypeNameSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DupWithTypeName> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::DupNames.DupWithTypeNameSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -700,7 +700,7 @@ namespace DupNames
         public static global::DupNames.DupWithTypeNameSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DupWithTypeName> source,
             global::System.Guid dupWithTypeName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "DupWithTypeName", dupWithTypeName }
             };
@@ -711,7 +711,7 @@ namespace DupNames
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::DupNames.DupWithTypeName1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DupWithTypeName1> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::DupNames.DupWithTypeName1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DupWithTypeName1> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::DupNames.DupWithTypeName1Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -723,7 +723,7 @@ namespace DupNames
         public static global::DupNames.DupWithTypeName1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DupWithTypeName1> source,
             global::System.Nullable<int> dupWithTypeName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "DupWithTypeName", dupWithTypeName }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/DupNamesWithCamelCaseDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/DupNamesWithCamelCaseDSC.cs
@@ -819,7 +819,7 @@ namespace DupNames.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::DupNames.DSC.DupWithTypeNameSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DSC.DupWithTypeName> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::DupNames.DSC.DupWithTypeNameSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DSC.DupWithTypeName> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::DupNames.DSC.DupWithTypeNameSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -831,7 +831,7 @@ namespace DupNames.DSC
         public static global::DupNames.DSC.DupWithTypeNameSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DSC.DupWithTypeName> source,
             global::System.Guid dupWithTypeName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "DupWithTypeName", dupWithTypeName }
             };
@@ -842,7 +842,7 @@ namespace DupNames.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::DupNames.DSC.DupWithTypeName1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DSC.DupWithTypeName1> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::DupNames.DSC.DupWithTypeName1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DSC.DupWithTypeName1> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::DupNames.DSC.DupWithTypeName1Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -854,7 +854,7 @@ namespace DupNames.DSC
         public static global::DupNames.DSC.DupWithTypeName1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::DupNames.DSC.DupWithTypeName1> source,
             global::System.Nullable<int> dupWithTypeName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "DupWithTypeName", dupWithTypeName }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctions.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctions.cs
@@ -1184,7 +1184,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1196,7 +1196,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };
@@ -1207,7 +1207,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1219,7 +1219,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source,
             string airlineCode)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "AirlineCode", airlineCode }
             };
@@ -1230,7 +1230,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1242,7 +1242,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source,
             string icaoCode)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "IcaoCode", icaoCode }
             };
@@ -1253,7 +1253,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1265,7 +1265,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source,
             int tripId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "TripId", tripId }
             };
@@ -1285,7 +1285,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1297,7 +1297,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsDSC.cs
@@ -1309,7 +1309,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1321,7 +1321,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };
@@ -1332,7 +1332,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1344,7 +1344,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source,
             string airlineCode)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "AirlineCode", airlineCode }
             };
@@ -1355,7 +1355,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1367,7 +1367,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source,
             string icaoCode)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "IcaoCode", icaoCode }
             };
@@ -1378,7 +1378,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1390,7 +1390,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source,
             int tripId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "TripId", tripId }
             };
@@ -1410,7 +1410,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1422,7 +1422,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsDSCWithInternalTypes.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsDSCWithInternalTypes.cs
@@ -1309,7 +1309,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1321,7 +1321,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };
@@ -1332,7 +1332,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1344,7 +1344,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source,
             string airlineCode)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "AirlineCode", airlineCode }
             };
@@ -1355,7 +1355,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1367,7 +1367,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source,
             string icaoCode)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "IcaoCode", icaoCode }
             };
@@ -1378,7 +1378,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1390,7 +1390,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source,
             int tripId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "TripId", tripId }
             };
@@ -1410,7 +1410,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1422,7 +1422,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsWithInternalTypes.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntitiesEnumsFunctionsWithInternalTypes.cs
@@ -1184,7 +1184,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1196,7 +1196,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };
@@ -1207,7 +1207,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1219,7 +1219,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirlineSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline> source,
             string airlineCode)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "AirlineCode", airlineCode }
             };
@@ -1230,7 +1230,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1242,7 +1242,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.AirportSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport> source,
             string icaoCode)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "IcaoCode", icaoCode }
             };
@@ -1253,7 +1253,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1265,7 +1265,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.TripSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip> source,
             int tripId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "TripId", tripId }
             };
@@ -1285,7 +1285,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1297,7 +1297,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory.Models
         public static global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.EmployeeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/EntityHierarchyWithIDAndIdDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/EntityHierarchyWithIDAndIdDSC.cs
@@ -292,7 +292,7 @@ namespace Namespace1.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace1.DSC.EntityBaseSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.DSC.EntityBase> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace1.DSC.EntityBaseSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.DSC.EntityBase> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace1.DSC.EntityBaseSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -304,7 +304,7 @@ namespace Namespace1.DSC
         public static global::Namespace1.DSC.EntityBaseSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.DSC.EntityBase> source,
             int id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -315,7 +315,7 @@ namespace Namespace1.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace1.DSC.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.DSC.EntityType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace1.DSC.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.DSC.EntityType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace1.DSC.EntityTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -327,7 +327,7 @@ namespace Namespace1.DSC
         public static global::Namespace1.DSC.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.DSC.EntityType> source,
             int id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/KeywordsAsNames.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/KeywordsAsNames.cs
@@ -297,7 +297,7 @@ namespace Namespace1
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace1.eventSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.@event> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace1.eventSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.@event> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace1.eventSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -309,7 +309,7 @@ namespace Namespace1
         public static global::Namespace1.eventSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace1.@event> source,
             string @string)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "string", @string }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTest.cs
@@ -8141,7 +8141,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Customer> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Customer> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.CustomerSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8153,7 +8153,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Customer> source,
             int customerId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerId", customerId }
             };
@@ -8164,7 +8164,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.GoodCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.GoodCustomer> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.GoodCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.GoodCustomer> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.GoodCustomerSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8176,7 +8176,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.GoodCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.GoodCustomer> source,
             int customerId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerId", customerId }
             };
@@ -8196,7 +8196,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.BadCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BadCustomer> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.BadCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BadCustomer> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.BadCustomerSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8208,7 +8208,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.BadCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BadCustomer> source,
             int customerId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerId", customerId }
             };
@@ -8228,7 +8228,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.CustomerInfoSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.CustomerInfo> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.CustomerInfoSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.CustomerInfo> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.CustomerInfoSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8240,7 +8240,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.CustomerInfoSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.CustomerInfo> source,
             int customerInfoId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerInfoId", customerInfoId }
             };
@@ -8251,7 +8251,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.OrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Order> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.OrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Order> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.OrderSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8263,7 +8263,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.OrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Order> source,
             int orderId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "OrderId", orderId }
             };
@@ -8274,7 +8274,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.CompanySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Company> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.CompanySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Company> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.CompanySingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8286,7 +8286,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.CompanySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Company> source,
             int companyId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CompanyId", companyId }
             };
@@ -8297,7 +8297,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.ProductSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Product> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.ProductSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Product> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.ProductSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8309,7 +8309,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.ProductSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Product> source,
             string iD)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "ID", iD }
             };
@@ -8320,7 +8320,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.ProductDetailSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.ProductDetail> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.ProductDetailSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.ProductDetail> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.ProductDetailSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8332,7 +8332,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.ProductDetailSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.ProductDetail> source,
             int productId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "ProductId", productId }
             };
@@ -8343,7 +8343,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.SpecialTypeWithPrecisionFacetSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.SpecialTypeWithPrecisionFacet> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.SpecialTypeWithPrecisionFacetSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.SpecialTypeWithPrecisionFacet> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.SpecialTypeWithPrecisionFacetSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8355,7 +8355,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.SpecialTypeWithPrecisionFacetSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.SpecialTypeWithPrecisionFacet> source,
             int id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -8366,7 +8366,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.BlobTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BlobType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.BlobTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BlobType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.BlobTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8378,7 +8378,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.BlobTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BlobType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -8389,7 +8389,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.ChildSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Child> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.ChildSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Child> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.ChildSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8401,7 +8401,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.ChildSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Child> source,
             global::System.Guid iD)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "ID", iD }
             };
@@ -8421,7 +8421,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Person> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Person> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.PersonSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8433,7 +8433,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Person> source,
             global::System.Guid iD)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "ID", iD }
             };
@@ -8444,7 +8444,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8456,7 +8456,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.TestType> source,
             global::System.DateTimeOffset id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -8467,7 +8467,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.TestCollectionTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.TestCollectionType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.TestCollectionTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.TestCollectionType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.TestCollectionTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8479,7 +8479,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.TestCollectionTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.TestCollectionType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -8490,7 +8490,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DefaultValueTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DefaultValueTestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DefaultValueTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DefaultValueTestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DefaultValueTestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8502,7 +8502,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.DefaultValueTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DefaultValueTestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -8513,7 +8513,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.MultiKeyTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.MultiKeyTestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.MultiKeyTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.MultiKeyTestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.MultiKeyTestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8531,7 +8531,7 @@ namespace MergedFunctionalTest
             global::System.DateTimeOffset dateTimeOffsetId,
             global::System.Guid guidId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Int64Id", int64Id },
                 { "StringId", stringId },
@@ -8545,7 +8545,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BaseType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BaseType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.BaseTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8557,7 +8557,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.BaseType> source,
             long keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -8568,7 +8568,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.KatmaiTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.KatmaiType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.KatmaiTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.KatmaiType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.KatmaiTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8580,7 +8580,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.KatmaiTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.KatmaiType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -8591,7 +8591,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.Level0Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level0> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.Level0Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level0> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.Level0Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8603,7 +8603,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.Level0Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level0> source,
             string level0Prop)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Level0Prop", level0Prop }
             };
@@ -8614,7 +8614,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.Level1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level1> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.Level1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level1> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.Level1Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8626,7 +8626,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.Level1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level1> source,
             int level1Id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Level1Id", level1Id }
             };
@@ -8646,7 +8646,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.Level2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level2> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.Level2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level2> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.Level2Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8658,7 +8658,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.Level2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Level2> source,
             int level1Id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Level1Id", level1Id }
             };
@@ -8687,7 +8687,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.SingleType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.SingleType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.SingleTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8699,7 +8699,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.SingleType> source,
             global::Microsoft.Spatial.GeographyPoint keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -8710,7 +8710,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.GroupSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Group> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.GroupSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Group> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.GroupSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8722,7 +8722,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.GroupSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Group> source,
             int id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -8733,7 +8733,7 @@ namespace MergedFunctionalTest
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.PrincipalSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Principal> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.PrincipalSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Principal> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.PrincipalSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8745,7 +8745,7 @@ namespace MergedFunctionalTest
         public static global::MergedFunctionalTest.PrincipalSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.Principal> source,
             int id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -9233,7 +9233,7 @@ namespace MergedFunctionalTest1
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest1.DerivedTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DerivedType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest1.DerivedTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DerivedType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest1.DerivedTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9245,7 +9245,7 @@ namespace MergedFunctionalTest1
         public static global::MergedFunctionalTest1.DerivedTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DerivedType> source,
             long keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -9265,7 +9265,7 @@ namespace MergedFunctionalTest1
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest1.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.Customer> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest1.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.Customer> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest1.CustomerSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9277,7 +9277,7 @@ namespace MergedFunctionalTest1
         public static global::MergedFunctionalTest1.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.Customer> source,
             int customerId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerId", customerId }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTestDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MergedFunctionalTestDSC.cs
@@ -8781,7 +8781,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Customer> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Customer> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.CustomerSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8793,7 +8793,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Customer> source,
             int customerId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerId", customerId }
             };
@@ -8804,7 +8804,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.GoodCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.GoodCustomer> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.GoodCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.GoodCustomer> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.GoodCustomerSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8816,7 +8816,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.GoodCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.GoodCustomer> source,
             int customerId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerId", customerId }
             };
@@ -8836,7 +8836,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.BadCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BadCustomer> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.BadCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BadCustomer> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.BadCustomerSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8848,7 +8848,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.BadCustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BadCustomer> source,
             int customerId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerId", customerId }
             };
@@ -8868,7 +8868,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.CustomerInfoSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.CustomerInfo> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.CustomerInfoSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.CustomerInfo> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.CustomerInfoSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8880,7 +8880,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.CustomerInfoSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.CustomerInfo> source,
             int customerInfoId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerInfoId", customerInfoId }
             };
@@ -8891,7 +8891,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.OrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Order> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.OrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Order> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.OrderSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8903,7 +8903,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.OrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Order> source,
             int orderId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "OrderId", orderId }
             };
@@ -8914,7 +8914,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.CompanySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Company> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.CompanySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Company> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.CompanySingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8926,7 +8926,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.CompanySingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Company> source,
             int companyId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CompanyId", companyId }
             };
@@ -8937,7 +8937,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.ProductSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Product> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.ProductSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Product> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.ProductSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8949,7 +8949,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.ProductSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Product> source,
             string iD)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "ID", iD }
             };
@@ -8960,7 +8960,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.ProductDetailSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.ProductDetail> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.ProductDetailSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.ProductDetail> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.ProductDetailSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8972,7 +8972,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.ProductDetailSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.ProductDetail> source,
             int productId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "ProductId", productId }
             };
@@ -8983,7 +8983,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.SpecialTypeWithPrecisionFacetSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.SpecialTypeWithPrecisionFacet> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.SpecialTypeWithPrecisionFacetSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.SpecialTypeWithPrecisionFacet> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.SpecialTypeWithPrecisionFacetSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -8995,7 +8995,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.SpecialTypeWithPrecisionFacetSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.SpecialTypeWithPrecisionFacet> source,
             int id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -9006,7 +9006,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.BlobTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BlobType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.BlobTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BlobType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.BlobTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9018,7 +9018,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.BlobTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BlobType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -9029,7 +9029,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.ChildSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Child> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.ChildSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Child> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.ChildSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9041,7 +9041,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.ChildSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Child> source,
             global::System.Guid iD)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "ID", iD }
             };
@@ -9061,7 +9061,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Person> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Person> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.PersonSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9073,7 +9073,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.PersonSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Person> source,
             global::System.Guid iD)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "ID", iD }
             };
@@ -9084,7 +9084,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9096,7 +9096,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.TestType> source,
             global::System.DateTimeOffset id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -9107,7 +9107,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.TestCollectionTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.TestCollectionType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.TestCollectionTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.TestCollectionType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.TestCollectionTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9119,7 +9119,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.TestCollectionTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.TestCollectionType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -9130,7 +9130,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.DefaultValueTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.DefaultValueTestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.DefaultValueTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.DefaultValueTestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.DefaultValueTestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9142,7 +9142,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.DefaultValueTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.DefaultValueTestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -9153,7 +9153,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.MultiKeyTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.MultiKeyTestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.MultiKeyTestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.MultiKeyTestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.MultiKeyTestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9171,7 +9171,7 @@ namespace MergedFunctionalTest.DSC
             global::System.DateTimeOffset dateTimeOffsetId,
             global::System.Guid guidId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Int64Id", int64Id },
                 { "StringId", stringId },
@@ -9185,7 +9185,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BaseType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BaseType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.BaseTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9197,7 +9197,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.BaseType> source,
             long keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -9208,7 +9208,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.KatmaiTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.KatmaiType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.KatmaiTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.KatmaiType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.KatmaiTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9220,7 +9220,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.KatmaiTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.KatmaiType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -9231,7 +9231,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.Level0Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level0> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.Level0Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level0> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.Level0Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9243,7 +9243,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.Level0Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level0> source,
             string level0Prop)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Level0Prop", level0Prop }
             };
@@ -9254,7 +9254,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.Level1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level1> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.Level1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level1> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.Level1Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9266,7 +9266,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.Level1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level1> source,
             int level1Id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Level1Id", level1Id }
             };
@@ -9286,7 +9286,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.Level2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level2> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.Level2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level2> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.Level2Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9298,7 +9298,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.Level2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Level2> source,
             int level1Id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Level1Id", level1Id }
             };
@@ -9327,7 +9327,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.SingleType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.SingleType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.SingleTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9339,7 +9339,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.SingleType> source,
             global::Microsoft.Spatial.GeographyPoint keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -9350,7 +9350,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.GroupSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Group> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.GroupSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Group> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.GroupSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9362,7 +9362,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.GroupSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Group> source,
             int id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -9373,7 +9373,7 @@ namespace MergedFunctionalTest.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest.DSC.PrincipalSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Principal> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest.DSC.PrincipalSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Principal> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest.DSC.PrincipalSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9385,7 +9385,7 @@ namespace MergedFunctionalTest.DSC
         public static global::MergedFunctionalTest.DSC.PrincipalSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest.DSC.Principal> source,
             int id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -9912,7 +9912,7 @@ namespace MergedFunctionalTest1.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest1.DSC.DerivedTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DSC.DerivedType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest1.DSC.DerivedTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DSC.DerivedType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest1.DSC.DerivedTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9924,7 +9924,7 @@ namespace MergedFunctionalTest1.DSC
         public static global::MergedFunctionalTest1.DSC.DerivedTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DSC.DerivedType> source,
             long keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -9944,7 +9944,7 @@ namespace MergedFunctionalTest1.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::MergedFunctionalTest1.DSC.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DSC.Customer> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::MergedFunctionalTest1.DSC.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DSC.Customer> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::MergedFunctionalTest1.DSC.CustomerSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -9956,7 +9956,7 @@ namespace MergedFunctionalTest1.DSC
         public static global::MergedFunctionalTest1.DSC.CustomerSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::MergedFunctionalTest1.DSC.Customer> source,
             int customerId)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "CustomerId", customerId }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/MultiReferenceModel.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/MultiReferenceModel.cs
@@ -953,7 +953,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.HeadUnitTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.HeadUnitType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.HeadUnitTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.HeadUnitType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.HeadUnitTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -965,7 +965,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo
         public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.HeadUnitTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.HeadUnitType> source,
             string serialNo)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "SerialNo", serialNo }
             };
@@ -976,7 +976,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.TruckTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.TruckType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.TruckTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.TruckType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.TruckTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -988,7 +988,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo
         public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.TruckTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.TruckType> source,
             string key)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Key", key }
             };
@@ -999,7 +999,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.DerivedVehicleGPSTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.DerivedVehicleGPSType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.DerivedVehicleGPSTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.DerivedVehicleGPSType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.DerivedVehicleGPSTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1011,7 +1011,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo
         public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.DerivedVehicleGPSTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.DerivedVehicleGPSType> source,
             string key)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Key", key }
             };
@@ -1632,7 +1632,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.GPS
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.GPS.VehicleGPSTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.GPS.VehicleGPSType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.GPS.VehicleGPSTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.GPS.VehicleGPSType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Microsoft.OData.SampleService.Models.ModelRefDemo.GPS.VehicleGPSTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -1644,7 +1644,7 @@ namespace Microsoft.OData.SampleService.Models.ModelRefDemo.GPS
         public static global::Microsoft.OData.SampleService.Models.ModelRefDemo.GPS.VehicleGPSTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.SampleService.Models.ModelRefDemo.GPS.VehicleGPSType> source,
             string key)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Key", key }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywords.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywords.cs
@@ -148,7 +148,7 @@ namespace NamespaceInKeywords.@event.@string.@int
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::NamespaceInKeywords.@event.@string.@int.TestType1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespaceInKeywords.@event.@string.@int.TestType1> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::NamespaceInKeywords.@event.@string.@int.TestType1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespaceInKeywords.@event.@string.@int.TestType1> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::NamespaceInKeywords.@event.@string.@int.TestType1Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -160,7 +160,7 @@ namespace NamespaceInKeywords.@event.@string.@int
         public static global::NamespaceInKeywords.@event.@string.@int.TestType1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespaceInKeywords.@event.@string.@int.TestType1> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -439,7 +439,7 @@ namespace NamespaceInKeywords.@double
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::NamespaceInKeywords.@double.TestType2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespaceInKeywords.@double.TestType2> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::NamespaceInKeywords.@double.TestType2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespaceInKeywords.@double.TestType2> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::NamespaceInKeywords.@double.TestType2Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -451,7 +451,7 @@ namespace NamespaceInKeywords.@double
         public static global::NamespaceInKeywords.@double.TestType2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespaceInKeywords.@double.TestType2> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywordsWithRefModel.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespaceInKeywordsWithRefModel.cs
@@ -154,7 +154,7 @@ namespace Event.String.Int
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Event.String.Int.TestType1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Event.String.Int.TestType1> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Event.String.Int.TestType1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Event.String.Int.TestType1> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Event.String.Int.TestType1Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -166,7 +166,7 @@ namespace Event.String.Int
         public static global::Event.String.Int.TestType1Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Event.String.Int.TestType1> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };
@@ -509,7 +509,7 @@ namespace Simple.Double
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Simple.Double.TestType2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.Double.TestType2> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Simple.Double.TestType2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.Double.TestType2> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Simple.Double.TestType2Single(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -521,7 +521,7 @@ namespace Simple.Double
         public static global::Simple.Double.TestType2Single ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.Double.TestType2> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixRepeatWithSchemaNameSpace.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixRepeatWithSchemaNameSpace.cs
@@ -289,7 +289,7 @@ namespace NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePre
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -301,7 +301,7 @@ namespace NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePre
         public static global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };
@@ -410,7 +410,7 @@ namespace NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePre
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo12.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo12.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo12.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo12.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo12.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -422,7 +422,7 @@ namespace NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePre
         public static global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo12.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo11.Foo12.NamespacePrefixRepeatWithSchemaNameSpace.Foo1.Foo12.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithDoubleNamespaces.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithDoubleNamespaces.cs
@@ -331,7 +331,7 @@ namespace Foo.NamespacePrefixWithDoubleNamespaces
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Foo.NamespacePrefixWithDoubleNamespaces.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.NamespacePrefixWithDoubleNamespaces.EntityType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Foo.NamespacePrefixWithDoubleNamespaces.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.NamespacePrefixWithDoubleNamespaces.EntityType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Foo.NamespacePrefixWithDoubleNamespaces.EntityTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -343,7 +343,7 @@ namespace Foo.NamespacePrefixWithDoubleNamespaces
         public static global::Foo.NamespacePrefixWithDoubleNamespaces.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.NamespacePrefixWithDoubleNamespaces.EntityType> source,
             global::System.Guid id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };
@@ -488,7 +488,7 @@ namespace Foo.NamespacePrefixWithDoubleNamespaces2
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Foo.NamespacePrefixWithDoubleNamespaces2.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.NamespacePrefixWithDoubleNamespaces2.EntityType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Foo.NamespacePrefixWithDoubleNamespaces2.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.NamespacePrefixWithDoubleNamespaces2.EntityType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Foo.NamespacePrefixWithDoubleNamespaces2.EntityTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -500,7 +500,7 @@ namespace Foo.NamespacePrefixWithDoubleNamespaces2
         public static global::Foo.NamespacePrefixWithDoubleNamespaces2.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.NamespacePrefixWithDoubleNamespaces2.EntityType> source,
             global::System.Guid id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithInheritence.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithInheritence.cs
@@ -292,7 +292,7 @@ namespace Foo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Foo.EntityBaseSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.EntityBase> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Foo.EntityBaseSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.EntityBase> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Foo.EntityBaseSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -304,7 +304,7 @@ namespace Foo
         public static global::Foo.EntityBaseSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.EntityBase> source,
             int idKey)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "IdKey", idKey }
             };
@@ -315,7 +315,7 @@ namespace Foo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Foo.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.EntityType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Foo.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.EntityType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Foo.EntityTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -327,7 +327,7 @@ namespace Foo
         public static global::Foo.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Foo.EntityType> source,
             int idKey)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "IdKey", idKey }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithSingleNamespace.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/NamespacePrefixWithSingleNamespace.cs
@@ -245,7 +245,7 @@ namespace NamespacePrefixWithSingleNamespace
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::NamespacePrefixWithSingleNamespace.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixWithSingleNamespace.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::NamespacePrefixWithSingleNamespace.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixWithSingleNamespace.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::NamespacePrefixWithSingleNamespace.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -257,7 +257,7 @@ namespace NamespacePrefixWithSingleNamespace
         public static global::NamespacePrefixWithSingleNamespace.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::NamespacePrefixWithSingleNamespace.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/OverrideOperationsDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/OverrideOperationsDSC.cs
@@ -482,7 +482,7 @@ namespace OverrideOperations.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::OverrideOperations.DSC.ETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::OverrideOperations.DSC.ET> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::OverrideOperations.DSC.ETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::OverrideOperations.DSC.ET> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::OverrideOperations.DSC.ETSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -494,7 +494,7 @@ namespace OverrideOperations.DSC
         public static global::OverrideOperations.DSC.ETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::OverrideOperations.DSC.ET> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };
@@ -505,7 +505,7 @@ namespace OverrideOperations.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::OverrideOperations.DSC.DerivedETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::OverrideOperations.DSC.DerivedET> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::OverrideOperations.DSC.DerivedETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::OverrideOperations.DSC.DerivedET> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::OverrideOperations.DSC.DerivedETSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -517,7 +517,7 @@ namespace OverrideOperations.DSC
         public static global::OverrideOperations.DSC.DerivedETSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::OverrideOperations.DSC.DerivedET> source,
             string userName)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "UserName", userName }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/PrefixConflict.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/PrefixConflict.cs
@@ -256,7 +256,7 @@ namespace PrefixConflict
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::PrefixConflict.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::PrefixConflict.EntityType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::PrefixConflict.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::PrefixConflict.EntityType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::PrefixConflict.EntityTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -268,7 +268,7 @@ namespace PrefixConflict
         public static global::PrefixConflict.EntityTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::PrefixConflict.EntityType> source,
             global::System.Guid id)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "Id", id }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/Simple.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/Simple.cs
@@ -110,7 +110,7 @@ namespace Simple
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Simple.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Simple.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Simple.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -122,7 +122,7 @@ namespace Simple
         public static global::Simple.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/SimpleDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/SimpleDSC.cs
@@ -129,7 +129,7 @@ namespace Simple.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Simple.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.DSC.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Simple.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.DSC.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Simple.DSC.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -141,7 +141,7 @@ namespace Simple.DSC
         public static global::Simple.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Simple.DSC.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UnexpectedElementsAndAttributes.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UnexpectedElementsAndAttributes.cs
@@ -110,7 +110,7 @@ namespace TestUnexpectedElementsAndAttributes
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::TestUnexpectedElementsAndAttributes.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::TestUnexpectedElementsAndAttributes.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::TestUnexpectedElementsAndAttributes.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::TestUnexpectedElementsAndAttributes.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::TestUnexpectedElementsAndAttributes.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -122,7 +122,7 @@ namespace TestUnexpectedElementsAndAttributes
         public static global::TestUnexpectedElementsAndAttributes.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::TestUnexpectedElementsAndAttributes.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "KeyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithNamespacePrefix.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithNamespacePrefix.cs
@@ -422,7 +422,7 @@ namespace namespacePrefix.Namespace.Foo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::namespacePrefix.Namespace.Foo.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.BaseType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::namespacePrefix.Namespace.Foo.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.BaseType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::namespacePrefix.Namespace.Foo.BaseTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -434,7 +434,7 @@ namespace namespacePrefix.Namespace.Foo
         public static global::namespacePrefix.Namespace.Foo.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.BaseType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };
@@ -445,7 +445,7 @@ namespace namespacePrefix.Namespace.Foo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::namespacePrefix.Namespace.Foo.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::namespacePrefix.Namespace.Foo.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::namespacePrefix.Namespace.Foo.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -457,7 +457,7 @@ namespace namespacePrefix.Namespace.Foo
         public static global::namespacePrefix.Namespace.Foo.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };
@@ -477,7 +477,7 @@ namespace namespacePrefix.Namespace.Foo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::namespacePrefix.Namespace.Foo.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.SingleType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::namespacePrefix.Namespace.Foo.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.SingleType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::namespacePrefix.Namespace.Foo.SingleTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -489,7 +489,7 @@ namespace namespacePrefix.Namespace.Foo
         public static global::namespacePrefix.Namespace.Foo.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::namespacePrefix.Namespace.Foo.SingleType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefix.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefix.cs
@@ -346,7 +346,7 @@ namespace Namespace.Foo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace.Foo.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.BaseType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace.Foo.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.BaseType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace.Foo.BaseTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -358,7 +358,7 @@ namespace Namespace.Foo
         public static global::Namespace.Foo.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.BaseType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };
@@ -369,7 +369,7 @@ namespace Namespace.Foo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace.Foo.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace.Foo.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace.Foo.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -381,7 +381,7 @@ namespace Namespace.Foo
         public static global::Namespace.Foo.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };
@@ -401,7 +401,7 @@ namespace Namespace.Foo
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace.Foo.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.SingleType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace.Foo.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.SingleType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace.Foo.SingleTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -413,7 +413,7 @@ namespace Namespace.Foo
         public static global::Namespace.Foo.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.SingleType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };

--- a/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefixDSC.cs
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/UpperCamelCaseWithoutNamespacePrefixDSC.cs
@@ -385,7 +385,7 @@ namespace Namespace.Foo.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace.Foo.DSC.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.BaseType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace.Foo.DSC.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.BaseType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace.Foo.DSC.BaseTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -397,7 +397,7 @@ namespace Namespace.Foo.DSC
         public static global::Namespace.Foo.DSC.BaseTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.BaseType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };
@@ -408,7 +408,7 @@ namespace Namespace.Foo.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace.Foo.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.TestType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace.Foo.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.TestType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace.Foo.DSC.TestTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -420,7 +420,7 @@ namespace Namespace.Foo.DSC
         public static global::Namespace.Foo.DSC.TestTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.TestType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };
@@ -440,7 +440,7 @@ namespace Namespace.Foo.DSC
         /// </summary>
         /// <param name="source">source entity set</param>
         /// <param name="keys">dictionary with the names and values of keys</param>
-        public static global::Namespace.Foo.DSC.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.SingleType> source, global::System.Collections.Generic.Dictionary<string, object> keys)
+        public static global::Namespace.Foo.DSC.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.SingleType> source, global::System.Collections.Generic.IDictionary<string, object> keys)
         {
             return new global::Namespace.Foo.DSC.SingleTypeSingle(source.Context, source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(source.Context, keys)));
         }
@@ -452,7 +452,7 @@ namespace Namespace.Foo.DSC
         public static global::Namespace.Foo.DSC.SingleTypeSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Namespace.Foo.DSC.SingleType> source,
             int keyProp)
         {
-            global::System.Collections.Generic.Dictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
+            global::System.Collections.Generic.IDictionary<string, object> keys = new global::System.Collections.Generic.Dictionary<string, object>
             {
                 { "keyProp", keyProp }
             };


### PR DESCRIPTION
This was previously merged. We are recreating it so that it can be cherry picked for release.
We are allowing ByKey method to receive an IDictionary<string, object> instead of the concrete class Dictionary<string, object>