### PR TITLE
Add support for loading configs from a config file

### DIFF
--- a/src/Common/ExtensionsHelper.cs
+++ b/src/Common/ExtensionsHelper.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.OData.ConnectedService.Models;
+
+namespace Microsoft.OData.ConnectedService.Common
+{
+    #region For update from Microsoft OData Connected Service
+    internal class ConnectedServiceJsonFileData
+    {
+        public string ProviderId { get; set; }
+
+        public UserSettings ExtendedData { get; set; }
+    }
+    #endregion
+}

--- a/src/Models/ServiceConfiguration.cs
+++ b/src/Models/ServiceConfiguration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OData.ConnectedService.Models
         public string Endpoint { get; set; }
         public Version EdmxVersion { get; set; }
         public string GeneratedFileNamePrefix { get; set; }
-        public bool UseNameSpacePrefix { get; set; }
+        public bool UseNamespacePrefix { get; set; }
         public string NamespacePrefix { get; set; }
         public bool UseDataServiceCollection { get; set; }
         public bool MakeTypesInternal { get; set; }

--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -20,6 +20,66 @@ namespace Microsoft.OData.ConnectedService.Models
         [DataMember]
         public ObservableCollection<string> MruEndpoints { get; private set; }
 
+        [DataMember]
+        public string ServiceName { get; set; }
+
+        [DataMember]
+        public string Endpoint { get; set; }
+
+        [DataMember]
+        public string GeneratedFileNamePrefix { get; set; }
+
+        [DataMember]
+        public bool UseNamespacePrefix { get; set; }
+
+        [DataMember]
+        public string NamespacePrefix { get; set; }
+
+        [DataMember]
+        public bool UseDataServiceCollection { get; set; }
+
+        [DataMember]
+        public bool MakeTypesInternal { get; set; }
+
+        [DataMember]
+        public bool OpenGeneratedFilesInIDE { get; set; }
+
+        [DataMember]
+        public bool GenerateMultipleFiles { get; set; }
+
+        [DataMember]
+        public string CustomHttpHeaders { get; set; }
+
+        [DataMember]
+        public bool EnableNamingAlias { get; set; }
+
+        [DataMember]
+        public bool IgnoreUnexpectedElementsAndAttributes { get; set; }
+
+        [DataMember]
+        public bool IncludeT4File { get; set; }
+
+        [DataMember]
+        public bool IncludeWebProxy { get; set; }
+
+        [DataMember]
+        public string WebProxyHost { get; set; }
+
+        [DataMember]
+        public bool IncludeWebProxyNetworkCredentials { get; set; }
+
+        [DataMember]
+        public string WebProxyNetworkCredentialsUsername { get; set; }
+
+        [DataMember]
+        public string WebProxyNetworkCredentialsPassword { get; set; }
+
+        [DataMember]
+        public string WebProxyNetworkCredentialsDomain { get; set; }
+
+        [DataMember]
+        public bool IncludeCustomHeaders { get; set; }
+
         public UserSettings()
         {
             this.MruEndpoints = new ObservableCollection<string>();

--- a/src/ODataConnectedService.csproj
+++ b/src/ODataConnectedService.csproj
@@ -143,6 +143,10 @@
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\RepoConnectedService\ODataConnectedService\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NuGet.VisualStudio, Version=4.0.0.2323, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\NuGet.VisualStudio.4.0.0\lib\net45\NuGet.VisualStudio.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
@@ -170,6 +174,7 @@
     <Compile Include="CodeGeneration\V4CodeGenDescriptor.cs" />
     <Compile Include="Common\Constants.cs" />
     <Compile Include="Common\EdmHelper.cs" />
+    <Compile Include="Common\ExtensionsHelper.cs" />
     <Compile Include="Common\ProjectHelper.cs" />
     <Compile Include="Common\UserSettingsPersistenceHelper.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OData.ConnectedService
             this.Context = context;
             this.UserSettings = UserSettings.Load(context.Logger);
 
-            ConfigODataEndpointViewModel = new ConfigODataEndpointViewModel(this.UserSettings);
+            ConfigODataEndpointViewModel = new ConfigODataEndpointViewModel(this.UserSettings, this);
             AdvancedSettingsViewModel = new AdvancedSettingsViewModel(this.UserSettings);
             OperationImportsViewModel = new OperationImportsViewModel();
 
@@ -56,7 +56,7 @@ namespace Microsoft.OData.ConnectedService
 
 
                 // The ViewModel should always be filled otherwise if the wizard is completed without visiting this page the generated code becomes wrong
-                AdvancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNameSpacePrefix;
+                AdvancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNamespacePrefix;
                 AdvancedSettingsViewModel.NamespacePrefix = serviceConfig.NamespacePrefix;
                 AdvancedSettingsViewModel.UseDataServiceCollection = serviceConfig.UseDataServiceCollection;
 
@@ -78,6 +78,7 @@ namespace Microsoft.OData.ConnectedService
                     {
                         var configOdataView = configOdataViewModel.View as ConfigODataEndpoint;
                         configOdataView.Endpoint.IsEnabled = false;
+                        configOdataView.OpenConnectedServiceJsonFileButton.IsEnabled = false;
                         configOdataView.OpenEndpointFileButton.IsEnabled = !serviceConfig.Endpoint.StartsWith("http");
                         configOdataView.ServiceName.IsEnabled = false;
                         configOdataViewModel.IncludeCustomHeaders = serviceConfig.IncludeCustomHeaders;
@@ -101,9 +102,9 @@ namespace Microsoft.OData.ConnectedService
                     {
                         if (advancedSettingsViewModel.View is AdvancedSettings advancedSettings)
                         {
-                            advancedSettingsViewModel.GeneratedFileName = serviceConfig.GeneratedFileNamePrefix;
+                            advancedSettingsViewModel.GeneratedFileNamePrefix = serviceConfig.GeneratedFileNamePrefix;
                             advancedSettings.ReferenceFileName.IsEnabled = false;
-                            advancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNameSpacePrefix;
+                            advancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNamespacePrefix;
                             advancedSettingsViewModel.NamespacePrefix = serviceConfig.NamespacePrefix;
                             advancedSettingsViewModel.UseDataServiceCollection = serviceConfig.UseDataServiceCollection;
                             advancedSettingsViewModel.GenerateMultipleFiles = serviceConfig.GenerateMultipleFiles;
@@ -131,8 +132,7 @@ namespace Microsoft.OData.ConnectedService
         public override Task<ConnectedServiceInstance> GetFinishedServiceInstanceAsync()
         {
             this.UserSettings.Save();
-
-            this.ServiceInstance.InstanceId = AdvancedSettingsViewModel.GeneratedFileName;
+            this.ServiceInstance.InstanceId = AdvancedSettingsViewModel.GeneratedFileNamePrefix;
             this.ServiceInstance.Name = ConfigODataEndpointViewModel.ServiceName;
             this.ServiceInstance.MetadataTempFilePath = ConfigODataEndpointViewModel.MetadataTempPath;
             this.ServiceInstance.ServiceConfig = this.CreateServiceConfiguration();
@@ -161,7 +161,7 @@ namespace Microsoft.OData.ConnectedService
             {
                 serviceConfiguration = new ServiceConfiguration();
             }
-
+            
             serviceConfiguration.ServiceName = ConfigODataEndpointViewModel.ServiceName;
             serviceConfiguration.Endpoint = ConfigODataEndpointViewModel.Endpoint;
             serviceConfiguration.EdmxVersion = ConfigODataEndpointViewModel.EdmxVersion;
@@ -176,8 +176,8 @@ namespace Microsoft.OData.ConnectedService
             serviceConfiguration.IncludeCustomHeaders = ConfigODataEndpointViewModel.IncludeCustomHeaders;
 
             serviceConfiguration.UseDataServiceCollection = AdvancedSettingsViewModel.UseDataServiceCollection;
-            serviceConfiguration.GeneratedFileNamePrefix = AdvancedSettingsViewModel.GeneratedFileName;
-            serviceConfiguration.UseNameSpacePrefix = AdvancedSettingsViewModel.UseNamespacePrefix;
+            serviceConfiguration.GeneratedFileNamePrefix = AdvancedSettingsViewModel.GeneratedFileNamePrefix;
+            serviceConfiguration.UseNamespacePrefix = AdvancedSettingsViewModel.UseNamespacePrefix;
             serviceConfiguration.MakeTypesInternal = AdvancedSettingsViewModel.MakeTypesInternal;
             serviceConfiguration.OpenGeneratedFilesInIDE = AdvancedSettingsViewModel.OpenGeneratedFilesInIDE;
             serviceConfiguration.GenerateMultipleFiles = AdvancedSettingsViewModel.GenerateMultipleFiles;

--- a/src/ViewModels/AdvancedSettingsViewModel.cs
+++ b/src/ViewModels/AdvancedSettingsViewModel.cs
@@ -16,21 +16,19 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         public string NamespacePrefix { get; set; }
         public bool EnableNamingAlias { get; set; }
         public bool IgnoreUnexpectedElementsAndAttributes { get; set; }
-        public string GeneratedFileName { get; set; }
+        public string GeneratedFileNamePrefix { get; set; }
         public bool IncludeT4File { get; set; }
         public bool MakeTypesInternal { get; set; }
         public bool OpenGeneratedFilesInIDE { get; set; }
-        public bool GenerateMultipleFiles { get; set; }
-
-        public UserSettings UserSettings { get; }
+        public bool GenerateMultipleFiles { get; set; }      
+        public UserSettings UserSettings { get; set; }
 
         public AdvancedSettingsViewModel(UserSettings userSettings) : base()
         {
-            this.UserSettings = userSettings;
             this.Title = "Settings";
             this.Description = "Advanced settings for generating client proxy";
             this.Legend = "Settings";
-            this.ResetDataContext();
+            this.UserSettings = userSettings;
         }
 
         public event EventHandler<EventArgs> PageEntering;
@@ -40,30 +38,29 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             await base.OnPageEnteringAsync(args);
 
             this.View = new AdvancedSettings();
-            this.ResetDataContext();
+            if (UserSettings != null)
+            {
+                this.GeneratedFileNamePrefix = UserSettings.GeneratedFileNamePrefix ?? Common.Constants.DefaultReferenceFileName;
+                this.OpenGeneratedFilesInIDE = UserSettings.OpenGeneratedFilesInIDE;
+                this.UseNamespacePrefix = UserSettings.UseNamespacePrefix;
+                this.NamespacePrefix = UserSettings.NamespacePrefix ?? Common.Constants.DefaultReferenceFileName;
+                this.UseDataServiceCollection = UserSettings.UseDataServiceCollection;
+                this.MakeTypesInternal = UserSettings.MakeTypesInternal;
+                this.IncludeT4File = UserSettings.IncludeT4File;
+                this.IgnoreUnexpectedElementsAndAttributes = UserSettings.IgnoreUnexpectedElementsAndAttributes;
+                this.EnableNamingAlias = UserSettings.EnableNamingAlias;
+                this.GenerateMultipleFiles = UserSettings.GenerateMultipleFiles;
+            }         
             this.View.DataContext = this;
-            PageEntering?.Invoke(this, EventArgs.Empty);
+            if (PageEntering != null)
+            {
+                this.PageEntering(this, EventArgs.Empty);
+            }
         }
 
         public override Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
         {
             return base.OnPageLeavingAsync(args);
         }
-
-        private void ResetDataContext()
-        {
-            this.UseNamespacePrefix = false;
-            this.NamespacePrefix = null;
-            this.UseDataServiceCollection = true;
-            this.IgnoreUnexpectedElementsAndAttributes = false;
-            this.EnableNamingAlias = false;
-            this.GeneratedFileName = Common.Constants.DefaultReferenceFileName;
-            this.IncludeT4File = false;
-            this.MakeTypesInternal = false;
-            this.OpenGeneratedFilesInIDE = false;
-            this.GenerateMultipleFiles = false;
-
-        }
-
     }
 }

--- a/src/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ViewModels/ConfigODataEndpointViewModel.cs
@@ -20,59 +20,44 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         public string ServiceName { get; set; }
         public Version EdmxVersion { get; set; }
         public string MetadataTempPath { get; set; }
-        public UserSettings UserSettings { get; }
         public string CustomHttpHeaders { get; set; }
-
-
+        public UserSettings UserSettings { get; set; }
         public bool IncludeWebProxy { get; set; }
-
         public string WebProxyHost { get; set; }
-
         public bool IncludeWebProxyNetworkCredentials { get; set; }
-
         public string WebProxyNetworkCredentialsUsername { get; set; }
         public string WebProxyNetworkCredentialsPassword { get; set; }
-
         public string WebProxyNetworkCredentialsDomain { get; set; }
-
         public bool IncludeCustomHeaders { get; set; }
-
         public event EventHandler<EventArgs> PageEntering;
-
-
-        public ConfigODataEndpointViewModel(UserSettings userSettings) : base()
+        public ODataConnectedServiceWizard ServiceWizard { get; set; }
+        public ConfigODataEndpointViewModel(UserSettings userSettings, ODataConnectedServiceWizard serviceWizard) : base()
         {
             this.Title = "Configure endpoint";
             this.Description = "Enter or choose an OData service endpoint to begin";
             this.Legend = "Endpoint";
-            this.View = new ConfigODataEndpoint();
-            this.View.DataContext = this;
-            this.ResetDataContext();
+            this.View = new ConfigODataEndpoint
+            {
+                DataContext = this
+            };
+            this.ServiceWizard = serviceWizard;
             this.UserSettings = userSettings;
+            this.ServiceName = Constants.DefaultServiceName;          
         }
-
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
             await base.OnPageEnteringAsync(args);
-
             if (PageEntering != null)
             {
                 this.PageEntering(this, EventArgs.Empty);
             }
         }
-
-        private void ResetDataContext()
-        {
-            this.ServiceName = Constants.DefaultServiceName;
-        }
-
         public event EventHandler<EventArgs> PageLeaving;
-
         public override Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
         {
+            LoadFromJsonFile();
             var wizard = this.Wizard as ODataConnectedServiceWizard;
             UserSettings.AddToTopOfMruList(wizard.UserSettings.MruEndpoints, this.Endpoint);
-
             try
             {
                 this.MetadataTempPath = GetMetadata(out var version);
@@ -181,6 +166,73 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             finally
             {
                 metadataStream?.Dispose();
+            }
+        }
+        public void LoadFromJsonFile()
+        {
+            if (this.UserSettings != null)
+            {
+                if (this.ServiceName != Constants.DefaultServiceName)
+                {
+                    UserSettings.ServiceName = this.ServiceName;
+                }
+                if (this.Endpoint != null)
+                {
+                    UserSettings.Endpoint = this.Endpoint;
+                }
+                if (this.WebProxyHost != null)
+                {
+                    UserSettings.WebProxyHost = this.WebProxyHost;
+                }
+                if (this.CustomHttpHeaders != null)
+                {
+                    UserSettings.CustomHttpHeaders = this.CustomHttpHeaders;
+                }
+                if (this.WebProxyNetworkCredentialsDomain != null)
+                {
+                    UserSettings.WebProxyNetworkCredentialsDomain = this.WebProxyNetworkCredentialsDomain;
+                }
+                if (this.WebProxyNetworkCredentialsPassword != null)
+                {
+                    UserSettings.WebProxyNetworkCredentialsPassword = this.WebProxyNetworkCredentialsPassword;
+                }
+                if (this.WebProxyNetworkCredentialsUsername != null)
+                {
+                    UserSettings.WebProxyNetworkCredentialsUsername = this.WebProxyNetworkCredentialsUsername;
+                }
+                if (this.IncludeCustomHeaders == true)
+                {
+                    UserSettings.IncludeCustomHeaders = this.IncludeCustomHeaders;
+                }
+                if (this.IncludeCustomHeaders == false && UserSettings.IncludeCustomHeaders == true)
+                {
+                    UserSettings.IncludeCustomHeaders = false;
+                }
+                if (this.IncludeWebProxy == true)
+                {
+                    UserSettings.IncludeWebProxy = true;
+                }
+                if (this.IncludeWebProxy == false && UserSettings.IncludeWebProxy == true)
+                {
+                    UserSettings.IncludeWebProxy = false;
+                }
+                if (this.IncludeWebProxyNetworkCredentials == true)
+                {
+                    UserSettings.IncludeWebProxyNetworkCredentials = true;
+                }
+                if (this.IncludeWebProxyNetworkCredentials == false && UserSettings.IncludeWebProxyNetworkCredentials == true)
+                {
+                    UserSettings.IncludeWebProxyNetworkCredentials = false;
+                }
+                this.ServiceName = UserSettings.ServiceName ?? Constants.DefaultServiceName;
+                this.Endpoint = UserSettings.Endpoint;
+                this.WebProxyHost = UserSettings.WebProxyHost;
+                this.IncludeWebProxy = UserSettings.IncludeWebProxy;
+                this.IncludeCustomHeaders = UserSettings.IncludeCustomHeaders;
+                this.IncludeWebProxyNetworkCredentials = UserSettings.IncludeWebProxyNetworkCredentials;
+                this.WebProxyNetworkCredentialsDomain = UserSettings.WebProxyNetworkCredentialsDomain;
+                this.WebProxyNetworkCredentialsPassword = UserSettings.WebProxyNetworkCredentialsPassword;
+                this.WebProxyNetworkCredentialsUsername = UserSettings.WebProxyNetworkCredentialsUsername;
             }
         }
     }

--- a/src/Views/AdvancedSettings.xaml
+++ b/src/Views/AdvancedSettings.xaml
@@ -15,7 +15,7 @@
 
             <TextBlock x:Name="ReferenceFileNameLabel" Text="Enter the file name (without extension):"
                            HorizontalAlignment="Left" Margin="0, 5, 0, 0"/>
-            <TextBox x:Name="ReferenceFileName" Text="{Binding GeneratedFileName}"
+            <TextBox x:Name="ReferenceFileName" Text="{Binding GeneratedFileNamePrefix}"
                          HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Bottom" Width="250" Margin="20, 5, 0, 0"/>
             <StackPanel x:Name="AdvancedSettingsHyperLinkPanel">
                 <TextBlock x:Name="Label" TextWrapping="WrapWithOverflow" Margin="0, 20, 40, 0">

--- a/src/Views/ConfigODataEndpoint.xaml
+++ b/src/Views/ConfigODataEndpoint.xaml
@@ -26,12 +26,29 @@
             Margin="0,5,10,5"
             HorizontalAlignment="Left"
             Text="Service name： " />
-        <TextBox
-            x:Name="ServiceName"
-            Width="250"
-            Margin="20,5,10,5"
-            HorizontalAlignment="Left"
-            Text="{Binding Path=ServiceName}" />
+        <Grid Margin="20,5,10,5" HorizontalAlignment="Stretch">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <TextBox x:Name="ServiceName" Text="{Binding Path=ServiceName}"
+                 HorizontalAlignment="Left" Margin="0, 5, 10, 5"  Width="230"  Height="20"/>
+            <Button
+                x:Name="OpenConnectedServiceJsonFileButton"
+                Grid.Column="1"
+                Width="210"
+                Height="20"
+                MinWidth="210"
+                MinHeight="20"
+                MaxWidth="210"
+                MaxHeight="20"
+                Margin="5,0,0,0"
+                HorizontalAlignment="Right"
+                HorizontalContentAlignment="Center"
+                Click="OpenConnectedServiceJsonFileButton_Click">
+                <TextBlock Text="Load ConnectedService json file" />
+            </Button>
+        </Grid>
         <TextBlock
             x:Name="EndpointLabel"
             Margin="0,5,10,5"

--- a/src/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/Views/ConfigODataEndpoint.xaml.cs
@@ -1,6 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using Microsoft.OData.ConnectedService.Common;
+using Microsoft.OData.ConnectedService.Models;
+using Microsoft.OData.ConnectedService.ViewModels;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -11,6 +17,7 @@ namespace Microsoft.OData.ConnectedService.Views
     /// </summary>
     public partial class ConfigODataEndpoint : UserControl
     {
+        internal UserSettings UserSettings { get; set; }
         public ConfigODataEndpoint()
         {
             InitializeComponent();
@@ -33,5 +40,74 @@ namespace Microsoft.OData.ConnectedService.Views
                 Endpoint.Text = openFileDialog.FileName;
             }
         }
-    }
+
+        private void OpenConnectedServiceJsonFileButton_Click(object sender, RoutedEventArgs e)
+        {
+            var openFileDialog = new Microsoft.Win32.OpenFileDialog
+            {
+                DefaultExt = ".json",
+                Filter = "JSON File (.json)|*.json",
+                Title = "Open OData Connected Service Config File"
+            };
+
+            var result = openFileDialog.ShowDialog();
+            if (result == false)
+                return;
+            if (!File.Exists(openFileDialog.FileName))
+            {
+               MessageBox.Show($"File \"{openFileDialog.FileName}\" does not exists.", "Open OData Connected Service json-file", MessageBoxButton.OK, MessageBoxImage.Warning);
+               return;
+            }
+
+            var jsonFileText = File.ReadAllText(openFileDialog.FileName);
+            if (string.IsNullOrWhiteSpace(jsonFileText))
+            {
+              MessageBox.Show("File have not content.", "Open OData Connected Service json-file", MessageBoxButton.OK, MessageBoxImage.Warning);
+               return;
+            }
+            if (JObject.Parse(jsonFileText) == null)
+            {
+               MessageBox.Show("Can't convert file content to JObject.", "Open OData Connected Service json-file", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            var microsoftConnectedServiceData = JsonConvert.DeserializeObject<ConnectedServiceJsonFileData>(jsonFileText);
+            if (microsoftConnectedServiceData != null)
+            {
+                this.UserSettings = new UserSettings();
+                this.UserSettings.Endpoint = microsoftConnectedServiceData.ExtendedData?.Endpoint ?? this.UserSettings.Endpoint;
+                this.UserSettings.ServiceName = microsoftConnectedServiceData.ExtendedData?.ServiceName ?? this.UserSettings.ServiceName;
+                this.UserSettings.GeneratedFileNamePrefix = microsoftConnectedServiceData.ExtendedData?.GeneratedFileNamePrefix ?? this.UserSettings.GeneratedFileNamePrefix;
+                this.UserSettings.OpenGeneratedFilesInIDE = microsoftConnectedServiceData.ExtendedData?.OpenGeneratedFilesInIDE ?? this.UserSettings.OpenGeneratedFilesInIDE;
+                this.UserSettings.MakeTypesInternal = microsoftConnectedServiceData.ExtendedData?.MakeTypesInternal ?? this.UserSettings.MakeTypesInternal;
+                this.UserSettings.NamespacePrefix = microsoftConnectedServiceData.ExtendedData?.NamespacePrefix ?? this.UserSettings.NamespacePrefix;
+                this.UserSettings.UseDataServiceCollection = microsoftConnectedServiceData.ExtendedData?.UseDataServiceCollection ?? this.UserSettings.UseDataServiceCollection;
+                this.UserSettings.UseNamespacePrefix = microsoftConnectedServiceData.ExtendedData?.UseNamespacePrefix ?? this.UserSettings.UseNamespacePrefix;
+                this.UserSettings.IncludeT4File = microsoftConnectedServiceData.ExtendedData?.IncludeT4File ?? this.UserSettings.IncludeT4File;
+                this.UserSettings.IgnoreUnexpectedElementsAndAttributes = microsoftConnectedServiceData.ExtendedData?.IgnoreUnexpectedElementsAndAttributes ?? this.UserSettings.IgnoreUnexpectedElementsAndAttributes;
+                this.UserSettings.GenerateMultipleFiles = microsoftConnectedServiceData.ExtendedData?.GenerateMultipleFiles ?? this.UserSettings.GenerateMultipleFiles;
+                this.UserSettings.EnableNamingAlias = microsoftConnectedServiceData.ExtendedData?.EnableNamingAlias ?? this.UserSettings.EnableNamingAlias;
+                this.UserSettings.CustomHttpHeaders = microsoftConnectedServiceData.ExtendedData?.CustomHttpHeaders ?? this.UserSettings.CustomHttpHeaders;
+                this.UserSettings.IncludeCustomHeaders = microsoftConnectedServiceData.ExtendedData?.IncludeCustomHeaders ?? this.UserSettings.IncludeCustomHeaders;
+                this.UserSettings.WebProxyHost = microsoftConnectedServiceData.ExtendedData?.WebProxyHost ?? this.UserSettings.WebProxyHost;
+                this.UserSettings.IncludeWebProxy = microsoftConnectedServiceData.ExtendedData?.IncludeWebProxy ?? this.UserSettings.IncludeWebProxy;
+                this.UserSettings.IncludeWebProxyNetworkCredentials = microsoftConnectedServiceData.ExtendedData?.IncludeWebProxyNetworkCredentials ?? this.UserSettings.IncludeWebProxyNetworkCredentials;
+                this.UserSettings.WebProxyNetworkCredentialsDomain = microsoftConnectedServiceData.ExtendedData?.WebProxyNetworkCredentialsDomain ?? this.UserSettings.WebProxyNetworkCredentialsDomain;
+                this.UserSettings.WebProxyNetworkCredentialsPassword = microsoftConnectedServiceData.ExtendedData?.WebProxyNetworkCredentialsPassword ?? this.UserSettings.WebProxyNetworkCredentialsPassword;
+                this.UserSettings.WebProxyNetworkCredentialsUsername = microsoftConnectedServiceData.ExtendedData?.WebProxyNetworkCredentialsUsername ?? this.UserSettings.WebProxyNetworkCredentialsUsername;
+                ODataConnectedServiceWizard ServiceWizard = ((ConfigODataEndpointViewModel)this.DataContext).ServiceWizard;
+                ServiceWizard.AdvancedSettingsViewModel.UserSettings = this.UserSettings;
+                ServiceWizard.ConfigODataEndpointViewModel.UserSettings = this.UserSettings;
+                this.Endpoint.Text = microsoftConnectedServiceData.ExtendedData?.Endpoint ?? this.Endpoint.Text;
+                this.ServiceName.Text = microsoftConnectedServiceData.ExtendedData?.ServiceName ?? this.ServiceName.Text;
+                this.CustomHttpHeaders.Text = microsoftConnectedServiceData.ExtendedData?.CustomHttpHeaders ?? this.CustomHttpHeaders.Text;
+                this.WebProxyHost.Text = microsoftConnectedServiceData.ExtendedData?.WebProxyHost ?? this.WebProxyHost.Text;
+                this.WebProxyNetworkCredentialsDomain.Text = microsoftConnectedServiceData.ExtendedData?.WebProxyNetworkCredentialsDomain ?? this.WebProxyNetworkCredentialsDomain.Text;
+                this.WebProxyNetworkCredentialsPassword.Text = microsoftConnectedServiceData.ExtendedData?.WebProxyNetworkCredentialsPassword ?? this.WebProxyNetworkCredentialsPassword.Text;
+                this.WebProxyNetworkCredentialsUsername.Text = microsoftConnectedServiceData.ExtendedData?.WebProxyNetworkCredentialsUsername ?? this.WebProxyNetworkCredentialsUsername.Text;
+                this.IncludeHttpHeadersElement.IsChecked = microsoftConnectedServiceData.ExtendedData?.IncludeCustomHeaders ?? this.IncludeHttpHeadersElement.IsChecked;
+                this.IncludeWebProxyElement.IsChecked = microsoftConnectedServiceData.ExtendedData?.IncludeWebProxy ?? this.IncludeWebProxyElement.IsChecked;
+                this.IncludeWebProxyNetworkCredentialsElement.IsChecked = microsoftConnectedServiceData.ExtendedData?.IncludeWebProxyNetworkCredentials ?? this.IncludeWebProxyNetworkCredentialsElement.IsChecked;
+            }
+        }
+    } 
 }

