### PR TITLE
version bump to target probable next release

### DIFF
--- a/src/ODataConnectedServiceProvider.cs
+++ b/src/ODataConnectedServiceProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.ConnectedService
             Description = "OData Connected Service for V1-V4";
             Icon = new BitmapImage(new Uri("pack://application:,,/" + this.GetType().Assembly.ToString() + ";component/Resources/Icon.png"));
             CreatedBy = "OData";
-            Version = new Version(0, 5, 0);
+            Version = new Version(0, 5, 1);
             MoreInfoUri = new Uri("https://github.com/odata/ODataConnectedService");
         }
 

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.5.0" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.5.1" Language="en-US" Publisher="Microsoft" />
         <Author>Microsoft</Author>
         <DisplayName>OData Connected Service</DisplayName>
         <Description xml:space="preserve">OData Connected Service for V1-V4</Description>


### PR DESCRIPTION
Now that 0.5.0 is out this bumps the version up so that the release from master has a new version number.