### PR TITLE
Make temp file metadata default

### DIFF
--- a/src/CodeGeneration/BaseCodeGenDescriptor.cs
+++ b/src/CodeGeneration/BaseCodeGenDescriptor.cs
@@ -73,16 +73,6 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             return referenceFolderPath;
         }
 
-        protected string GetEdmxFileFolder()
-        {
-            var serviceReferenceFolderName = this.Context.HandlerHelper.GetServiceArtifactsRootFolder();
-
-            var referenceFolderPath = Path.Combine(
-                ProjectHelper.GetProjectFullPath(this.Project));
-
-            return referenceFolderPath;
-        }
-
         internal async Task CheckAndInstallNuGetPackageAsync(string packageSource, string nugetPackage)
         {
             try

--- a/src/CodeGeneration/BaseCodeGenDescriptor.cs
+++ b/src/CodeGeneration/BaseCodeGenDescriptor.cs
@@ -73,6 +73,16 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             return referenceFolderPath;
         }
 
+        protected string GetEdmxFileFolder()
+        {
+            var serviceReferenceFolderName = this.Context.HandlerHelper.GetServiceArtifactsRootFolder();
+
+            var referenceFolderPath = Path.Combine(
+                ProjectHelper.GetProjectFullPath(this.Project));
+
+            return referenceFolderPath;
+        }
+
         internal async Task CheckAndInstallNuGetPackageAsync(string packageSource, string nugetPackage)
         {
             try

--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -73,7 +73,12 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 text = Regex.Replace(text, "(public const bool EnableNamingAlias = )true;", "$1" + this.ServiceConfiguration.EnableNamingAlias.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 text = Regex.Replace(text, "(public const bool IgnoreUnexpectedElementsAndAttributes = )true;", "$1" + this.ServiceConfiguration.IgnoreUnexpectedElementsAndAttributes.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 text = Regex.Replace(text, "(public const bool MakeTypesInternal = )false;", "$1" + ServiceConfiguration.MakeTypesInternal.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
-                text = Regex.Replace(text, "(public const string CustomHttpHeaders = )\"\";", "$1@\"" + ServiceConfiguration.CustomHttpHeaders ?? string.Empty + "\";");
+                string customHeaders = "";
+                if(ServiceConfiguration.CustomHttpHeaders != null)
+                {
+                    customHeaders = ServiceConfiguration.CustomHttpHeaders;
+                }
+                text = Regex.Replace(text, "(public const string CustomHttpHeaders = )\"\";", "$1@\"" + customHeaders + "\";");
                 text = Regex.Replace(text, "(public const string TempFilePath = )\"\";", "$1\"" + CsdlFileName + "\";");
                 await writer.WriteAsync(text);
                 await writer.FlushAsync();
@@ -114,7 +119,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             const string CsdlFileName = "Csdl.xml";
             string tempMetadataFile = Path.Combine(GetReferenceFileFolder(), CsdlFileName);
             await this.Context.HandlerHelper.AddFileAsync(tempFile, tempMetadataFile);
-            t4CodeGenerator.TempFilePath = tempMetadataFile;
+            t4CodeGenerator.TempFilePath = CsdlFileName;
 
             using (StreamWriter writer = File.CreateText(tempFile))
             {

--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -106,10 +106,11 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 }
             }
             t4CodeGenerator.CustomHttpHeaders = headers;
-            string tempMetadataFile = Path.Combine(GetEdmxFileFolder(), "Edmx" + ".xml");
-            t4CodeGenerator.TempFilePath = tempMetadataFile;
-
             string tempFile = Path.GetTempFileName();
+            const string CsdlFileName = "Csdl.xml";
+            string tempMetadataFile = Path.Combine(GetReferenceFileFolder(), CsdlFileName);
+            await this.Context.HandlerHelper.AddFileAsync(tempFile, tempMetadataFile);
+            t4CodeGenerator.TempFilePath = tempMetadataFile;
 
             using (StreamWriter writer = File.CreateText(tempFile))
             {

--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -59,6 +59,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
         {
             string tempFile = Path.GetTempFileName();
             string t4Folder = Path.Combine(this.CurrentAssemblyPath, "Templates");
+            const string CsdlFileName = "Csdl.xml";
 
             using (StreamWriter writer = File.CreateText(tempFile))
             {
@@ -73,11 +74,14 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 text = Regex.Replace(text, "(public const bool IgnoreUnexpectedElementsAndAttributes = )true;", "$1" + this.ServiceConfiguration.IgnoreUnexpectedElementsAndAttributes.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 text = Regex.Replace(text, "(public const bool MakeTypesInternal = )false;", "$1" + ServiceConfiguration.MakeTypesInternal.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 text = Regex.Replace(text, "(public const string CustomHttpHeaders = )\"\";", "$1@\"" + ServiceConfiguration.CustomHttpHeaders ?? string.Empty + "\";");
+                text = Regex.Replace(text, "(public const string TempFilePath = )\"\";", "$1\"" + CsdlFileName + "\";");
                 await writer.WriteAsync(text);
                 await writer.FlushAsync();
             }
 
             string referenceFolder = GetReferenceFileFolder();
+            string tempMetadataFile = Path.Combine(referenceFolder, CsdlFileName);
+            await this.Context.HandlerHelper.AddFileAsync(tempFile, tempMetadataFile);
             await this.Context.HandlerHelper.AddFileAsync(Path.Combine(t4Folder, "ODataT4CodeGenerator.ttinclude"), Path.Combine(referenceFolder, this.GeneratedFileNamePrefix + ".ttinclude"));
             await this.Context.HandlerHelper.AddFileAsync(Path.Combine(t4Folder, "ODataT4CodeGenFilesManager.ttinclude"), Path.Combine(referenceFolder, "ODataT4CodeGenFilesManager.ttinclude"));
             await this.Context.HandlerHelper.AddFileAsync(tempFile, Path.Combine(referenceFolder, this.GeneratedFileNamePrefix + ".tt"));

--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -106,6 +106,8 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 }
             }
             t4CodeGenerator.CustomHttpHeaders = headers;
+            string tempMetadataFile = Path.Combine(GetEdmxFileFolder(), "Edmx" + ".xml");
+            t4CodeGenerator.TempFilePath = tempMetadataFile;
 
             string tempFile = Path.GetTempFileName();
 


### PR DESCRIPTION
We usually store the metadata in a string variable. We have the option of specifying a temp metadata file path where we store the metadata in an xml file. 
This PR makes the temp metadata file the default practice.