### PR TITLE
Fix issue #69: saving the wizard pages state

### DIFF
--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OData.ConnectedService.Models
         private ConnectedServiceLogger logger;
 
         [DataMember]
-        public ObservableCollection<string> MruEndpoints { get; private set; }
+        public ObservableCollection<string> MruEndpoints { get; set; }
 
         [DataMember]
         public string ServiceName { get; set; }

--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -80,6 +80,9 @@ namespace Microsoft.OData.ConnectedService.Models
         [DataMember]
         public bool IncludeCustomHeaders { get; set; }
 
+        [DataMember]
+        public List<string> ExcludedOperationImports { get; set; }
+
         public UserSettings()
         {
             this.MruEndpoints = new ObservableCollection<string>();

--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -26,101 +26,43 @@ namespace Microsoft.OData.ConnectedService
 
         public ODataConnectedServiceInstance ServiceInstance => this.serviceInstance ?? (this.serviceInstance = new ODataConnectedServiceInstance());
 
-
         public Version EdmxVersion => this.ConfigODataEndpointViewModel.EdmxVersion;
 
         public UserSettings UserSettings { get; }
+
+        private readonly ServiceConfigurationV4 _serviceConfig;
+
+        private string _processedEndpointForOperationImports;
 
         public ODataConnectedServiceWizard(ConnectedServiceProviderContext context)
         {
             this.Context = context;
             this.UserSettings = UserSettings.Load(context.Logger);
 
+            // Since ServiceConfigurationV4 is a derived type of ServiceConfiguration. So we can deserialize a ServiceConfiguration into a ServiceConfigurationV4.
+            this._serviceConfig = this.Context.GetExtendedDesignerData<ServiceConfigurationV4>();
+
             ConfigODataEndpointViewModel = new ConfigODataEndpointViewModel(this.UserSettings, this);
             AdvancedSettingsViewModel = new AdvancedSettingsViewModel(this.UserSettings);
-            OperationImportsViewModel = new OperationImportsViewModel();
+            OperationImportsViewModel = new OperationImportsViewModel(this.UserSettings);
 
-            ServiceConfigurationV4 serviceConfig = null;
-
-            OperationImportsViewModel.PageEntering += ObjectSelectionViewModel_PageEntering;
+            OperationImportsViewModel.PageEntering += OperationImportsViewModel_PageEntering;
 
             if (this.Context.IsUpdating)
             {
-                //Since ServiceConfigurationV4 is a derived type of ServiceConfiguration. So we can deserialize a ServiceConfiguration into a ServiceConfigurationV4.
-                serviceConfig = this.Context.GetExtendedDesignerData<ServiceConfigurationV4>();
-                ConfigODataEndpointViewModel.Endpoint = serviceConfig.Endpoint;
-                ConfigODataEndpointViewModel.EdmxVersion = serviceConfig.EdmxVersion;
-                ConfigODataEndpointViewModel.ServiceName = serviceConfig.ServiceName;
-                ConfigODataEndpointViewModel.CustomHttpHeaders = serviceConfig.CustomHttpHeaders;
+                ConfigODataEndpointViewModel.Endpoint = this._serviceConfig.Endpoint;
+                ConfigODataEndpointViewModel.EdmxVersion = this._serviceConfig.EdmxVersion;
+                ConfigODataEndpointViewModel.ServiceName = this._serviceConfig.ServiceName;
+                ConfigODataEndpointViewModel.CustomHttpHeaders = this._serviceConfig.CustomHttpHeaders;
 
-
+                // Restore the main settings to UI elements.
+                ConfigODataEndpointViewModel.PageEntering += ConfigODataEndpointViewModel_PageEntering;
 
                 // The ViewModel should always be filled otherwise if the wizard is completed without visiting this page the generated code becomes wrong
-                AdvancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNamespacePrefix;
-                AdvancedSettingsViewModel.NamespacePrefix = serviceConfig.NamespacePrefix;
-                AdvancedSettingsViewModel.UseDataServiceCollection = serviceConfig.UseDataServiceCollection;
+                AdvancedSettingsViewModel_PageEntering(AdvancedSettingsViewModel, EventArgs.Empty);
 
-                if (serviceConfig.EdmxVersion == Common.Constants.EdmxVersion4)
-                {
-                    AdvancedSettingsViewModel.IgnoreUnexpectedElementsAndAttributes =
-                        serviceConfig.IgnoreUnexpectedElementsAndAttributes;
-                    AdvancedSettingsViewModel.EnableNamingAlias = serviceConfig.EnableNamingAlias;
-                    AdvancedSettingsViewModel.IncludeT4File = serviceConfig.IncludeT4File;
-                    AdvancedSettingsViewModel.MakeTypesInternal = serviceConfig.MakeTypesInternal;
-                }
-
-
-                ConfigODataEndpointViewModel.PageEntering += (sender, args) =>
-                {
-
-                    var configOdataViewModel = sender as ConfigODataEndpointViewModel;
-                    if (configOdataViewModel != null)
-                    {
-                        var configOdataView = configOdataViewModel.View as ConfigODataEndpoint;
-                        configOdataView.Endpoint.IsEnabled = false;
-                        configOdataView.OpenConnectedServiceJsonFileButton.IsEnabled = false;
-                        configOdataView.OpenEndpointFileButton.IsEnabled = !serviceConfig.Endpoint.StartsWith("http");
-                        configOdataView.ServiceName.IsEnabled = false;
-                        configOdataViewModel.IncludeCustomHeaders = serviceConfig.IncludeCustomHeaders;
-                        configOdataViewModel.IncludeWebProxy = serviceConfig.IncludeWebProxy;
-                        configOdataViewModel.WebProxyHost = serviceConfig.WebProxyHost;
-
-                        configOdataViewModel.IncludeWebProxyNetworkCredentials = serviceConfig.IncludeWebProxyNetworkCredentials;
-                        configOdataViewModel.WebProxyNetworkCredentialsDomain = serviceConfig.WebProxyNetworkCredentialsDomain;
-
-                       // don't accept any credentials from the restored settings
-                        configOdataViewModel.WebProxyNetworkCredentialsUsername = null;
-                        configOdataViewModel.WebProxyNetworkCredentialsPassword = null;
-                    }
-                };
-
-
-                //Restore the advanced settings to UI elements.
-                AdvancedSettingsViewModel.PageEntering += (sender, args) =>
-                {
-                    if (sender is AdvancedSettingsViewModel advancedSettingsViewModel)
-                    {
-                        if (advancedSettingsViewModel.View is AdvancedSettings advancedSettings)
-                        {
-                            advancedSettingsViewModel.GeneratedFileNamePrefix = serviceConfig.GeneratedFileNamePrefix;
-                            advancedSettings.ReferenceFileName.IsEnabled = false;
-                            advancedSettingsViewModel.UseNamespacePrefix = serviceConfig.UseNamespacePrefix;
-                            advancedSettingsViewModel.NamespacePrefix = serviceConfig.NamespacePrefix;
-                            advancedSettingsViewModel.UseDataServiceCollection = serviceConfig.UseDataServiceCollection;
-                            advancedSettingsViewModel.GenerateMultipleFiles = serviceConfig.GenerateMultipleFiles;
-                            advancedSettings.GenerateMultipleFiles.IsEnabled = false;
-
-                            if (serviceConfig.EdmxVersion == Common.Constants.EdmxVersion4)
-                            {
-                                advancedSettingsViewModel.IgnoreUnexpectedElementsAndAttributes = serviceConfig.IgnoreUnexpectedElementsAndAttributes;
-                                advancedSettingsViewModel.EnableNamingAlias = serviceConfig.EnableNamingAlias;
-                                advancedSettingsViewModel.IncludeT4File = serviceConfig.IncludeT4File;
-                                advancedSettingsViewModel.MakeTypesInternal = serviceConfig.MakeTypesInternal;
-                                advancedSettings.IncludeT4File.IsEnabled = false;
-                            }
-                        }
-                    }
-                };
+                // Restore the advanced settings to UI elements.
+                AdvancedSettingsViewModel.PageEntering += AdvancedSettingsViewModel_PageEntering;
             }
 
             this.Pages.Add(ConfigODataEndpointViewModel);
@@ -149,19 +91,22 @@ namespace Microsoft.OData.ConnectedService
             ServiceConfiguration serviceConfiguration;
             if (ConfigODataEndpointViewModel.EdmxVersion == Common.Constants.EdmxVersion4)
             {
-                var ServiceConfigurationV4 = new ServiceConfigurationV4();
-                ServiceConfigurationV4.ExcludedOperationImports = OperationImportsViewModel.ExcludedOperationImportsNames.ToList();
-                ServiceConfigurationV4.IgnoreUnexpectedElementsAndAttributes = AdvancedSettingsViewModel.IgnoreUnexpectedElementsAndAttributes;
-                ServiceConfigurationV4.EnableNamingAlias = AdvancedSettingsViewModel.EnableNamingAlias;
-                ServiceConfigurationV4.IncludeT4File = AdvancedSettingsViewModel.IncludeT4File;
-                ServiceConfigurationV4.OpenGeneratedFilesInIDE = AdvancedSettingsViewModel.OpenGeneratedFilesInIDE;
-                serviceConfiguration = ServiceConfigurationV4;
+                var serviceConfigurationV4 = new ServiceConfigurationV4
+                {
+                    ExcludedOperationImports = OperationImportsViewModel.ExcludedOperationImportsNames.ToList(),
+                    IgnoreUnexpectedElementsAndAttributes =
+                        AdvancedSettingsViewModel.IgnoreUnexpectedElementsAndAttributes,
+                    EnableNamingAlias = AdvancedSettingsViewModel.EnableNamingAlias,
+                    IncludeT4File = AdvancedSettingsViewModel.IncludeT4File,
+                    OpenGeneratedFilesInIDE = AdvancedSettingsViewModel.OpenGeneratedFilesInIDE
+                };
+                serviceConfiguration = serviceConfigurationV4;
             }
             else
             {
                 serviceConfiguration = new ServiceConfiguration();
             }
-            
+
             serviceConfiguration.ServiceName = ConfigODataEndpointViewModel.ServiceName;
             serviceConfiguration.Endpoint = ConfigODataEndpointViewModel.Endpoint;
             serviceConfiguration.EdmxVersion = ConfigODataEndpointViewModel.EdmxVersion;
@@ -172,9 +117,7 @@ namespace Microsoft.OData.ConnectedService
             serviceConfiguration.WebProxyNetworkCredentialsUsername = ConfigODataEndpointViewModel.WebProxyNetworkCredentialsUsername;
             serviceConfiguration.WebProxyNetworkCredentialsPassword = ConfigODataEndpointViewModel.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = ConfigODataEndpointViewModel.WebProxyNetworkCredentialsDomain;
-
             serviceConfiguration.IncludeCustomHeaders = ConfigODataEndpointViewModel.IncludeCustomHeaders;
-
             serviceConfiguration.UseDataServiceCollection = AdvancedSettingsViewModel.UseDataServiceCollection;
             serviceConfiguration.GeneratedFileNamePrefix = AdvancedSettingsViewModel.GeneratedFileNamePrefix;
             serviceConfiguration.UseNamespacePrefix = AdvancedSettingsViewModel.UseNamespacePrefix;
@@ -192,29 +135,86 @@ namespace Microsoft.OData.ConnectedService
 
         #region "Event Handlers"
 
-        public void ObjectSelectionViewModel_PageEntering(object sender, EventArgs args)
+        public void ConfigODataEndpointViewModel_PageEntering(object sender, EventArgs args)
         {
-            if (sender is OperationImportsViewModel objectSelectionViewModel)
+            if (sender is ConfigODataEndpointViewModel configOdataViewModel)
             {
-                if (ConfigODataEndpointViewModel.EdmxVersion != Constants.EdmxVersion4)
+                if (configOdataViewModel.View is ConfigODataEndpoint configOdataView)
                 {
-                    objectSelectionViewModel.View.IsEnabled = false;
-                    objectSelectionViewModel.IsSupportedODataVersion = false;
-                    return;
+                    configOdataView.Endpoint.IsEnabled = false;
+                    configOdataView.OpenConnectedServiceJsonFileButton.IsEnabled = false;
+                    configOdataView.OpenEndpointFileButton.IsEnabled = !this._serviceConfig.Endpoint.StartsWith("http");
+                    configOdataView.ServiceName.IsEnabled = false;
                 }
-                var model = EdmHelper.GetEdmModelFromFile(ConfigODataEndpointViewModel.MetadataTempPath);
-                var operations = EdmHelper.GetOperationImports(model);
-                OperationImportsViewModel.LoadOperationImports(operations);
 
-                if (Context.IsUpdating)
+                configOdataViewModel.IncludeCustomHeaders = this._serviceConfig.IncludeCustomHeaders;
+                configOdataViewModel.IncludeWebProxy = this._serviceConfig.IncludeWebProxy;
+                configOdataViewModel.WebProxyHost = this._serviceConfig.WebProxyHost;
+                configOdataViewModel.IncludeWebProxyNetworkCredentials = this._serviceConfig.IncludeWebProxyNetworkCredentials;
+                configOdataViewModel.WebProxyNetworkCredentialsDomain = this._serviceConfig.WebProxyNetworkCredentialsDomain;
+
+                // don't accept any credentials from the restored settings
+                configOdataViewModel.WebProxyNetworkCredentialsUsername = null;
+                configOdataViewModel.WebProxyNetworkCredentialsPassword = null;
+            }
+        }
+
+        public void AdvancedSettingsViewModel_PageEntering(object sender, EventArgs args)
+        {
+            if (sender is AdvancedSettingsViewModel advancedSettingsViewModel)
+            {
+                if (advancedSettingsViewModel.View is AdvancedSettings advancedSettings)
                 {
-                    var serviceConfig = Context.GetExtendedDesignerData<ServiceConfigurationV4>();
-                    objectSelectionViewModel.ExcludeOperationImports(serviceConfig?.ExcludedOperationImports ?? Enumerable.Empty<string>());
+                    advancedSettingsViewModel.GeneratedFileNamePrefix = this._serviceConfig.GeneratedFileNamePrefix;
+                    advancedSettings.ReferenceFileName.IsEnabled = !this.Context.IsUpdating;
+                    advancedSettingsViewModel.UseNamespacePrefix = this._serviceConfig.UseNamespacePrefix;
+                    advancedSettingsViewModel.NamespacePrefix = this._serviceConfig.NamespacePrefix ?? Common.Constants.DefaultReferenceFileName;
+                    advancedSettingsViewModel.UseDataServiceCollection = this._serviceConfig.UseDataServiceCollection;
+                    advancedSettingsViewModel.OpenGeneratedFilesInIDE = this._serviceConfig.OpenGeneratedFilesInIDE;
+                    advancedSettingsViewModel.GenerateMultipleFiles = this._serviceConfig.GenerateMultipleFiles;
+                    advancedSettings.GenerateMultipleFiles.IsEnabled = !this.Context.IsUpdating;
+
+                    if (this._serviceConfig.EdmxVersion == Common.Constants.EdmxVersion4)
+                    {
+                        advancedSettingsViewModel.IgnoreUnexpectedElementsAndAttributes = this._serviceConfig.IgnoreUnexpectedElementsAndAttributes;
+                        advancedSettingsViewModel.EnableNamingAlias = this._serviceConfig.EnableNamingAlias;
+                        advancedSettingsViewModel.IncludeT4File = this._serviceConfig.IncludeT4File;
+                        advancedSettingsViewModel.MakeTypesInternal = this._serviceConfig.MakeTypesInternal;
+                        advancedSettings.IncludeT4File.IsEnabled = !this.Context.IsUpdating;
+                    }
                 }
             }
         }
 
+        public void OperationImportsViewModel_PageEntering(object sender, EventArgs args)
+        {
+            if (sender is OperationImportsViewModel operationImportsViewModel)
+            {
+                if (this._processedEndpointForOperationImports != ConfigODataEndpointViewModel.Endpoint)
+                {
+                    if (ConfigODataEndpointViewModel.EdmxVersion != Constants.EdmxVersion4)
+                    {
+                        operationImportsViewModel.View.IsEnabled = false;
+                        operationImportsViewModel.IsSupportedODataVersion = false;
+                        return;
+                    }
+                    var model = EdmHelper.GetEdmModelFromFile(ConfigODataEndpointViewModel.MetadataTempPath);
+                    var operations = EdmHelper.GetOperationImports(model);
+                    OperationImportsViewModel.LoadOperationImports(operations);
+                }
+
+                if (Context.IsUpdating)
+                {
+                    operationImportsViewModel.ExcludeOperationImports(this._serviceConfig?.ExcludedOperationImports ?? Enumerable.Empty<string>());
+                }
+
+                this._processedEndpointForOperationImports = ConfigODataEndpointViewModel.Endpoint;
+            }
+        }
+
         #endregion
+
+        #region Disposing
 
         /// <summary>
         /// Cleanup object references
@@ -256,5 +256,7 @@ namespace Microsoft.OData.ConnectedService
                 base.Dispose(disposing);
             }
         }
