### PR TITLE
Feature/add webroxy option for metadata fetching

### DIFF
--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -50,8 +50,13 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             {
                 await AddGeneratedCodeAsync();
             }
-            // Don't write headers to json file
+
             this.ServiceConfiguration.CustomHttpHeaders = null;
+
+            // Since all the code is generated make sure we don't write the username and password for the network credentials
+            this.ServiceConfiguration.WebProxyNetworkCredentialsUsername = null;
+            this.ServiceConfiguration.WebProxyNetworkCredentialsPassword = null;
+
         }
 
         private async Task AddT4FileAsync()
@@ -139,6 +144,13 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 }
             }
             t4CodeGenerator.CustomHttpHeaders = headers;
+
+            t4CodeGenerator.IncludeWebProxy = ServiceConfiguration.IncludeWebProxy;
+            t4CodeGenerator.WebProxyHost = ServiceConfiguration.WebProxyHost;
+            t4CodeGenerator.IncludeWebProxyNetworkCredentials = ServiceConfiguration.IncludeWebProxyNetworkCredentials;
+            t4CodeGenerator.WebProxyNetworkCredentialsUsername = ServiceConfiguration.WebProxyNetworkCredentialsUsername;
+            t4CodeGenerator.WebProxyNetworkCredentialsPassword = ServiceConfiguration.WebProxyNetworkCredentialsPassword;
+            t4CodeGenerator.WebProxyNetworkCredentialsDomain = ServiceConfiguration.WebProxyNetworkCredentialsDomain;
 
             string tempFile = Path.GetTempFileName();
 

--- a/src/Models/ServiceConfiguration.cs
+++ b/src/Models/ServiceConfiguration.cs
@@ -19,6 +19,15 @@ namespace Microsoft.OData.ConnectedService.Models
         public bool OpenGeneratedFilesInIDE { get; set; }
         public bool GenerateMultipleFiles { get; set; }
         public string CustomHttpHeaders { get; set; }
+        public bool IncludeWebProxy { get; set; }
+        public string WebProxyHost { get; set; }
+        public bool IncludeWebProxyNetworkCredentials { get; set; }
+        public string WebProxyNetworkCredentialsUsername { get; set; }
+        public string WebProxyNetworkCredentialsPassword { get; set; }
+        public string WebProxyNetworkCredentialsDomain { get; set; }
+        public bool IncludeCustomHeaders { get; set; }
+
+
     }
 
     internal class ServiceConfigurationV4 : ServiceConfiguration

--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -26,6 +26,7 @@ namespace Microsoft.OData.ConnectedService
 
         public ODataConnectedServiceInstance ServiceInstance => this.serviceInstance ?? (this.serviceInstance = new ODataConnectedServiceInstance());
 
+
         public Version EdmxVersion => this.ConfigODataEndpointViewModel.EdmxVersion;
 
         public UserSettings UserSettings { get; }
@@ -52,8 +53,7 @@ namespace Microsoft.OData.ConnectedService
                 ConfigODataEndpointViewModel.ServiceName = serviceConfig.ServiceName;
                 ConfigODataEndpointViewModel.CustomHttpHeaders = serviceConfig.CustomHttpHeaders;
 
-                if (ConfigODataEndpointViewModel.View is ConfigODataEndpoint configODataEndpoint)
-                    configODataEndpoint.IsEnabled = false;
+
 
                 // The ViewModel should always be filled otherwise if the wizard is completed without visiting this page the generated code becomes wrong
                 AdvancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNameSpacePrefix;
@@ -68,6 +68,30 @@ namespace Microsoft.OData.ConnectedService
                     AdvancedSettingsViewModel.IncludeT4File = serviceConfig.IncludeT4File;
                     AdvancedSettingsViewModel.MakeTypesInternal = serviceConfig.MakeTypesInternal;
                 }
+
+
+                ConfigODataEndpointViewModel.PageEntering += (sender, args) =>
+                {
+
+                    var configOdataViewModel = sender as ConfigODataEndpointViewModel;
+                    if (configOdataViewModel != null)
+                    {
+                        var configOdataView = configOdataViewModel.View as ConfigODataEndpoint;
+                        configOdataView.Endpoint.IsEnabled = false;
+                        configOdataView.ServiceName.IsEnabled = false;
+                        configOdataViewModel.IncludeCustomHeaders = serviceConfig.IncludeCustomHeaders;
+                        configOdataViewModel.IncludeWebProxy = serviceConfig.IncludeWebProxy;
+                        configOdataViewModel.WebProxyHost = serviceConfig.WebProxyHost;
+
+                        configOdataViewModel.IncludeWebProxyNetworkCredentials = serviceConfig.IncludeWebProxyNetworkCredentials;
+                        configOdataViewModel.WebProxyNetworkCredentialsDomain = serviceConfig.WebProxyNetworkCredentialsDomain;
+
+                       // don't accept any credentials from the restored settings
+                        configOdataViewModel.WebProxyNetworkCredentialsUsername = null;
+                        configOdataViewModel.WebProxyNetworkCredentialsPassword = null;
+                    }
+                };
+
 
                 //Restore the advanced settings to UI elements.
                 AdvancedSettingsViewModel.PageEntering += (sender, args) =>
@@ -141,12 +165,22 @@ namespace Microsoft.OData.ConnectedService
             serviceConfiguration.Endpoint = ConfigODataEndpointViewModel.Endpoint;
             serviceConfiguration.EdmxVersion = ConfigODataEndpointViewModel.EdmxVersion;
             serviceConfiguration.CustomHttpHeaders = ConfigODataEndpointViewModel.CustomHttpHeaders;
+            serviceConfiguration.IncludeWebProxy = ConfigODataEndpointViewModel.IncludeWebProxy;
+            serviceConfiguration.WebProxyHost = ConfigODataEndpointViewModel.WebProxyHost;
+            serviceConfiguration.IncludeWebProxyNetworkCredentials = ConfigODataEndpointViewModel.IncludeWebProxyNetworkCredentials;
+            serviceConfiguration.WebProxyNetworkCredentialsUsername = ConfigODataEndpointViewModel.WebProxyNetworkCredentialsUsername;
+            serviceConfiguration.WebProxyNetworkCredentialsPassword = ConfigODataEndpointViewModel.WebProxyNetworkCredentialsPassword;
+            serviceConfiguration.WebProxyNetworkCredentialsDomain = ConfigODataEndpointViewModel.WebProxyNetworkCredentialsDomain;
+
+            serviceConfiguration.IncludeCustomHeaders = ConfigODataEndpointViewModel.IncludeCustomHeaders;
+
             serviceConfiguration.UseDataServiceCollection = AdvancedSettingsViewModel.UseDataServiceCollection;
             serviceConfiguration.GeneratedFileNamePrefix = AdvancedSettingsViewModel.GeneratedFileName;
             serviceConfiguration.UseNameSpacePrefix = AdvancedSettingsViewModel.UseNamespacePrefix;
             serviceConfiguration.MakeTypesInternal = AdvancedSettingsViewModel.MakeTypesInternal;
             serviceConfiguration.OpenGeneratedFilesInIDE = AdvancedSettingsViewModel.OpenGeneratedFilesInIDE;
             serviceConfiguration.GenerateMultipleFiles = AdvancedSettingsViewModel.GenerateMultipleFiles;
