### PR TITLE
Increment version for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,29 @@ as the class it is testing, followed by the suffix `Test`.
 Example: for some class `Microsoft.OData.ConnectedService.X.Y` located in `src\X\Y.cs`,
 the test class would be `Microsoft.OData.Tests.ConnectedService.Tests.X.YTest` located in `test\X\YTest.cs`
 
-### Building Commandline 
-The project can also be build using on the commandline by relying on the provided build.cmd
+### Building Command-line 
+The project can also be build using on the command-line by relying on the provided build.cmd
 
 ### FAQ
   **Question**: The extension module is not loaded when debugging in the Visual Studio experimental instance, or it is not listed as part of the "Add Connected Service" options
-  **Workaround**: Disable signing by going to the Project Properties > Signing and disabling both "Sign the assembly" and "Delay sign only" options.
+  **Workaround**: Disable strong name verification for the main and test assemblies. You can do that using the `sn.exe` tool from
+  the Visual Studio Developer Command Prompt. First, build the solution using Visual Studio, then open the developer command
+  prompt with Adminstrator privileges and run the following commands:
+
+  For the main assembly:
+
+  ```
+  sn.exe -Vr path\to\ODataConnectedService\src\bin\Debug\Microsoft.OData.ConnectedService.dll
+  ```
+
+  For the test assembly:
+  ```
+  sn.exe -Vr path\to\ODataConnectedService\test\ODataConnectedService.Tests\bin\Debug\ODataConnectedServiceTests.dll
+  ```
+  Then restart Visual Studio.
+
+  If disabling verification is not an option, then you can disable signing by going to the Project Properties > Signing and disabling both "Sign the assembly" and "Delay sign only" options. Do this for both the main and test projects. Then open the `AssemblyInfo.cs` file
+  under the main project's properties in solution explorer and remove the public key from the `[assembly: InternalsVisibleTo("ODataConnectedService.Tests, PublicKey=...")]` attribute so that it only reads as `[assembly: InternalsVisibleTo("ODataConnectedService.Tests")]`. Remember to re-enable delay-signing and to restore the public key before commiting your changes.
   
   **Question**: In Visual Studio 2017, upon configuring the service endpoint in the OData Connected Services extension and clicking "Finish", I get an error message that says "Value cannot be null.\r\nParameter name: path1".  
   **Workaround**: Download the [Microsoft WCF ToolKit](https://download.microsoft.com/download/1/C/A/1CAA41C7-88B9-42D6-9E11-3C655656DAB1/WcfDataServices.exe) and install it. Then go to the registry and find the following key: `[HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft WCF Data Services]`. Create a duplicate of "VS 2010 Tooling" (if this doesn't exist, use "5.6" instead) named "VS 2014 Tooling". Then try again. (Special thanks to [mohsenno1](https://github.com/mohsenno1) for pointing this out.)

--- a/src/ODataConnectedServiceProvider.cs
+++ b/src/ODataConnectedServiceProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.ConnectedService
             Description = "OData Connected Service for V1-V4";
             Icon = new BitmapImage(new Uri("pack://application:,,/" + this.GetType().Assembly.ToString() + ";component/Resources/Icon.png"));
             CreatedBy = "OData";
-            Version = new Version(0, 5, 1);
+            Version = new Version(0, 6, 0);
             MoreInfoUri = new Uri("https://github.com/odata/ODataConnectedService");
         }
 

--- a/src/ODataConnectedServiceProvider.cs
+++ b/src/ODataConnectedServiceProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.ConnectedService
             Description = "OData Connected Service for V1-V4";
             Icon = new BitmapImage(new Uri("pack://application:,,/" + this.GetType().Assembly.ToString() + ";component/Resources/Icon.png"));
             CreatedBy = "OData";
-            Version = new Version(0, 6, 0);
+            Version = new Version(0, 6, 1);
             MoreInfoUri = new Uri("https://github.com/odata/ODataConnectedService");
         }
 

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -35,8 +35,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.0.0")]
-[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyVersion("0.6.0.0")]
+[assembly: AssemblyFileVersion("0.6.0.0")]
 [assembly: NeutralResourcesLanguageAttribute("en")]
 
 [assembly: InternalsVisibleTo("ODataConnectedService.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.5.1" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.6.0" Language="en-US" Publisher="Microsoft" />
         <Author>Microsoft</Author>
         <DisplayName>OData Connected Service</DisplayName>
         <Description xml:space="preserve">OData Connected Service for V1-V4</Description>

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.6.0" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.6.1" Language="en-US" Publisher="Microsoft" />
         <Author>Microsoft</Author>
         <DisplayName>OData Connected Service</DisplayName>
         <Description xml:space="preserve">OData Connected Service for V1-V4</Description>


### PR DESCRIPTION
Now that 0.6.0 has been release, let's bump the development version so that it doesn't conflict with the version in production in case we have both installed.