+
+        #endregion
     }
 }

--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.ConnectedService
 
         private readonly ServiceConfigurationV4 _serviceConfig;
 
-        private string _processedEndpointForOperationImports;
+        internal string ProcessedEndpointForOperationImports;
 
         public ODataConnectedServiceWizard(ConnectedServiceProviderContext context)
         {
@@ -190,7 +190,7 @@ namespace Microsoft.OData.ConnectedService
         {
             if (sender is OperationImportsViewModel operationImportsViewModel)
             {
-                if (this._processedEndpointForOperationImports != ConfigODataEndpointViewModel.Endpoint)
+                if (this.ProcessedEndpointForOperationImports != ConfigODataEndpointViewModel.Endpoint)
                 {
                     if (ConfigODataEndpointViewModel.EdmxVersion != Constants.EdmxVersion4)
                     {
@@ -208,7 +208,7 @@ namespace Microsoft.OData.ConnectedService
                     operationImportsViewModel.ExcludeOperationImports(this._serviceConfig?.ExcludedOperationImports ?? Enumerable.Empty<string>());
                 }
 
-                this._processedEndpointForOperationImports = ConfigODataEndpointViewModel.Endpoint;
+                this.ProcessedEndpointForOperationImports = ConfigODataEndpointViewModel.Endpoint;
             }
         }
 

--- a/src/ViewModels/AdvancedSettingsViewModel.cs
+++ b/src/ViewModels/AdvancedSettingsViewModel.cs
@@ -49,7 +49,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         {
             await base.OnPageEnteringAsync(args);
             this.View = new AdvancedSettings { DataContext = this };
-            PageEntering?.Invoke(this, EventArgs.Empty);
+            this.PageEntering?.Invoke(this, EventArgs.Empty);
         }
 
         public override Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)

--- a/src/ViewModels/AdvancedSettingsViewModel.cs
+++ b/src/ViewModels/AdvancedSettingsViewModel.cs
@@ -12,15 +12,25 @@ namespace Microsoft.OData.ConnectedService.ViewModels
     internal class AdvancedSettingsViewModel : ConnectedServiceWizardPage
     {
         public bool UseDataServiceCollection { get; set; }
+
         public bool UseNamespacePrefix { get; set; }
+
         public string NamespacePrefix { get; set; }
+
         public bool EnableNamingAlias { get; set; }
+
         public bool IgnoreUnexpectedElementsAndAttributes { get; set; }
+
         public string GeneratedFileNamePrefix { get; set; }
+
         public bool IncludeT4File { get; set; }
+
         public bool MakeTypesInternal { get; set; }
+
         public bool OpenGeneratedFilesInIDE { get; set; }
-        public bool GenerateMultipleFiles { get; set; }      
+
+        public bool GenerateMultipleFiles { get; set; }
+
         public UserSettings UserSettings { get; set; }
 
         public AdvancedSettingsViewModel(UserSettings userSettings) : base()
@@ -29,6 +39,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             this.Description = "Advanced settings for generating client proxy";
             this.Legend = "Settings";
             this.UserSettings = userSettings;
+            this.GeneratedFileNamePrefix = Common.Constants.DefaultReferenceFileName;
+            this.NamespacePrefix = Common.Constants.DefaultReferenceFileName;
         }
 
         public event EventHandler<EventArgs> PageEntering;
@@ -36,8 +48,35 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
             await base.OnPageEnteringAsync(args);
+            this.View = new AdvancedSettings { DataContext = this };
+            PageEntering?.Invoke(this, EventArgs.Empty);
+        }
 
