### PR TITLE
Auto selects last metadata endpoint

### DIFF
--- a/src/Views/ConfigODataEndpoint.xaml
+++ b/src/Views/ConfigODataEndpoint.xaml
@@ -48,7 +48,8 @@
                 HorizontalAlignment="Stretch"
                 IsEditable="True"
                 ItemsSource="{Binding Path=UserSettings.MruEndpoints}"
-                Text="{Binding Path=Endpoint, TargetNullValue='Enter your endpoint...'}" />
+                Text="{Binding Path=Endpoint, TargetNullValue='Enter your endpoint...'}" 
+				SelectedIndex="0"/>
             <Button
                 x:Name="OpenEndpointFileButton"
                 Grid.Column="1"


### PR DESCRIPTION
Hi,

The endpoint drop-down contains the recent endpoints that were used.

![image](https://user-images.githubusercontent.com/2716316/77905822-9a218800-728f-11ea-8c68-0dcb1b0031e3.png)

When working on a server-client app that requires frequent changes to the server and re-generation of the client entities, any redundant click is tedious.
This PR changes the `ComboBox` to auto-select the first URL.