### PR TITLE
Fix bug: saved service name is overwritten with default when updating client

### DIFF
--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -35,8 +35,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.0.0")]
-[assembly: AssemblyFileVersion("0.7.0.0")]
+[assembly: AssemblyVersion("0.7.1.0")]
+[assembly: AssemblyFileVersion("0.7.1.0")]
 [assembly: NeutralResourcesLanguageAttribute("en")]
 
 [assembly: InternalsVisibleTo("ODataConnectedService.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ViewModels/ConfigODataEndpointViewModel.cs
@@ -45,16 +45,15 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             this.Title = "Configure endpoint";
             this.Description = "Enter or choose an OData service endpoint to begin";
             this.Legend = "Endpoint";
+            this.View = new ConfigODataEndpoint();
+            this.View.DataContext = this;
+            this.ResetDataContext();
             this.UserSettings = userSettings;
-
         }
 
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
             await base.OnPageEnteringAsync(args);
-            this.View = new ConfigODataEndpoint();
-            this.ResetDataContext();
-            this.View.DataContext = this;
 
             if (PageEntering != null)
             {

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.7.0" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.7.1" Language="en-US" Publisher="Microsoft" />
         <Author>Microsoft</Author>
         <DisplayName>OData Connected Service</DisplayName>
         <Description xml:space="preserve">OData Connected Service for V1-V4</Description>


### PR DESCRIPTION
Fixes issue #75

The cause was that the `ResetDataContext()` method, which sets the service name to the default, was being called in the page entering event (which happens after the page has been initialized with values loaded from saved data). I've moved that method to the constructor.

Also updated the version to 0.7.1 so that I can make a patch release after this is merged.