-            this.View = new AdvancedSettings();
+        public override Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
+        {
+            SaveToUserSettings();
+            return base.OnPageLeavingAsync(args);
+        }
+
+        public void SaveToUserSettings()
+        {
+            if (this.UserSettings != null)
+            {
+                UserSettings.GeneratedFileNamePrefix = this.GeneratedFileNamePrefix;
+                UserSettings.OpenGeneratedFilesInIDE = this.OpenGeneratedFilesInIDE;
+                UserSettings.UseNamespacePrefix = this.UseNamespacePrefix;
+                UserSettings.NamespacePrefix = this.NamespacePrefix;
+                UserSettings.UseDataServiceCollection = this.UseDataServiceCollection;
+                UserSettings.MakeTypesInternal = this.MakeTypesInternal;
+                UserSettings.IncludeT4File = this.IncludeT4File;
+                UserSettings.IgnoreUnexpectedElementsAndAttributes = this.IgnoreUnexpectedElementsAndAttributes;
+                UserSettings.EnableNamingAlias = this.EnableNamingAlias;
+                UserSettings.GenerateMultipleFiles = this.GenerateMultipleFiles;
+            }
+        }
+
+        public void LoadFromUserSettings()
+        {
             if (UserSettings != null)
             {
                 this.GeneratedFileNamePrefix = UserSettings.GeneratedFileNamePrefix ?? Common.Constants.DefaultReferenceFileName;
@@ -50,17 +89,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                 this.IgnoreUnexpectedElementsAndAttributes = UserSettings.IgnoreUnexpectedElementsAndAttributes;
                 this.EnableNamingAlias = UserSettings.EnableNamingAlias;
                 this.GenerateMultipleFiles = UserSettings.GenerateMultipleFiles;
-            }         
-            this.View.DataContext = this;
-            if (PageEntering != null)
-            {
-                this.PageEntering(this, EventArgs.Empty);
             }
-        }
-
-        public override Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
-        {
-            return base.OnPageLeavingAsync(args);
         }
     }
 }

