### PR TITLE
Remove Microsoft WCF ToolKit dependency

### DIFF
--- a/src/CodeGeneration/BaseCodeGenDescriptor.cs
+++ b/src/CodeGeneration/BaseCodeGenDescriptor.cs
@@ -57,8 +57,8 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             this.PackageInstaller = componentModel.GetService<IVsPackageInstaller>();
         }
 
-        public abstract Task AddNugetPackages();
-        public abstract Task AddGeneratedClientCode();
+        public abstract Task AddNugetPackagesAsync();
+        public abstract Task AddGeneratedClientCodeAsync();
 
         protected string GetReferenceFileFolder()
         {

--- a/src/CodeGeneration/BaseCodeGenDescriptor.cs
+++ b/src/CodeGeneration/BaseCodeGenDescriptor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using EnvDTE;
@@ -70,6 +71,28 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 this.Context.ServiceInstance.Name);
 
             return referenceFolderPath;
+        }
+
+        internal async Task CheckAndInstallNuGetPackageAsync(string packageSource, string nugetPackage)
+        {
+            try
+            {
+                if (!PackageInstallerServices.IsPackageInstalled(this.Project, nugetPackage))
+                {
+                    Version packageVersion = null;
+                    PackageInstaller.InstallPackage(packageSource, this.Project, nugetPackage, packageVersion, false);
+
+                    await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, $"Nuget Package \"{nugetPackage}\" for OData client was added.");
+                }
+                else
+                {
+                    await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, $"Nuget Package \"{nugetPackage}\" for OData client already installed.");
+                }
+            }
+            catch (Exception ex)
+            {
+                await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Error, $"Nuget Package \"{nugetPackage}\" for OData client not installed. Error: {ex.Message}.");
+            }
         }
     }
 }

--- a/src/CodeGeneration/V3CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V3CodeGenDescriptor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             this.ClientDocUri = Common.Constants.V3DocUri;
         }
 
-        public async override Task AddNugetPackages()
+        public async override Task AddNugetPackagesAsync()
         {
             await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Adding Nuget Packages");
 
@@ -53,7 +53,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             }
         }
 
-        public async override Task AddGeneratedClientCode()
+        public async override Task AddGeneratedClientCodeAsync()
         {
             await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Generating Client Proxy ...");
 

--- a/src/CodeGeneration/V3CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V3CodeGenDescriptor.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
-using System;
 using System.Data.Services.Design;
 using System.IO;
 using System.Linq;
 using System.Security;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 using EnvDTE;
-using Microsoft.OData.ConnectedService.Common;
 using Microsoft.VisualStudio.ConnectedServices;
 
 namespace Microsoft.OData.ConnectedService.CodeGeneration
@@ -26,31 +23,13 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
 
         public async override Task AddNugetPackagesAsync()
         {
-            await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Adding Nuget Packages");
+            await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Adding Nuget Packages...");
 
-            var wcfDSInstallLocation = CodeGeneratorUtils.GetWCFDSInstallLocation();
-            var packageSource = Path.Combine(wcfDSInstallLocation, @"bin\NuGet");
-            if (Directory.Exists(packageSource))
-            {
-                var files = Directory.EnumerateFiles(packageSource, "*.nupkg").ToList();
-                foreach (var nugetPackage in Common.Constants.V3NuGetPackages)
-                {
-                    if (!files.Any(f => Regex.IsMatch(f, nugetPackage + @"(.\d){2,4}.nupkg")))
-                    {
-                        packageSource = Common.Constants.NuGetOnlineRepository;
-                    }
-                }
-            }
-            else
-            {
-                packageSource = Common.Constants.NuGetOnlineRepository;
-            }
+            foreach (var nugetPackage in Common.Constants.V3NuGetPackages)
+                await CheckAndInstallNuGetPackageAsync(Common.Constants.NuGetOnlineRepository, nugetPackage);
 
-            if (!PackageInstallerServices.IsPackageInstalled(this.Project, this.ClientNuGetPackageName))
-            {
-                Version packageVersion = null;
-                PackageInstaller.InstallPackage(Common.Constants.NuGetOnlineRepository, this.Project, this.ClientNuGetPackageName, packageVersion, false);
-            }
+            await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Nuget Packages were installed.");
+
         }
 
         public async override Task AddGeneratedClientCodeAsync()

--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
-using System;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -30,13 +29,12 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
 
         public override async Task AddNugetPackagesAsync()
         {
-            await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Adding Nuget Packages");
+            await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Adding Nuget Packages...");
 
-            if (!PackageInstallerServices.IsPackageInstalled(this.Project, this.ClientNuGetPackageName))
-            {
-                Version packageVersion = null;
-                PackageInstaller.InstallPackage(Common.Constants.NuGetOnlineRepository, this.Project, this.ClientNuGetPackageName, packageVersion, false);
-            }
+            foreach (var nugetPackage in Common.Constants.V4NuGetPackages)
+                await CheckAndInstallNuGetPackageAsync(Common.Constants.NuGetOnlineRepository, nugetPackage);
+
+            await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Nuget Packages were installed.");
         }
 
         public override async Task AddGeneratedClientCodeAsync()

--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -27,8 +27,8 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
         private IODataT4CodeGeneratorFactory CodeGeneratorFactory { get; set; }
 
         private new ServiceConfigurationV4 ServiceConfiguration { get; set; }
-        
-        public override async Task AddNugetPackages()
+
+        public override async Task AddNugetPackagesAsync()
         {
             await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Adding Nuget Packages");
 
@@ -39,21 +39,21 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             }
         }
 