+
             if (AdvancedSettingsViewModel.UseNamespacePrefix && !string.IsNullOrEmpty(AdvancedSettingsViewModel.NamespacePrefix))
             {
                 serviceConfiguration.NamespacePrefix = AdvancedSettingsViewModel.NamespacePrefix;

--- a/src/Templates/ODataT4CodeGenerator.cs
+++ b/src/Templates/ODataT4CodeGenerator.cs
@@ -1319,7 +1319,7 @@ public class CodeGenerationContext
                     }
                 }
 
-                if(proxy!=null)
+                if(proxy != null)
                 {
                     webRequest.Proxy= proxy;
                 }

--- a/src/Templates/ODataT4CodeGenerator.cs
+++ b/src/Templates/ODataT4CodeGenerator.cs
@@ -88,7 +88,22 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             this.ApplyParametersFromConfigurationClass();
         }
 
-        context = new CodeGenerationContext(new Uri(this.MetadataDocumentUri, UriKind.Absolute), this.NamespacePrefix, this.CustomHttpHeaders)
+        WebProxy proxy = null;
+        if(this.IncludeWebProxy)
+        {
+            proxy = new WebProxy(this.WebProxyHost,true);
+
+            if(this.IncludeWebProxyNetworkCredentials)
+            {
+               NetworkCredential  credentials = new NetworkCredential(this.WebProxyNetworkCredentialsUsername,
+               this.WebProxyNetworkCredentialsPassword,
+               this.WebProxyNetworkCredentialsDomain);
+               proxy.Credentials = credentials;
+            }
+
+        }
+
+        context = new CodeGenerationContext(new Uri(this.MetadataDocumentUri, UriKind.Absolute), this.NamespacePrefix, proxy, this.CustomHttpHeaders)
         {
             UseDataServiceCollection = this.UseDataServiceCollection,
             TargetLanguage = this.TargetLanguage,
@@ -191,6 +206,7 @@ public static class Configuration
 	
 	// Comma-separated list of the names of operation imports to exclude from the generated code
 	public const string ExcludedOperationImports = "";
+
 }
 
 public static class Customization
@@ -293,7 +309,7 @@ private string metadataDocumentUri;
 /// <summary>
 /// The Func to get referenced model's XmlReader. Must have value when the this.Edmx xml or this.metadataDocumentUri's model has referneced model.
 /// </summary>
-public Func<Uri,XmlReader> GetReferencedModelReaderFunc
+public Func<Uri, WebProxy, IList<string>, XmlReader> GetReferencedModelReaderFunc
 {
     get;
     set;
@@ -409,9 +425,62 @@ public FilesManager MultipleFilesManager
 }
 
 /// <summary>
+/// The web proxy host address
+/// </summary>
+public string WebProxyHost
+{
+    get;
+    set;
+}
+
+/// <summary>
 /// true to generate multiple files, false generate a single file.
 /// </summary>
 public bool GenerateMultipleFiles
+{
+    get;
+    set;
+}
+/// <summary>
+/// Boolean to show if we should include the web proxy 
+/// </summary>
+public bool IncludeWebProxy
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// Boolean to show if we should include the web proxy network credentials
+/// </summary>
+public bool IncludeWebProxyNetworkCredentials
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// The web proxy host network credentials domain
+/// </summary>
+public string WebProxyNetworkCredentialsDomain
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// The web proxy host network credentials username
+/// </summary>
+public string WebProxyNetworkCredentialsUsername
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// The web proxy host network credentials password
+/// </summary>
+public string WebProxyNetworkCredentialsPassword
 {
     get;
     set;
@@ -660,6 +729,24 @@ private void ApplyParametersFromCommandLine()
 }
 
 /// <summary>
+/// Enable one to mock the requests when fetching metadata
+/// </summary>
+internal interface IHttpRequestCreator
+{
+    HttpWebRequest Create(Uri uri);
+}
+/// <summary>
+/// Includes a default http request creator that creates web requests for the client
+/// </summary>
+internal class DefaultHttpRequestCreator : IHttpRequestCreator
+{
+    public HttpWebRequest Create(Uri uri)
+    {
+        return (HttpWebRequest) WebRequest.Create(uri);
+    }
+}
+
+/// <summary>
 /// Context object to provide the model and configuration info to the code generator.
 /// </summary>
 public class CodeGenerationContext
@@ -728,14 +815,32 @@ public class CodeGenerationContext
     private HashSet<string> keyAsSegmentContainers;
 
     /// <summary>
+    /// Preconfigured WebProxy for fetching the metadata
+    /// </summary>
+    private WebProxy webProxy;
+    private  IList<string> customHttpHeaders;
+    /// <summary>
     /// Constructs an instance of <see cref="CodeGenerationContext"/>.
     /// </summary>
     /// <param name="metadataUri">The Uri to the metadata document. The supported scheme are File, http and https.</param>
-    public CodeGenerationContext(Uri metadataUri, string namespacePrefix, IList<string> CustomHttpHeaders = null)
-        : this(GetEdmxStringFromMetadataPath(metadataUri, CustomHttpHeaders), namespacePrefix)
+    /// <param name="namespacePrefix">The namespacePrefix is used as the only namespace in generated code
+    public CodeGenerationContext(Uri metadataUri, string namespacePrefix)
+        : this(metadataUri, namespacePrefix, null, null)
     {
     }
 
+    /// <summary>
+    /// Constructs an instance of <see cref="CodeGenerationContext"/>.
+    /// </summary>
+    /// <param name="metadataUri">The Uri to the metadata document. The supported scheme are File, http and https.</param>
+    /// <param name="proxy">Webproxy instance to use for retriving the metadata</param>
+    /// <param name="namespacePrefix">The namespacePrefix is used as the only namespace in generated code
+    public CodeGenerationContext(Uri metadataUri, string namespacePrefix,  WebProxy proxy,  IList<string> CustomHttpHeaders)
+        : this(GetEdmxStringFromMetadataPath(metadataUri, proxy, CustomHttpHeaders), namespacePrefix)
+    {
+        webProxy = proxy;
+        customHttpHeaders = CustomHttpHeaders;
+    }
     /// <summary>
     /// Constructs an instance of <see cref="CodeGenerationContext"/>.
     /// </summary>