--- a/src/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ViewModels/ConfigODataEndpointViewModel.cs
@@ -17,47 +17,57 @@ namespace Microsoft.OData.ConnectedService.ViewModels
     internal class ConfigODataEndpointViewModel : ConnectedServiceWizardPage
     {
         public string Endpoint { get; set; }
+
         public string ServiceName { get; set; }
+
         public Version EdmxVersion { get; set; }
+
         public string MetadataTempPath { get; set; }
+
         public string CustomHttpHeaders { get; set; }
+
         public UserSettings UserSettings { get; set; }
+
         public bool IncludeWebProxy { get; set; }
+
         public string WebProxyHost { get; set; }
+
         public bool IncludeWebProxyNetworkCredentials { get; set; }
+
         public string WebProxyNetworkCredentialsUsername { get; set; }
+
         public string WebProxyNetworkCredentialsPassword { get; set; }
+
         public string WebProxyNetworkCredentialsDomain { get; set; }
+
         public bool IncludeCustomHeaders { get; set; }
+
         public event EventHandler<EventArgs> PageEntering;
+
         public ODataConnectedServiceWizard ServiceWizard { get; set; }
+
         public ConfigODataEndpointViewModel(UserSettings userSettings, ODataConnectedServiceWizard serviceWizard) : base()
         {
             this.Title = "Configure endpoint";
             this.Description = "Enter or choose an OData service endpoint to begin";
             this.Legend = "Endpoint";
-            this.View = new ConfigODataEndpoint
-            {
-                DataContext = this
-            };
             this.ServiceWizard = serviceWizard;
             this.UserSettings = userSettings;
-            this.ServiceName = Constants.DefaultServiceName;          
+            this.ServiceName = Constants.DefaultServiceName;
         }
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
             await base.OnPageEnteringAsync(args);
-            if (PageEntering != null)
-            {
-                this.PageEntering(this, EventArgs.Empty);
-            }
+            View = new ConfigODataEndpoint { DataContext = this };
+            PageEntering?.Invoke(this, EventArgs.Empty);
         }