-        public override async Task AddGeneratedClientCode()
+        public override async Task AddGeneratedClientCodeAsync()
         {
             await this.Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Generating Client Proxy ...");
 
             if (this.ServiceConfiguration.IncludeT4File)
             {
-                await AddT4File();
+                await AddT4FileAsync();
             }
             else
             {
-                await AddGeneratedCSharpCode();
+                await AddGeneratedCSharpCodeAsync();
             }
         }
 
-        private async Task AddT4File()
+        private async Task AddT4FileAsync()
         {
             string tempFile = Path.GetTempFileName();
             string t4Folder = Path.Combine(this.CurrentAssemblyPath, "Templates");
@@ -75,11 +75,11 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             }
 
             string referenceFolder = GetReferenceFileFolder();
-            await this.Context.HandlerHelper.AddFileAsync(Path.Combine(t4Folder, "ODataT4CodeGenerator.ttinclude"), Path.Combine(referenceFolder, this.GeneratedFileNamePrefix + ".ttinclude"));            
+            await this.Context.HandlerHelper.AddFileAsync(Path.Combine(t4Folder, "ODataT4CodeGenerator.ttinclude"), Path.Combine(referenceFolder, this.GeneratedFileNamePrefix + ".ttinclude"));
             await this.Context.HandlerHelper.AddFileAsync(tempFile, Path.Combine(referenceFolder, this.GeneratedFileNamePrefix + ".tt"));
         }
 
-        private async Task AddGeneratedCSharpCode()
+        private async Task AddGeneratedCSharpCodeAsync()
         {
             ODataT4CodeGenerator t4CodeGenerator = CodeGeneratorFactory.Create();
             t4CodeGenerator.MetadataDocumentUri = MetadataUri;

--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -46,6 +46,14 @@ namespace Microsoft.OData.ConnectedService.Common
             V3SpatialNuGetPackage
         };
 