--- a/src/packages.config
+++ b/src/packages.config
@@ -22,5 +22,6 @@
   <package id="Microsoft.VisualStudio.Threading" version="15.0.240" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Utilities" version="15.0.26201" targetFramework="net45" />
   <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="NuGet.VisualStudio" version="4.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR adds support for loading ODataConnectedService wizard configs from a .json file. 

The following is a sample .json file to load 
<pre>
{
  "ExtendedData": {
    "ExcludedOperationImports": [],
    "EnableNamingAlias": false,
    "IgnoreUnexpectedElementsAndAttributes": false,
    "IncludeT4File": false,
    "ServiceName": "OData Service",
    "Endpoint": "https://services.odata.org/v4/TripPinServiceRW/$metadata",
    "GeneratedFileNamePrefix": "Test",
    "UseNamespacePrefix": true,
    "NamespacePrefix":"Test",
    "UseDataServiceCollection": true,
    "MakeTypesInternal": false,
    "OpenGeneratedFilesInIDE": true,
    "GenerateMultipleFiles":false,
    "CustomHttpHeaders": null,
    "IncludeWebProxy": false,
    "WebProxyHost": null,
    "IncludeWebProxyNetworkCredentials": false,
    "WebProxyNetworkCredentialsUsername": null,
    "WebProxyNetworkCredentialsPassword": null,
    "WebProxyNetworkCredentialsDomain": null,
    "IncludeCustomHeaders": false
  }
}
</pre>
You can as well get this file from an OData Connected Service project and fill the fields as per your requirements. 
Once you fill these fields they will always be pre-loaded whenever you create an OData Connected Service project not unless you want to update them then you can load a new .json file with new configurations. 