@@ -795,12 +900,25 @@ public class CodeGenerationContext
     /// <summary>
     /// The func for user code to overwrite and provide referenced model's XmlReader.
     /// </summary>
-    public Func<Uri,XmlReader> GetReferencedModelReaderFunc
+    public Func<Uri, WebProxy, IList<string>, XmlReader> GetReferencedModelReaderFunc
     {
         get { return getReferencedModelReaderFunc; }
         set { this.getReferencedModelReaderFunc = value; }
     }
+    private static IHttpRequestCreator requestCreator;
+    internal static IHttpRequestCreator RequestCreator
+    { 
+        get 
+        { 
+             if(requestCreator==null)
+             {
+                requestCreator= new DefaultHttpRequestCreator();
+             }
+             return  requestCreator;
+        }
 
+        set { requestCreator = value;}
+    }
     /// <summary>
     /// Basic setting for XmlReader.
     /// </summary>
@@ -809,7 +927,7 @@ public class CodeGenerationContext
     /// <summary>
     /// The func for user code to overwrite and provide referenced model's XmlReader.
     /// </summary>
-    private Func<Uri, XmlReader> getReferencedModelReaderFunc = uri => XmlReader.Create(GetEdmxStreamFromUri(uri), settings);
+    private Func<Uri, WebProxy, IList<string>, XmlReader> getReferencedModelReaderFunc = (uri, proxy, headers) => XmlReader.Create(GetEdmxStreamFromUri(uri, proxy, headers), settings);
 
     /// <summary>
     /// The Wrapper func for user code to overwrite and provide referenced model's stream.