+
         public event EventHandler<EventArgs> PageLeaving;
         public override Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
         {
-            LoadFromJsonFile();
+            SaveToUserSettings();
             var wizard = this.Wizard as ODataConnectedServiceWizard;
-            UserSettings.AddToTopOfMruList(wizard.UserSettings.MruEndpoints, this.Endpoint);
+            UserSettings.AddToTopOfMruList(wizard?.UserSettings?.MruEndpoints, this.Endpoint);
             try
             {
                 this.MetadataTempPath = GetMetadata(out var version);
@@ -121,7 +131,6 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
                 WebResponse webResponse = webRequest.GetResponse();
                 metadataStream = webResponse.GetResponseStream();
-                
             }
             else
             {
@@ -138,7 +147,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             string workFile = Path.GetTempFileName();
 
             try
-            {   
+            {
                 using (XmlReader reader = XmlReader.Create(metadataStream))
                 {
                     using (XmlWriter writer = XmlWriter.Create(workFile))
@@ -168,71 +177,21 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                 metadataStream?.Dispose();
             }
         }
-        public void LoadFromJsonFile()
+
+        public void SaveToUserSettings()
         {
             if (this.UserSettings != null)
             {
-                if (this.ServiceName != Constants.DefaultServiceName)
-                {
-                    UserSettings.ServiceName = this.ServiceName;
-                }
-                if (this.Endpoint != null)
-                {
-                    UserSettings.Endpoint = this.Endpoint;
-                }
-                if (this.WebProxyHost != null)
-                {
-                    UserSettings.WebProxyHost = this.WebProxyHost;
-                }
-                if (this.CustomHttpHeaders != null)
-                {
-                    UserSettings.CustomHttpHeaders = this.CustomHttpHeaders;
-                }
-                if (this.WebProxyNetworkCredentialsDomain != null)
-                {
-                    UserSettings.WebProxyNetworkCredentialsDomain = this.WebProxyNetworkCredentialsDomain;
-                }
-                if (this.WebProxyNetworkCredentialsPassword != null)
-                {
-                    UserSettings.WebProxyNetworkCredentialsPassword = this.WebProxyNetworkCredentialsPassword;
-                }
-                if (this.WebProxyNetworkCredentialsUsername != null)
-                {
-                    UserSettings.WebProxyNetworkCredentialsUsername = this.WebProxyNetworkCredentialsUsername;
-                }
-                if (this.IncludeCustomHeaders == true)
-                {
-                    UserSettings.IncludeCustomHeaders = this.IncludeCustomHeaders;
-                }
-                if (this.IncludeCustomHeaders == false && UserSettings.IncludeCustomHeaders == true)
-                {
-                    UserSettings.IncludeCustomHeaders = false;
-                }
-                if (this.IncludeWebProxy == true)
-                {
-                    UserSettings.IncludeWebProxy = true;
-                }
-                if (this.IncludeWebProxy == false && UserSettings.IncludeWebProxy == true)
-                {
-                    UserSettings.IncludeWebProxy = false;
-                }
-                if (this.IncludeWebProxyNetworkCredentials == true)
-                {
-                    UserSettings.IncludeWebProxyNetworkCredentials = true;
-                }
-                if (this.IncludeWebProxyNetworkCredentials == false && UserSettings.IncludeWebProxyNetworkCredentials == true)
-                {
-                    UserSettings.IncludeWebProxyNetworkCredentials = false;
-                }
-                this.ServiceName = UserSettings.ServiceName ?? Constants.DefaultServiceName;
-                this.Endpoint = UserSettings.Endpoint;
-                this.WebProxyHost = UserSettings.WebProxyHost;
-                this.IncludeWebProxy = UserSettings.IncludeWebProxy;
-                this.IncludeCustomHeaders = UserSettings.IncludeCustomHeaders;
-                this.IncludeWebProxyNetworkCredentials = UserSettings.IncludeWebProxyNetworkCredentials;
-                this.WebProxyNetworkCredentialsDomain = UserSettings.WebProxyNetworkCredentialsDomain;
-                this.WebProxyNetworkCredentialsPassword = UserSettings.WebProxyNetworkCredentialsPassword;
-                this.WebProxyNetworkCredentialsUsername = UserSettings.WebProxyNetworkCredentialsUsername;
+                UserSettings.ServiceName = this.ServiceName;
+                UserSettings.Endpoint = this.Endpoint;
+                UserSettings.WebProxyHost = this.WebProxyHost;
+                UserSettings.CustomHttpHeaders = this.CustomHttpHeaders;
+                UserSettings.WebProxyNetworkCredentialsDomain = this.WebProxyNetworkCredentialsDomain;
+                UserSettings.WebProxyNetworkCredentialsPassword = this.WebProxyNetworkCredentialsPassword;
+                UserSettings.WebProxyNetworkCredentialsUsername = this.WebProxyNetworkCredentialsUsername;
+                UserSettings.IncludeCustomHeaders = this.IncludeCustomHeaders;
+                UserSettings.IncludeWebProxy = this.IncludeWebProxy;
+                UserSettings.IncludeWebProxyNetworkCredentials = this.IncludeWebProxyNetworkCredentials;
             }
         }
     }

--- a/src/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ViewModels/ConfigODataEndpointViewModel.cs
@@ -58,8 +58,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
             await base.OnPageEnteringAsync(args);
-            View = new ConfigODataEndpoint { DataContext = this };
-            PageEntering?.Invoke(this, EventArgs.Empty);
+            this.View = new ConfigODataEndpoint { DataContext = this };
+            this.PageEntering?.Invoke(this, EventArgs.Empty);
         }
 
         public event EventHandler<EventArgs> PageLeaving;
@@ -87,7 +87,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
-        private string GetMetadata(out Version edmxVersion)
+        internal string GetMetadata(out Version edmxVersion)
         {
             if (string.IsNullOrEmpty(this.Endpoint))
             {
@@ -192,6 +192,24 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                 UserSettings.IncludeCustomHeaders = this.IncludeCustomHeaders;
                 UserSettings.IncludeWebProxy = this.IncludeWebProxy;
                 UserSettings.IncludeWebProxyNetworkCredentials = this.IncludeWebProxyNetworkCredentials;
+            }
+        }
+
+        public void LoadFromUserSettings()
+        {
+            if (this.UserSettings != null)
+            {
+                this.ServiceName = UserSettings.ServiceName ?? Constants.DefaultServiceName;
+                this.Endpoint = UserSettings.Endpoint;
+                this.WebProxyHost = UserSettings.WebProxyHost;
+                this.IncludeWebProxy = UserSettings.IncludeWebProxy;
+                this.IncludeCustomHeaders = UserSettings.IncludeCustomHeaders;
+                this.CustomHttpHeaders = UserSettings.CustomHttpHeaders;
+                this.IncludeWebProxyNetworkCredentials = UserSettings.IncludeWebProxyNetworkCredentials;
+                this.WebProxyNetworkCredentialsDomain = UserSettings.WebProxyNetworkCredentialsDomain;
+                this.WebProxyNetworkCredentialsPassword = UserSettings.WebProxyNetworkCredentialsPassword;
+                this.WebProxyNetworkCredentialsUsername = UserSettings.WebProxyNetworkCredentialsUsername;
+                this.View = new ConfigODataEndpoint { DataContext = this };
             }
         }
     }

