### PR TITLE
Custom http headers enhancements

### DIFF
--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -72,13 +72,14 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 text = Regex.Replace(text, "(public const bool EnableNamingAlias = )true;", "$1" + this.ServiceConfiguration.EnableNamingAlias.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 text = Regex.Replace(text, "(public const bool IgnoreUnexpectedElementsAndAttributes = )true;", "$1" + this.ServiceConfiguration.IgnoreUnexpectedElementsAndAttributes.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 text = Regex.Replace(text, "(public const bool MakeTypesInternal = )false;", "$1" + ServiceConfiguration.MakeTypesInternal.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
-                text = Regex.Replace(text, "(public const bool CustomHttpHeaders = )\"\";", "$1" + ServiceConfiguration.CustomHttpHeaders.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
+                text = Regex.Replace(text, "(public const string CustomHttpHeaders = )\"\";", "$1@\"" + ServiceConfiguration.CustomHttpHeaders ?? string.Empty + "\";");
                 await writer.WriteAsync(text);
                 await writer.FlushAsync();
             }
 
             string referenceFolder = GetReferenceFileFolder();
             await this.Context.HandlerHelper.AddFileAsync(Path.Combine(t4Folder, "ODataT4CodeGenerator.ttinclude"), Path.Combine(referenceFolder, this.GeneratedFileNamePrefix + ".ttinclude"));
+            await this.Context.HandlerHelper.AddFileAsync(Path.Combine(t4Folder, "ODataT4CodeGenFilesManager.ttinclude"), Path.Combine(referenceFolder, "ODataT4CodeGenFilesManager.ttinclude"));
             await this.Context.HandlerHelper.AddFileAsync(tempFile, Path.Combine(referenceFolder, this.GeneratedFileNamePrefix + ".tt"));
         }
 

--- a/src/ODataConnectedService.csproj
+++ b/src/ODataConnectedService.csproj
@@ -207,7 +207,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Content Include="Templates\ODataT4CodeGenFilesManager.ttinclude" />
+    <Content Include="Templates\ODataT4CodeGenFilesManager.ttinclude">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5">

--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -60,8 +60,6 @@ namespace Microsoft.OData.ConnectedService
                 ConfigODataEndpointViewModel.EdmxVersion = serviceConfig.EdmxVersion;
                 ConfigODataEndpointViewModel.ServiceName = serviceConfig.ServiceName;
                 ConfigODataEndpointViewModel.CustomHttpHeaders = serviceConfig.CustomHttpHeaders;
-                var configODataEndpoint = (ConfigODataEndpointViewModel.View as ConfigODataEndpoint);
-                configODataEndpoint.IsEnabled = false;
 
                 //Restore the advanced settings to UI elements.
                 AdvancedSettingsViewModel.PageEntering += (sender, args) =>

--- a/src/Views/ConfigODataEndpoint.xaml
+++ b/src/Views/ConfigODataEndpoint.xaml
@@ -38,6 +38,16 @@
             AcceptsReturn="True"
             VerticalScrollBarVisibility="Visible"
             Margin="20, 5, 10, 5"
-            Width="250"/>
+            Width="250">
+            <TextBox.ToolTip>
+                <ToolTip HorizontalAlignment="Center">
+                    <TextBlock>
+                        (Optional) We add Http Headers to our http request as a multiline string e.g <LineBreak/>
+                        HeaderKey1: HeaderValue1<LineBreak/>
+                        HeaderKey2: HeaderValue2<LineBreak/>
+                    </TextBlock>
+                </ToolTip>
+            </TextBox.ToolTip>
+        </TextBox>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
Fixes issue #49 
This PR fixes regression issues in PR #27 

*Issues fixed*
An exception was being thrown when `custom http headers` was null/empty.
We have enhanced the view by adding a text tool tip for the CustomHttpHeaders textbox
Enabled the ConfigODataEndpoint view during Connected service update