@@ -820,7 +938,7 @@ public class CodeGenerationContext
         {
             return (uri) =>
             {
-                using (XmlReader reader = GetReferencedModelReaderFunc(uri))
+                using (XmlReader reader = GetReferencedModelReaderFunc(uri, webProxy, customHttpHeaders))
                 {
                     if (reader == null)
                     {
@@ -1165,10 +1283,10 @@ public class CodeGenerationContext
     /// Reads the edmx string from a file path or a http/https path.
     /// </summary>
     /// <param name="metadataUri">The Uri to the metadata document. The supported scheme are File, http and https.</param>
-    private static string GetEdmxStringFromMetadataPath(Uri metadataUri, IList<string> CustomHttpHeaders = null)
+    private static string GetEdmxStringFromMetadataPath(Uri metadataUri, WebProxy proxy, IList<string> customHttpHeaders)
     {
         string content = null;
-        using (StreamReader streamReader = new StreamReader(GetEdmxStreamFromUri(metadataUri, CustomHttpHeaders)))
+        using (StreamReader streamReader = new StreamReader(GetEdmxStreamFromUri(metadataUri, proxy ,customHttpHeaders)))
         {
             content = streamReader.ReadToEnd();
         }
@@ -1180,7 +1298,7 @@ public class CodeGenerationContext
     /// Get the metadata stream from a file path or a http/https path.
     /// </summary>
     /// <param name="metadataUri">The Uri to the stream. The supported scheme are File, http and https.</param>
-    private static Stream GetEdmxStreamFromUri(Uri metadataUri, IList<string> CustomHttpHeaders  = null)
+    private static Stream GetEdmxStreamFromUri(Uri metadataUri, WebProxy proxy, IList<string> customHttpHeaders)
     {
         Debug.Assert(metadataUri != null, "metadataUri != null");
         Stream metadataStream = null;
@@ -1192,16 +1310,23 @@ public class CodeGenerationContext
         {
             try
             {
-                HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(metadataUri);
-                if (CustomHttpHeaders != null)
+                 HttpWebRequest webRequest = RequestCreator.Create(metadataUri);
+                if (customHttpHeaders != null)
                 {
-                    foreach (var header in CustomHttpHeaders)
+                    foreach (var header in customHttpHeaders)
                     {
                         webRequest.Headers.Add(header);
                     }
                 }
+
+                if(proxy!=null)
+                {
+                    webRequest.Proxy= proxy;
+                }
+
                 WebResponse webResponse = webRequest.GetResponse();
                 metadataStream = webResponse.GetResponseStream();
+               
             }
             catch (WebException e)
             {
@@ -1505,7 +1630,7 @@ public abstract class ODataClientTemplate : TemplateBase
             {
                     if(context.GenerateMultipleFiles) 
                     {
-                        context.MultipleFilesManager.StartNewFile($"{enumType.Name}{(this.context.TargetLanguage == LanguageOption.VB ? ".vb" : ".cs")}", false);
+                        context.MultipleFilesManager.StartNewFile($"{enumType.Name}{(this.context.TargetLanguage == LanguageOption.VB ? ".vb" : ".cs")}",false);
                         this.WriteNamespaceStart(this.context.GetPrefixedNamespace(fullNamespace, this, true, false));
                     }
 
@@ -1523,7 +1648,7 @@ public abstract class ODataClientTemplate : TemplateBase
                 {
                     if(context.GenerateMultipleFiles) 
                     {
-                        context.MultipleFilesManager.StartNewFile($"{complexType.Name}{(this.context.TargetLanguage == LanguageOption.VB ? ".vb" : ".cs")}", false);
+                        context.MultipleFilesManager.StartNewFile($"{complexType.Name}{(this.context.TargetLanguage == LanguageOption.VB ? ".vb" : ".cs")}",false);
                         this.WriteNamespaceStart(this.context.GetPrefixedNamespace(fullNamespace, this, true, false));
                     }
 
@@ -1539,7 +1664,7 @@ public abstract class ODataClientTemplate : TemplateBase
                 {
                     if(context.GenerateMultipleFiles) 
                     {
-                        context.MultipleFilesManager.StartNewFile($"{entityType.Name}{(this.context.TargetLanguage == LanguageOption.VB ? ".vb" : ".cs")}", false);
+                        context.MultipleFilesManager.StartNewFile($"{entityType.Name}{(this.context.TargetLanguage == LanguageOption.VB ? ".vb" : ".cs")}",false);
                         this.WriteNamespaceStart(this.context.GetPrefixedNamespace(fullNamespace, this, true, false));
                     }
 
@@ -4124,8 +4249,8 @@ this.Write("\")]\r\n            private static global::Microsoft.OData.Edm.IEdmM
             if (useTempFile)
             {
 
-this.Write("            [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Microsof" +
-        "t.OData.Client.Design.T4\", \"");
+this.Write("            [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Microsoft.OD" +
+        "ata.Client.Design.T4\", \"");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(T4Version));
 
@@ -4140,8 +4265,8 @@ this.Write("\";\r\n");
             else
             {
 
-this.Write("            [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Microsof" +
-        "t.OData.Client.Design.T4\", \"");
+this.Write("            [global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Microsoft.OD" +
+        "ata.Client.Design.T4\", \"");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(T4Version));
 
@@ -4225,8 +4350,7 @@ this.Write("                global::System.Xml.XmlReader reader = CreateXmlReade
                 else
                 {
 
-this.Write("                global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);\r" +
-        "\n");
+this.Write("                global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);\r\n");
 
 
                 }
@@ -7181,8 +7305,8 @@ this.Write(@" specified by key from an entity set
 
 this.Write(this.ToStringHelper.ToStringWithCulture(entityTypeName));
 
-this.Write("), ByVal keys As Global.System.Collections.Generic.IDictionary(Of String, Object))" +
-        " As ");
+this.Write("), ByVal keys As Global.System.Collections.Generic.IDictionary(Of String, Object)" +
+        ") As ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
@@ -7233,9 +7357,9 @@ this.Write(") As ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(returnTypeName));
 
-this.Write("\r\n            Dim keys As Global.System.Collections.Generic.IDictionary(Of String," +
-        " Object) = New Global.System.Collections.Generic.Dictionary(Of String, Object)()" +
-        " From\r\n            {\r\n                ");
+this.Write("\r\n            Dim keys As Global.System.Collections.Generic.IDictionary(Of String" +
+        ", Object) = New Global.System.Collections.Generic.Dictionary(Of String, Object)(" +
+        ") From\r\n            {\r\n                ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(keyDictionaryItems));
 

--- a/src/Templates/ODataT4CodeGenerator.tt
+++ b/src/Templates/ODataT4CodeGenerator.tt
@@ -42,6 +42,7 @@ public static class Configuration
 	
 	// Comma-separated list of the names of operation imports to exclude from the generated code
 	public const string ExcludedOperationImports = "";
+
 }
 
 public static class Customization

--- a/src/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Templates/ODataT4CodeGenerator.ttinclude
@@ -1179,7 +1179,7 @@ public class CodeGenerationContext
                     }
                 }
 
-                if(proxy!=null)
+                if(proxy != null)
                 {
                     webRequest.Proxy= proxy;
                 }

--- a/src/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Templates/ODataT4CodeGenerator.ttinclude
@@ -61,7 +61,22 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             this.ApplyParametersFromConfigurationClass();
         }
 
-        context = new CodeGenerationContext(new Uri(this.MetadataDocumentUri, UriKind.Absolute), this.NamespacePrefix, this.CustomHttpHeaders)
+        WebProxy proxy = null;
+        if(this.IncludeWebProxy)
+        {
+            proxy = new WebProxy(this.WebProxyHost,true);
+
+            if(this.IncludeWebProxyNetworkCredentials)
+            {
+               NetworkCredential  credentials = new NetworkCredential(this.WebProxyNetworkCredentialsUsername,
+               this.WebProxyNetworkCredentialsPassword,
+               this.WebProxyNetworkCredentialsDomain);
+               proxy.Credentials = credentials;
+            }
+
+        }
+
+        context = new CodeGenerationContext(new Uri(this.MetadataDocumentUri, UriKind.Absolute), this.NamespacePrefix, proxy, this.CustomHttpHeaders)
         {
             UseDataServiceCollection = this.UseDataServiceCollection,
             TargetLanguage = this.TargetLanguage,
@@ -154,7 +169,7 @@ private string metadataDocumentUri;
 /// <summary>
 /// The Func to get referenced model's XmlReader. Must have value when the this.Edmx xml or this.metadataDocumentUri's model has referneced model.
 /// </summary>
-public Func<Uri,XmlReader> GetReferencedModelReaderFunc
+public Func<Uri, WebProxy, IList<string>, XmlReader> GetReferencedModelReaderFunc
 {
     get;
     set;
@@ -270,9 +285,62 @@ public FilesManager MultipleFilesManager
 }
 
 /// <summary>
+/// The web proxy host address
+/// </summary>
+public string WebProxyHost
+{
+    get;
+    set;
+}
+
+/// <summary>
 /// true to generate multiple files, false generate a single file.
 /// </summary>
 public bool GenerateMultipleFiles
+{
+    get;
+    set;
+}
+/// <summary>
+/// Boolean to show if we should include the web proxy 
+/// </summary>
+public bool IncludeWebProxy
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// Boolean to show if we should include the web proxy network credentials
+/// </summary>
+public bool IncludeWebProxyNetworkCredentials
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// The web proxy host network credentials domain
+/// </summary>
+public string WebProxyNetworkCredentialsDomain
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// The web proxy host network credentials username
+/// </summary>
+public string WebProxyNetworkCredentialsUsername
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// The web proxy host network credentials password
+/// </summary>
+public string WebProxyNetworkCredentialsPassword
 {
     get;
     set;
@@ -521,6 +589,24 @@ private void ApplyParametersFromCommandLine()
 }
 
 /// <summary>
+/// Enable one to mock the requests when fetching metadata
+/// </summary>
+internal interface IHttpRequestCreator
+{
+    HttpWebRequest Create(Uri uri);
+}
+/// <summary>
+/// Includes a default http request creator that creates web requests for the client
+/// </summary>
+internal class DefaultHttpRequestCreator : IHttpRequestCreator
+{
+    public HttpWebRequest Create(Uri uri)
+    {
+        return (HttpWebRequest) WebRequest.Create(uri);
+    }
+}
+
+/// <summary>
 /// Context object to provide the model and configuration info to the code generator.
 /// </summary>
 public class CodeGenerationContext
@@ -589,14 +675,32 @@ public class CodeGenerationContext
     private HashSet<string> keyAsSegmentContainers;
 
     /// <summary>
+    /// Preconfigured WebProxy for fetching the metadata
+    /// </summary>
+    private WebProxy webProxy;
+    private  IList<string> customHttpHeaders;
+    /// <summary>
     /// Constructs an instance of <see cref="CodeGenerationContext"/>.
     /// </summary>
     /// <param name="metadataUri">The Uri to the metadata document. The supported scheme are File, http and https.</param>
-    public CodeGenerationContext(Uri metadataUri, string namespacePrefix, IList<string> CustomHttpHeaders = null)
-        : this(GetEdmxStringFromMetadataPath(metadataUri, CustomHttpHeaders), namespacePrefix)
+    /// <param name="namespacePrefix">The namespacePrefix is used as the only namespace in generated code
+    public CodeGenerationContext(Uri metadataUri, string namespacePrefix)
+        : this(metadataUri, namespacePrefix, null, null)
     {
     }
 
+    /// <summary>
+    /// Constructs an instance of <see cref="CodeGenerationContext"/>.
+    /// </summary>
+    /// <param name="metadataUri">The Uri to the metadata document. The supported scheme are File, http and https.</param>
+    /// <param name="proxy">Webproxy instance to use for retriving the metadata</param>
+    /// <param name="namespacePrefix">The namespacePrefix is used as the only namespace in generated code
+    public CodeGenerationContext(Uri metadataUri, string namespacePrefix,  WebProxy proxy,  IList<string> CustomHttpHeaders)
+        : this(GetEdmxStringFromMetadataPath(metadataUri, proxy, CustomHttpHeaders), namespacePrefix)
+    {
+        webProxy = proxy;
+        customHttpHeaders = CustomHttpHeaders;
+    }
     /// <summary>
     /// Constructs an instance of <see cref="CodeGenerationContext"/>.
     /// </summary>
@@ -656,12 +760,25 @@ public class CodeGenerationContext
     /// <summary>
     /// The func for user code to overwrite and provide referenced model's XmlReader.
     /// </summary>
-    public Func<Uri,XmlReader> GetReferencedModelReaderFunc
+    public Func<Uri, WebProxy, IList<string>, XmlReader> GetReferencedModelReaderFunc
     {
         get { return getReferencedModelReaderFunc; }
         set { this.getReferencedModelReaderFunc = value; }
     }
+    private static IHttpRequestCreator requestCreator;
+    internal static IHttpRequestCreator RequestCreator
+    { 
+        get 
+        { 
+             if(requestCreator==null)
+             {
+                requestCreator= new DefaultHttpRequestCreator();
+             }
+             return  requestCreator;
+        }
 
+        set { requestCreator = value;}
+    }
     /// <summary>
     /// Basic setting for XmlReader.
     /// </summary>
@@ -670,7 +787,7 @@ public class CodeGenerationContext
     /// <summary>
     /// The func for user code to overwrite and provide referenced model's XmlReader.
     /// </summary>
-    private Func<Uri, XmlReader> getReferencedModelReaderFunc = uri => XmlReader.Create(GetEdmxStreamFromUri(uri), settings);
+    private Func<Uri, WebProxy, IList<string>, XmlReader> getReferencedModelReaderFunc = (uri, proxy, headers) => XmlReader.Create(GetEdmxStreamFromUri(uri, proxy, headers), settings);
 
     /// <summary>
     /// The Wrapper func for user code to overwrite and provide referenced model's stream.
@@ -681,7 +798,7 @@ public class CodeGenerationContext
         {
             return (uri) =>
             {
-                using (XmlReader reader = GetReferencedModelReaderFunc(uri))
+                using (XmlReader reader = GetReferencedModelReaderFunc(uri, webProxy, customHttpHeaders))
                 {
                     if (reader == null)
                     {
@@ -1026,10 +1143,10 @@ public class CodeGenerationContext
     /// Reads the edmx string from a file path or a http/https path.
     /// </summary>
     /// <param name="metadataUri">The Uri to the metadata document. The supported scheme are File, http and https.</param>
-    private static string GetEdmxStringFromMetadataPath(Uri metadataUri, IList<string> CustomHttpHeaders = null)
+    private static string GetEdmxStringFromMetadataPath(Uri metadataUri, WebProxy proxy, IList<string> customHttpHeaders)
     {
         string content = null;
-        using (StreamReader streamReader = new StreamReader(GetEdmxStreamFromUri(metadataUri, CustomHttpHeaders)))
+        using (StreamReader streamReader = new StreamReader(GetEdmxStreamFromUri(metadataUri, proxy ,customHttpHeaders)))
         {
             content = streamReader.ReadToEnd();
         }
@@ -1041,7 +1158,7 @@ public class CodeGenerationContext
     /// Get the metadata stream from a file path or a http/https path.
     /// </summary>
     /// <param name="metadataUri">The Uri to the stream. The supported scheme are File, http and https.</param>
-    private static Stream GetEdmxStreamFromUri(Uri metadataUri, IList<string> CustomHttpHeaders  = null)
+    private static Stream GetEdmxStreamFromUri(Uri metadataUri, WebProxy proxy, IList<string> customHttpHeaders)
     {
         Debug.Assert(metadataUri != null, "metadataUri != null");
         Stream metadataStream = null;
@@ -1053,16 +1170,23 @@ public class CodeGenerationContext
         {
             try
             {
-                HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(metadataUri);
-                if (CustomHttpHeaders != null)
+                 HttpWebRequest webRequest = RequestCreator.Create(metadataUri);
+                if (customHttpHeaders != null)
                 {
-                    foreach (var header in CustomHttpHeaders)
+                    foreach (var header in customHttpHeaders)
                     {
                         webRequest.Headers.Add(header);
                     }
                 }
+
+                if(proxy!=null)
+                {
+                    webRequest.Proxy= proxy;
+                }
+
                 WebResponse webResponse = webRequest.GetResponse();
                 metadataStream = webResponse.GetResponseStream();
+               
             }
             catch (WebException e)
             {

--- a/src/ViewModels/AdvancedSettingsViewModel.cs
+++ b/src/ViewModels/AdvancedSettingsViewModel.cs
@@ -59,9 +59,10 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             this.EnableNamingAlias = false;
             this.GeneratedFileName = Common.Constants.DefaultReferenceFileName;
             this.IncludeT4File = false;
-            MakeTypesInternal = false;
+            this.MakeTypesInternal = false;
             this.OpenGeneratedFilesInIDE = false;
-            GenerateMultipleFiles = false;
+            this.GenerateMultipleFiles = false;
+
         }
 
     }

--- a/src/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ViewModels/ConfigODataEndpointViewModel.cs
@@ -149,7 +149,6 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                     Credentials = CredentialCache.DefaultNetworkCredentials
 
                 };
-                PermissionSet permissionSet = new PermissionSet(System.Security.Permissions.PermissionState.Unrestricted);
 
                 metadataStream = (Stream)xmlUrlResolver.GetEntity(metadataUri, null, typeof(Stream));
             }
@@ -157,7 +156,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             string workFile = Path.GetTempFileName();
 
             try
-            {   using(metadataStream)
+            {   
                 using (XmlReader reader = XmlReader.Create(metadataStream))
                 {
                     using (XmlWriter writer = XmlWriter.Create(workFile))
@@ -181,6 +180,10 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             catch (WebException e)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Cannot access {0}", this.Endpoint), e);
+            }
+            finally
+            {
+                metadataStream?.Dispose();
             }
         }
     }

--- a/src/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ViewModels/ConfigODataEndpointViewModel.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
-using System.Security;
 using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.OData.ConnectedService.Common;

--- a/src/Views/AdvancedSettings.xaml
+++ b/src/Views/AdvancedSettings.xaml
@@ -12,6 +12,7 @@
              d:DesignHeight="400" d:DesignWidth="500">
     <StackPanel>
         <StackPanel x:Name="SettingsPanel" HorizontalAlignment="Left" Margin="10,0,0,0" VerticalAlignment="Top" Height="175">
+
             <TextBlock x:Name="ReferenceFileNameLabel" Text="Enter the file name (without extension):"
                            HorizontalAlignment="Left" Margin="0, 5, 0, 0"/>
             <TextBox x:Name="ReferenceFileName" Text="{Binding GeneratedFileName}"

--- a/src/Views/ConfigODataEndpoint.xaml
+++ b/src/Views/ConfigODataEndpoint.xaml
@@ -11,6 +11,9 @@
              d:DataContext="{d:DesignInstance Type=viewModels:ConfigODataEndpointViewModel}"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="500">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+    </UserControl.Resources>
     <StackPanel HorizontalAlignment="Left" Margin="10, 0, 0, 0" VerticalAlignment="Top" Width="490">
         <TextBlock x:Name="ServiceName1" Text="Service name： "
                    HorizontalAlignment="Left" Margin="0, 5, 10, 5">
@@ -24,13 +27,20 @@
                   Margin="20, 5, 5, 0" IsEditable="True"
                   ItemsSource="{Binding Path=UserSettings.MruEndpoints}"
                   Text="{Binding Path=Endpoint, TargetNullValue='Enter your endpoint...' }"/>
-        <TextBlock
+
+        <CheckBox x:Name="IncludeHttpHeadersElement" Content="Include Custom Http Headers" IsChecked="{Binding IncludeCustomHeaders}"
+                          HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,15" FontWeight="Medium"/>
+
+        <StackPanel
+                    Visibility="{Binding Path=IsChecked, ElementName=IncludeHttpHeadersElement, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="20, 0, 0, 0">
+
+            <TextBlock
             x:Name="CustomHttpHeadersLabel"
             Text="Custom Headers： "
             HorizontalAlignment="Left"
             Margin="0, 5, 10, 5">
-        </TextBlock>
-        <TextBox
+            </TextBlock>
+            <TextBox
             x:Name="CustomHttpHeaders"
             Text="{Binding Path=CustomHttpHeaders}"
             HorizontalAlignment="Left"
@@ -39,15 +49,51 @@
             VerticalScrollBarVisibility="Visible"
             Margin="20, 5, 10, 5"
             Width="250">
-            <TextBox.ToolTip>
-                <ToolTip HorizontalAlignment="Center">
-                    <TextBlock>
+                <TextBox.ToolTip>
+                    <ToolTip HorizontalAlignment="Center">
+                        <TextBlock>
                         (Optional) We add Http Headers to our http request as a multiline string e.g <LineBreak/>
                         HeaderKey1: HeaderValue1<LineBreak/>
                         HeaderKey2: HeaderValue2<LineBreak/>
-                    </TextBlock>
-                </ToolTip>
-            </TextBox.ToolTip>
-        </TextBox>
+                        </TextBlock>
+                    </ToolTip>
+                </TextBox.ToolTip>
+            </TextBox>
+        </StackPanel>
+
+        <CheckBox x:Name="IncludeWebProxyElement" Content="Include WebProxy" IsChecked="{Binding IncludeWebProxy}"
+                          HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 15" FontWeight="Medium"/>
+
+        <StackPanel
+                    Visibility="{Binding Path=IsChecked, ElementName=IncludeWebProxyElement, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="20, 0, 0, 0">
+
+            <StackPanel Orientation="Vertical" Margin=" 0, 0, 0,0" >
+                <TextBlock x:Name="HostLabel" Text="Enter the webproxy host with the port (e.g. http://localhost:8080):"
+                           HorizontalAlignment="Left" Margin="0, 0, 5, 0"/>
+                <TextBox x:Name="WebProxyHost" Text="{Binding WebProxyHost}"
+                             HorizontalAlignment="Left" TextWrapping="Wrap" Width="300" Margin="0, 0, 0, 0"/>
+            </StackPanel>
+            <CheckBox x:Name="IncludeWebProxyNetworkCredentialsElement" Content="Include Proxy Network credentials" IsChecked="{Binding IncludeWebProxyNetworkCredentials}"
+                          HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 10" FontWeight="Medium"/>
+            <StackPanel Orientation="Vertical"
+                        Visibility="{Binding Path=IsChecked, ElementName=IncludeWebProxyNetworkCredentialsElement, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="20, 0, 0, 0">
+
+                <TextBlock x:Name="WebProxyNetworkCredentialsUsernameLabel" Text="Username:"
+                           HorizontalAlignment="Left" Margin="0, 10, 0, 0"/>
+                <TextBox x:Name="WebProxyNetworkCredentialsUsername" Text="{Binding WebProxyNetworkCredentialsUsername}"
+                             HorizontalAlignment="Left" TextWrapping="Wrap" Width="300" Margin="0, 5, 0, 0"/>
+
+                <TextBlock x:Name="WebProxyNetworkCredentialsPasswordLabel" Text="Password:"
+                           HorizontalAlignment="Left" Margin="0, 10, 0, 0"/>
+                <TextBox x:Name="WebProxyNetworkCredentialsPassword" Text="{Binding WebProxyNetworkCredentialsPassword}"
+                             HorizontalAlignment="Left" TextWrapping="Wrap" Width="300" Margin="0, 5, 0, 0"/>
+
+                <TextBlock x:Name="WebProxyNetworkCredentialsDomainLabel" Text="Domain:"
+                           HorizontalAlignment="Left" Margin="0, 10, 0, 0"/>
+                <TextBox x:Name="WebProxyNetworkCredentialsDomain" Text="{Binding WebProxyNetworkCredentialsDomain}"
+                             HorizontalAlignment="Left" TextWrapping="Wrap" Width="300" Margin="0, 5, 0, 0"/>
+
+            </StackPanel>
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/test/ODataConnectedService.Tests/CodeGeneration/V4CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/V4CodeGenDescriptorTest.cs
@@ -116,7 +116,6 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
         [TestMethod]
         public void Test_GeneratesAndSavesCodeFileWithProxy()
         {
-            // @todo add mock Httpcreator and work with it to create the files
 
             var serviceName = "MyService";
             ServiceConfiguration serviceConfig = new ServiceConfigurationV4()

--- a/test/ODataConnectedService.Tests/CodeGeneration/V4CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/V4CodeGenDescriptorTest.cs
@@ -11,6 +11,9 @@ using Microsoft.OData.ConnectedService.Models;
 using Microsoft.OData.ConnectedService.Templates;
 using Microsoft.OData.ConnectedService.Tests.TestHelpers;
 using System.Collections.Generic;
+using System.Net;
+using ODataConnectedService.Tests;
+using System.Text;
 
 namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
 {
@@ -110,10 +113,90 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
                     handlerHelper.AddedFileTargetFilePath);
             }
         }
-
-        static V4CodeGenDescriptor SetupCodeGenDescriptor(ServiceConfiguration serviceConfig, string serviceName, IODataT4CodeGeneratorFactory codeGenFactory, TestConnectedServiceHandlerHelper handlerHelper, ODataT4CodeGenerator.LanguageOption targetLanguage = ODataT4CodeGenerator.LanguageOption.CSharp)
+        [TestMethod]
+        public void Test_GeneratesAndSavesCodeFileWithProxy()
         {
-            var referenceFolderPath = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName);
+            // @todo add mock Httpcreator and work with it to create the files
+
+            var serviceName = "MyService";
+            ServiceConfiguration serviceConfig = new ServiceConfigurationV4()
+            {
+                UseDataServiceCollection = false,
+                ServiceName = serviceName,
+                GeneratedFileNamePrefix = "MyFile",
+                IncludeT4File = false,
+                IncludeWebProxy = true,
+                IncludeWebProxyNetworkCredentials = true,
+                WebProxyHost = "http://example.com:80",
+                WebProxyNetworkCredentialsUsername = "user",
+                WebProxyNetworkCredentialsPassword = "pass",
+                Endpoint = "http://localhost:9000"
+            };
+
+
+            var testT4Factory = new TestODataT4NetworkCodeGeneratorFactory();
+            testT4Factory.EDMX = ODataT4CodeGeneratorTestDescriptors.Simple.Metadata;
+
+
+            var handlerHelper = new TestConnectedServiceHandlerHelper();
+
+            var codeGenDescriptor = SetupCodeGenDescriptor(serviceConfig, serviceName,
+              testT4Factory, handlerHelper);
+
+            codeGenDescriptor.AddGeneratedClientCodeAsync().Wait();
+            using (var reader = new StreamReader(handlerHelper.AddedFileInputFileName))
+            {
+                var generatedCode = reader.ReadToEnd();
+                ODataT4CodeGeneratorTestDescriptors.Simple.Verify(generatedCode, true/*isCSharp*/, false/*useDSC*/);
+
+                var requestGenerator = (TestODataT4NetworkCodeGeneratorFactory.TestHttpCreator)ODataT4CodeGenerator.CodeGenerationContext.RequestCreator;
+                var proxy = requestGenerator.mock.Object.Proxy;
+                Assert.IsNotNull(proxy);
+                Assert.IsNotNull(proxy.Credentials);
+                Assert.AreEqual(Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "MyFile.cs"),
+                    handlerHelper.AddedFileTargetFilePath);
+            }
+        }
+
+        [TestMethod]
+        public void Test_GeneratesAndSavesCodeFileWithoutProxy()
+        {
+            // @todo add mock Httpcreator and work with it to create the files
+
+            var serviceName = "MyService";
+            ServiceConfiguration serviceConfig = new ServiceConfigurationV4()
+            {
+                UseDataServiceCollection = false,
+                ServiceName = serviceName,
+                GeneratedFileNamePrefix = "MyFile",
+                IncludeT4File = false,
+                Endpoint = "http://localhost:9000"
+            };
+
+
+            var testT4Factory = new TestODataT4NetworkCodeGeneratorFactory();
+            testT4Factory.EDMX = ODataT4CodeGeneratorTestDescriptors.Simple.Metadata;
+
+            var handlerHelper = new TestConnectedServiceHandlerHelper();
+
+            var codeGenDescriptor = SetupCodeGenDescriptor(serviceConfig, serviceName,
+              testT4Factory, handlerHelper);
+
+            codeGenDescriptor.AddGeneratedClientCodeAsync().Wait();
+            using (var reader = new StreamReader(handlerHelper.AddedFileInputFileName))
+            {
+                var generatedCode = reader.ReadToEnd();
+                ODataT4CodeGeneratorTestDescriptors.Simple.Verify(generatedCode, true/*isCSharp*/, false/*useDSC*/);
+                var requestGenerator = (TestODataT4NetworkCodeGeneratorFactory.TestHttpCreator)ODataT4CodeGenerator.CodeGenerationContext.RequestCreator;
+                var proxy = requestGenerator.mock.Object.Proxy;
+                Assert.IsNull(proxy);
+                Assert.AreEqual(Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "MyFile.cs"),
+                    handlerHelper.AddedFileTargetFilePath);
+            }
+        }
+        static V4CodeGenDescriptor SetupCodeGenDescriptor(ServiceConfiguration serviceConfig, string serviceName, IODataT4CodeGeneratorFactory codeGenFactory, TestConnectedServiceHandlerHelper handlerHelper, ODataT4CodeGenerator.LanguageOption targetLanguage = ODataT4CodeGenerator.LanguageOption.CSharp)
+            {
+                var referenceFolderPath = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName);
             Directory.CreateDirectory(referenceFolderPath);
             Project project = CreateTestProject(TestProjectRootPath, targetLanguage);
             var serviceInstance = new ODataConnectedServiceInstance()
@@ -124,7 +207,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             handlerHelper.ServicesRootFolder = ServicesRootFolder;
             ConnectedServiceHandlerContext context = new TestConnectedServiceHandlerContext(serviceInstance, handlerHelper);
 
-            return new TestV4CodeGenDescriptor(MetadataUri, context, project, codeGenFactory);
+            return new TestV4CodeGenDescriptor(serviceConfig.Endpoint ?? MetadataUri, context, project, codeGenFactory);
         }
 
         static Project CreateTestProject(string projectPath, ODataT4CodeGenerator.LanguageOption targetLanguage = ODataT4CodeGenerator.LanguageOption.CSharp)
@@ -154,7 +237,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
         }
     }
 
-    class TestV4CodeGenDescriptor: V4CodeGenDescriptor
+    class TestV4CodeGenDescriptor : V4CodeGenDescriptor
     {
         public TestV4CodeGenDescriptor(string metadataUri, ConnectedServiceHandlerContext context, Project project, IODataT4CodeGeneratorFactory codeGenFactory)
             : base(metadataUri, context, project, codeGenFactory)
@@ -163,12 +246,16 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
         protected override void Init() { }
     }
 
-    class TestODataT4CodeGenerator: ODataT4CodeGenerator
+    class TestODataT4CodeGenerator : ODataT4CodeGenerator
     {
         public override string TransformText()
         {
             return "Generated code";
         }
+    }
+    class TestODataT4CodeGeneratorUsingProxy : ODataT4CodeGenerator
+    {
+
     }
 
     class TestODataT4CodeGeneratorFactory : IODataT4CodeGeneratorFactory
@@ -179,6 +266,63 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             var generator = new TestODataT4CodeGenerator();
             LastCreatedInstance = generator;
             return generator;
+        }
+    }
+
+    internal class TestODataT4NetworkCodeGeneratorFactory : IODataT4CodeGeneratorFactory
+    {
+        public ODataT4CodeGenerator LastCreatedInstance { get; private set; }
+
+        public int MyProperty { get; set; }
+
+        public string EDMX { get; set; }
+        public ODataT4CodeGenerator Create()
+        {
+            var generator = new TestODataT4CodeGeneratorUsingProxy();
+            LastCreatedInstance = generator;
+            ODataT4CodeGenerator.CodeGenerationContext.RequestCreator = new TestHttpCreator(EDMX);
+
+            return generator;
+        }
+
+        public class TestHttpCreator : ODataT4CodeGenerator.IHttpRequestCreator
+        {
+            internal Mock<HttpWebRequest> mock;
+            private WebResponse response;
+
+            public TestHttpCreator(string edmx)
+            {
+
+                var edmxStream = new MemoryStream(Encoding.ASCII.GetBytes(edmx));
+                response = new TestWebResponse(edmxStream);
+                this.mock = new Mock<HttpWebRequest>();
+                mock.Setup(inst => inst.GetResponse()).Returns(response);
+                mock.SetupProperty(inst => inst.Proxy);
+
+
+
+            }
+
+            public HttpWebRequest Create(System.Uri metadataUri)
+            {
+                return this.mock.Object;
+            }
+
+
+        }
+        private class TestWebResponse : WebResponse
+        {
+            private readonly Stream stream;
+
+            public TestWebResponse(Stream stream)
+            {
+
+                this.stream = stream;
+            }
+            public override Stream GetResponseStream()
+            {
+                return stream;
+            }
         }
     }
 }

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTestDescriptors.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTestDescriptors.cs
@@ -37,7 +37,7 @@ namespace ODataConnectedService.Tests
             /// <summary>
             /// Gets or Sets the func for getting the referenced model's stream.
             /// </summary>
-            public Func<Uri,WebProxy,IList<string>, XmlReader> GetReferencedModelReaderFunc { get; set; }
+            public Func<Uri, WebProxy, IList<string>, XmlReader> GetReferencedModelReaderFunc { get; set; }
 
             /// <summary>
             /// Dictionary of expected CSharp/VB code generation results.

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTestDescriptors.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTestDescriptors.cs
@@ -15,7 +15,7 @@ using System.Reflection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Validation;
-
+using System.Net;
 
 namespace ODataConnectedService.Tests
 {
@@ -37,7 +37,7 @@ namespace ODataConnectedService.Tests
             /// <summary>
             /// Gets or Sets the func for getting the referenced model's stream.
             /// </summary>
-            public Func<Uri, XmlReader> GetReferencedModelReaderFunc { get; set; }
+            public Func<Uri,WebProxy,IList<string>, XmlReader> GetReferencedModelReaderFunc { get; set; }
 
             /// <summary>
             /// Dictionary of expected CSharp/VB code generation results.
@@ -397,7 +397,7 @@ namespace ODataConnectedService.Tests
         public static ODataT4CodeGeneratorTestsDescriptor NamespaceInKeywordsWithRefModel = new ODataT4CodeGeneratorTestsDescriptor()
         {
             Metadata = EdmxNamespaceInKeywordsWithRefModel,
-            GetReferencedModelReaderFunc = url => XmlReader.Create(new MemoryStream(Encoding.UTF8.GetBytes(EdmxNamespaceInKeywordsWithRefModelReferencedEdmx))),
+            GetReferencedModelReaderFunc = (url,proxy,headers) => XmlReader.Create(new MemoryStream(Encoding.UTF8.GetBytes(EdmxNamespaceInKeywordsWithRefModelReferencedEdmx))),
             ExpectedResults = new Dictionary<string, string>() 
             { 
                 { ExpectedCSharp, NamespaceInKeywordsWithRefModelCSharp }, 
@@ -427,7 +427,7 @@ namespace ODataConnectedService.Tests
         public static ODataT4CodeGeneratorTestsDescriptor MultiReferenceModel = new ODataT4CodeGeneratorTestsDescriptor()
         {
             Metadata = EdmxWithMultiReferenceModel,
-            GetReferencedModelReaderFunc = url =>
+            GetReferencedModelReaderFunc = (url,proxy,headers) =>
             {
                 string text;
                 string urlStr = url.OriginalString;

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
@@ -26,7 +26,8 @@ namespace ODataConnectedService.Tests
     using Microsoft.OData.ConnectedService.Templates;
     using Microsoft.OData.Client;
     using Microsoft.OData.ConnectedService.Tests.Templates;
-
+    using System.Collections.Generic;
+    using System.Net;
     [TestClass]
     public class ODataT4CodeGeneratorTests
     {
@@ -443,7 +444,8 @@ namespace ODataConnectedService.Tests
             ODataT4CodeGeneratorTestDescriptors.ValidateEdmx(TempFilePath);
         }
 
-        private static string CodeGenWithT4Template(string edmx, string namespacePrefix, bool isCSharp, bool useDataServiceCollection, bool enableNamingAlias = false, bool ignoreUnexpectedElementsAndAttributes = false, Func<Uri, XmlReader> getReferencedModelReaderFunc = null, bool appendDSCSuffix = false, string TempFilePath = null, bool generateMultipleFiles = false)
+        private static string CodeGenWithT4Template(string edmx, string namespacePrefix, bool isCSharp, bool useDataServiceCollection, bool enableNamingAlias = false, bool ignoreUnexpectedElementsAndAttributes = false, Func<Uri,WebProxy, IList<string>, XmlReader> getReferencedModelReaderFunc = null, bool appendDSCSuffix = false, string TempFilePath = null, bool generateMultipleFiles = false)
+
         {
             if (useDataServiceCollection
                 && appendDSCSuffix) // hack now


### PR DESCRIPTION
Testing with HTTP locally
1. Start a HTTP odata webapi process
2. Install https://mitmproxy.org/
3. Run mitmproxy  
4. Start odata OCS in another vs instance and enter the proxy settings. You can change them on the mitmproxy ui which is installed by default on windows
5. Try to generate code.

For https follow the same and allow insecure certs or install the mitmproxy chain to your computer. 
Steps can get more complicated due to certificate pinning in windows