+        public static string[] V4NuGetPackages = new string[]
+        {
+            V4ClientNuGetPackage,
+            V4ODataNuGetPackage,
+            V4EdmNuGetPackage,
+            V4SpatialNuGetPackage
+        };
+
         private static Dictionary<string, Version> supportedEdmxNamespaces = new Dictionary<string, Version>
         {
             { EdmxVersion1Namespace, EdmxVersion1},

--- a/src/ODataConnectedServiceHandler.cs
+++ b/src/ODataConnectedServiceHandler.cs
@@ -45,16 +45,16 @@ namespace Microsoft.OData.ConnectedService
             Project project = ProjectHelper.GetProjectFromHierarchy(context.ProjectHierarchy);
             ODataConnectedServiceInstance serviceInstance = (ODataConnectedServiceInstance)context.ServiceInstance;
 
-            var codeGenDescriptor = await GenerateCode(serviceInstance.ServiceConfig.Endpoint, serviceInstance.ServiceConfig.EdmxVersion, context, project);
+            var codeGenDescriptor = await GenerateCodeAsync(serviceInstance.ServiceConfig.Endpoint, serviceInstance.ServiceConfig.EdmxVersion, context, project);
             context.SetExtendedDesignerData<ServiceConfiguration>(serviceInstance.ServiceConfig);
             return codeGenDescriptor;
         }
 
-        private async Task<BaseCodeGenDescriptor> GenerateCode(string metadataUri, Version edmxVersion, ConnectedServiceHandlerContext context, Project project)
+        private async Task<BaseCodeGenDescriptor> GenerateCodeAsync(string metadataUri, Version edmxVersion, ConnectedServiceHandlerContext context, Project project)
         {
             BaseCodeGenDescriptor codeGenDescriptor = codeGenDescriptorFactory.Create(edmxVersion, metadataUri, context, project);
-            await codeGenDescriptor.AddNugetPackages();
-            await codeGenDescriptor.AddGeneratedClientCode();
+            await codeGenDescriptor.AddNugetPackagesAsync();
+            await codeGenDescriptor.AddGeneratedClientCodeAsync();
             return codeGenDescriptor;
         }
     }

--- a/test/ODataConnectedService.Tests/CodeGeneration/V4CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/V4CodeGenDescriptorTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
                 IncludeT4File = false
             };
             var codeGenDescriptor = SetupCodeGenDescriptor(serviceConfig, "TestService", codeGenFactory, handlerHelper);
-            codeGenDescriptor.AddGeneratedClientCode().Wait();
+            codeGenDescriptor.AddGeneratedClientCodeAsync().Wait();
 
             var generator = codeGenFactory.LastCreatedInstance;
             Assert.AreEqual(useDSC, generator.UseDataServiceCollection);
@@ -77,7 +77,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             var handlerHelper = new TestConnectedServiceHandlerHelper();
             var codeGenDescriptor = SetupCodeGenDescriptor(serviceConfig, serviceName,
                 new TestODataT4CodeGeneratorFactory(), handlerHelper);
-            codeGenDescriptor.AddGeneratedClientCode().Wait();
+            codeGenDescriptor.AddGeneratedClientCodeAsync().Wait();
             using (var reader = new StreamReader(handlerHelper.AddedFileInputFileName))
             {
                 var generatedCode = reader.ReadToEnd();

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceHandlerTest.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceHandlerTest.cs
@@ -98,13 +98,13 @@ namespace Microsoft.OData.ConnectedService.Tests
         public bool AddedNugetPackages { get; private set; }
 
         protected override void Init() { }
-        public override Task AddGeneratedClientCode()
+        public override Task AddGeneratedClientCodeAsync()
         {
             AddedClientCode = true;
             return Task.CompletedTask;
         }
 
-        public override Task AddNugetPackages()
+        public override Task AddNugetPackagesAsync()
         {
             AddedNugetPackages = true;
             return Task.CompletedTask;


### PR DESCRIPTION
1) Add `Async` suffix to async methods;
2) Remove [Microsoft WCF ToolKit](https://download.microsoft.com/download/1/C/A/1CAA41C7-88B9-42D6-9E11-3C655656DAB1/WcfDataServices.exe) dependency: no need to install it to generate client code for **OData v3**.