--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.OData.ConnectedService.Models;
@@ -15,13 +14,16 @@ namespace Microsoft.OData.ConnectedService.ViewModels
     {
         private bool _isSupportedVersion;
 
-        public OperationImportsViewModel(): base()
+        public UserSettings UserSettings { get; set; }
+
+        public OperationImportsViewModel(UserSettings userSettings = null) : base()
         {
             Title = "Object Selection";
             Description = "Select function and action imports to include in the generated code.";
             Legend = "Function/Action Imports";
             OperationImports = new List<OperationImportModel>();
             IsSupportedODataVersion = true;
+            this.UserSettings = userSettings;
         }
 
         public IEnumerable<OperationImportModel> OperationImports { get; set; }
@@ -62,12 +64,13 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
             await base.OnPageEnteringAsync(args);
-            View = new OperationImports() { DataContext = this };
+            View = new OperationImports { DataContext = this };
             PageEntering?.Invoke(this, EventArgs.Empty);
         }
 
         public override async Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
         {
+            SaveToUserSettings();
             return await base.OnPageLeavingAsync(args);
         }
 
@@ -75,7 +78,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         {
             var toLoad = new List<OperationImportModel>();
             var alreadyAdded = new HashSet<string>();
-            
+
             foreach (var operation in operationImports)
             {
                 if (!alreadyAdded.Contains(operation.Name))
@@ -122,5 +125,25 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
+        public void SaveToUserSettings()
+        {
+            if (this.UserSettings != null)
+            {
+                UserSettings.ExcludedOperationImports = this.ExcludedOperationImportsNames?.Any() == true
+                    ? this.ExcludedOperationImportsNames.ToList()
+                    : new List<string>();
+            }
+        }
+
+        public void LoadFromUserSettings()
+        {
+            if (UserSettings != null)
+            {
+                if (UserSettings.ExcludedOperationImports?.Any() == true)
+                {
+                    ExcludeOperationImports(UserSettings.ExcludedOperationImports ?? Enumerable.Empty<string>());
+                }
+            }
+        }
     }
 }

--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -64,8 +64,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
             await base.OnPageEnteringAsync(args);
-            View = new OperationImports { DataContext = this };
-            PageEntering?.Invoke(this, EventArgs.Empty);
+            this.View = new OperationImports { DataContext = this };
+            this.PageEntering?.Invoke(this, EventArgs.Empty);
         }
 
         public override async Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)

--- a/src/Views/ConfigODataEndpoint.xaml
+++ b/src/Views/ConfigODataEndpoint.xaml
@@ -31,8 +31,13 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <TextBox x:Name="ServiceName" Text="{Binding Path=ServiceName}"
-                 HorizontalAlignment="Left" Margin="0, 5, 10, 5"  Width="230"  Height="20"/>
+            <TextBox
+                x:Name="ServiceName"
+                Width="230"
+                Height="20"
+                Margin="0,5,10,5"
+                HorizontalAlignment="Left"
+                Text="{Binding Path=ServiceName, Mode=TwoWay}" />
             <Button
                 x:Name="OpenConnectedServiceJsonFileButton"
                 Grid.Column="1"
@@ -65,7 +70,7 @@
                 HorizontalAlignment="Stretch"
                 IsEditable="True"
                 ItemsSource="{Binding Path=UserSettings.MruEndpoints}"
-                Text="{Binding Path=Endpoint, TargetNullValue='Enter your endpoint...'}" />
+                Text="{Binding Path=Endpoint, Mode=TwoWay, TargetNullValue='Enter your endpoint...'}" />
             <Button
                 x:Name="OpenEndpointFileButton"
                 Grid.Column="1"
@@ -85,7 +90,7 @@
             VerticalAlignment="Top"
             Content="Include Custom Http Headers"
             FontWeight="Medium"
-            IsChecked="{Binding IncludeCustomHeaders}" />
+            IsChecked="{Binding IncludeCustomHeaders, Mode=TwoWay}" />
 
         <StackPanel Margin="20,0,0,0" Visibility="{Binding Path=IsChecked, ElementName=IncludeHttpHeadersElement, Converter={StaticResource BooleanToVisibilityConverter}}">
 
@@ -100,7 +105,7 @@
                 Margin="20,5,10,5"
                 HorizontalAlignment="Left"
                 AcceptsReturn="True"
-                Text="{Binding Path=CustomHttpHeaders}"
+                Text="{Binding Path=CustomHttpHeaders, Mode=TwoWay}"
                 TextWrapping="Wrap"
                 VerticalScrollBarVisibility="Visible">
                 <TextBox.ToolTip>
@@ -122,7 +127,7 @@
             VerticalAlignment="Top"
             Content="Include WebProxy"
             FontWeight="Medium"
-            IsChecked="{Binding IncludeWebProxy}" />
+            IsChecked="{Binding IncludeWebProxy, Mode=TwoWay}" />
 
         <StackPanel Margin="20,0,0,0" Visibility="{Binding Path=IsChecked, ElementName=IncludeWebProxyElement, Converter={StaticResource BooleanToVisibilityConverter}}">
 
@@ -147,7 +152,7 @@
                 VerticalAlignment="Top"
                 Content="Include Proxy Network credentials"
                 FontWeight="Medium"
-                IsChecked="{Binding IncludeWebProxyNetworkCredentials}" />
+                IsChecked="{Binding IncludeWebProxyNetworkCredentials, Mode=TwoWay}" />
             <StackPanel
                 Margin="20,0,0,0"
                 Orientation="Vertical"
@@ -163,7 +168,7 @@
                     Width="300"
                     Margin="0,5,0,0"
                     HorizontalAlignment="Left"
-                    Text="{Binding WebProxyNetworkCredentialsUsername}"
+                    Text="{Binding WebProxyNetworkCredentialsUsername, Mode=TwoWay}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
@@ -176,7 +181,7 @@
                     Width="300"
                     Margin="0,5,0,0"
                     HorizontalAlignment="Left"
-                    Text="{Binding WebProxyNetworkCredentialsPassword}"
+                    Text="{Binding WebProxyNetworkCredentialsPassword, Mode=TwoWay}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
@@ -189,7 +194,7 @@
                     Width="300"
                     Margin="0,5,0,0"
                     HorizontalAlignment="Left"
-                    Text="{Binding WebProxyNetworkCredentialsDomain}"
+                    Text="{Binding WebProxyNetworkCredentialsDomain, Mode=TwoWay}"
                     TextWrapping="Wrap" />
 
             </StackPanel>

--- a/src/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/Views/ConfigODataEndpoint.xaml.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
 // Licensed under the MIT License.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.OData.ConnectedService.Common;
 using Microsoft.OData.ConnectedService.Models;
 using Microsoft.OData.ConnectedService.ViewModels;
@@ -88,6 +89,7 @@ namespace Microsoft.OData.ConnectedService.Views
                 this.UserSettings.EnableNamingAlias = microsoftConnectedServiceData.ExtendedData?.EnableNamingAlias ?? this.UserSettings.EnableNamingAlias;
                 this.UserSettings.CustomHttpHeaders = microsoftConnectedServiceData.ExtendedData?.CustomHttpHeaders ?? this.UserSettings.CustomHttpHeaders;
                 this.UserSettings.IncludeCustomHeaders = microsoftConnectedServiceData.ExtendedData?.IncludeCustomHeaders ?? this.UserSettings.IncludeCustomHeaders;
+                this.UserSettings.ExcludedOperationImports = microsoftConnectedServiceData.ExtendedData?.ExcludedOperationImports ?? new List<string>();
                 this.UserSettings.WebProxyHost = microsoftConnectedServiceData.ExtendedData?.WebProxyHost ?? this.UserSettings.WebProxyHost;
                 this.UserSettings.IncludeWebProxy = microsoftConnectedServiceData.ExtendedData?.IncludeWebProxy ?? this.UserSettings.IncludeWebProxy;
                 this.UserSettings.IncludeWebProxyNetworkCredentials = microsoftConnectedServiceData.ExtendedData?.IncludeWebProxyNetworkCredentials ?? this.UserSettings.IncludeWebProxyNetworkCredentials;
@@ -97,6 +99,9 @@ namespace Microsoft.OData.ConnectedService.Views
                 ODataConnectedServiceWizard ServiceWizard = ((ConfigODataEndpointViewModel)this.DataContext).ServiceWizard;
                 ServiceWizard.AdvancedSettingsViewModel.UserSettings = this.UserSettings;
                 ServiceWizard.ConfigODataEndpointViewModel.UserSettings = this.UserSettings;
+                ServiceWizard.OperationImportsViewModel.UserSettings = this.UserSettings;
+                ServiceWizard.AdvancedSettingsViewModel.LoadFromUserSettings();
+                ServiceWizard.OperationImportsViewModel.LoadFromUserSettings();
                 this.Endpoint.Text = microsoftConnectedServiceData.ExtendedData?.Endpoint ?? this.Endpoint.Text;
                 this.ServiceName.Text = microsoftConnectedServiceData.ExtendedData?.ServiceName ?? this.ServiceName.Text;
                 this.CustomHttpHeaders.Text = microsoftConnectedServiceData.ExtendedData?.CustomHttpHeaders ?? this.CustomHttpHeaders.Text;
@@ -109,5 +114,5 @@ namespace Microsoft.OData.ConnectedService.Views
                 this.IncludeWebProxyNetworkCredentialsElement.IsChecked = microsoftConnectedServiceData.ExtendedData?.IncludeWebProxyNetworkCredentials ?? this.IncludeWebProxyNetworkCredentialsElement.IsChecked;
             }
         }
-    } 
+    }
 }


### PR DESCRIPTION
Fix #69, fix #94

Refactored `ODataConnectedServiceWizard`:
* extract `PageEntering`-methods
* rename `ObjectSelectionViewModel_PageEntering` to `OperationImportsViewModel_PageEntering`
* update **Operation Imports** only for the new Endpoints

![save_state_new](https://user-images.githubusercontent.com/29679226/78256983-f1c72a00-7501-11ea-8d1f-f1fabc6574dc.gif)