### PR TITLE
Make temp file metadata an embedded resource

### DIFF
--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -39,6 +39,7 @@ namespace Microsoft.OData.ConnectedService.Common
         public const string DefaultServiceName = "OData Service";
 
         public const string SchemaTypesWillAutomaticallyBeIncluded = "type(s) will automatically be included to ensure the generated code compiles successfully.";
+        public const string CsdlFileName = "Csdl.xml";
 
         public static string[] V3NuGetPackages = {
             V3ClientNuGetPackage,

--- a/src/ODataConnectedService.csproj
+++ b/src/ODataConnectedService.csproj
@@ -68,6 +68,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\EnvDTE.8.0.2\lib\net10\EnvDTE.dll</HintPath>
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
@@ -153,6 +154,10 @@
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="stdole, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\stdole.7.0.3302\lib\net10\stdole.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data.Entity" />
@@ -164,6 +169,10 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\VSLangProj.7.0.3301\lib\net10\VSLangProj.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Templates/ODataT4CodeGenerator.tt
+++ b/src/Templates/ODataT4CodeGenerator.tt
@@ -20,7 +20,10 @@ public static class Configuration
 
 	// The path for the temporary file where the metadata xml document can be stored. Use this if your metadata is too big to be stored in a string literal. Ensure that you have write permission for this path. 
 	// For example - "C:\\temp\\Test.xml"
-	public const string TempFilePath = "";
+	public const string MetadataFilePath = "";
+
+	// The relative path for the MetadataFilePath.
+	public const string MetadataFileRelativePath = "";
 
 	// This flag indicates whether to enable naming alias. The value must be set to true or false.
 	public const bool EnableNamingAlias = true;

--- a/src/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Templates/ODataT4CodeGenerator.ttinclude
@@ -46,7 +46,8 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             TargetLanguage = this.TargetLanguage,
             EnableNamingAlias = this.EnableNamingAlias,
             IgnoreUnexpectedElementsAndAttributes = this.IgnoreUnexpectedElementsAndAttributes,
-            TempFilePath = this.TempFilePath,
+            MetadataFilePath = this.MetadataFilePath,
+            MetadataFileRelativePath = this.MetadataFileRelativePath,
             MakeTypesInternal = this.MakeTypesInternal,
             MultipleFilesManager = FilesManager.Create(this.Host, null),
             GenerateMultipleFiles = this.GenerateMultipleFiles,
@@ -83,7 +84,8 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             TargetLanguage = this.TargetLanguage,
             EnableNamingAlias = this.EnableNamingAlias,
             IgnoreUnexpectedElementsAndAttributes = this.IgnoreUnexpectedElementsAndAttributes,
-            TempFilePath = this.TempFilePath,
+            MetadataFilePath = this.MetadataFilePath,
+            MetadataFileRelativePath = this.MetadataFileRelativePath,
             MakeTypesInternal = this.MakeTypesInternal,
             MultipleFilesManager = FilesManager.Create(this.Host, null),
             GenerateMultipleFiles = this.GenerateMultipleFiles,
@@ -287,9 +289,18 @@ public IEnumerable <string> ExcludedSchemaTypes
 }
 
 /// <summary>
-/// The path for the temporary file where the metadata xml document can be stored.
+/// The path for the file where the metadata xml document can be stored.
 /// </summary>
-public string TempFilePath
+public string MetadataFilePath
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// The relative path for the file where the metadata xml document can be stored.
+/// </summary>
+public string MetadataFileRelativePath
 {
     get;
     set;
@@ -550,7 +561,8 @@ private void ApplyParametersFromConfigurationClass()
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
     this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
     this.MakeTypesInternal = Configuration.MakeTypesInternal;
-    this.TempFilePath = Configuration.TempFilePath;
+    this.MetadataFilePath = Configuration.MetadataFilePath;
+    this.MetadataFileRelativePath = Configuration.MetadataFileRelativePath;
     this.GenerateMultipleFiles = Configuration.GenerateMultipleFiles;
     this.SetCustomHttpHeadersFromString(Configuration.CustomHttpHeaders);
     this.ExcludedOperationImports = Configuration.ExcludedOperationImports.Split(',')
@@ -1042,9 +1054,18 @@ public class CodeGenerationContext
     }
 
     /// <summary>
-    /// The path for the temporary file where the metadata xml document can be stored.
+    /// The path for the file where the metadata xml document can be stored.
     /// </summary>
-    public string TempFilePath
+    public string MetadataFilePath
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// The relative path for the file where the metadata xml document can be stored.
+    /// </summary>
+    public string MetadataFileRelativePath
     {
         get;
         set;
@@ -1827,7 +1848,7 @@ public abstract class ODataClientTemplate : TemplateBase
     internal void WriteEntityContainer(IEdmEntityContainer container, string fullNamespace)
     {
         string camelCaseContainerName = container.Name;
-        string path = this.context.TempFilePath;
+        string path = this.context.MetadataFilePath;
         bool useTempFile = !String.IsNullOrEmpty(path);
         if (this.context.EnableNamingAlias)
         {
@@ -3924,7 +3945,8 @@ namespace <#= fullNamespace #>
 
     internal override void WriteGeneratedEdmModel(string escapedEdmxString)
     {
-        string path = this.context.TempFilePath;
+        string path = this.context.MetadataFilePath;
+        string relativePath = this.context.MetadataFileRelativePath;
         if(!String.IsNullOrEmpty(path))
         {
             using (StreamWriter writer = new StreamWriter(path, false))
@@ -3965,7 +3987,7 @@ namespace <#= fullNamespace #>
             {
 #>
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-            private const string filePath = @"<#= path #>";
+            private const string filePath = @"<#= relativePath #>";
 <#+
             }
             else
@@ -4065,16 +4087,26 @@ namespace <#= fullNamespace #>
             }
 
 <#+
-            if (useTempFile)
-            {
+        if (useTempFile)
+        {
 #>
-                [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-                private static global::System.Xml.XmlReader CreateXmlReader()
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
+            private static global::System.Xml.XmlReader CreateXmlReader()
+            {
+                try
                 {
-                    return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(filePath));
+                    var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
+                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
+                    return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }
-<#+
+                catch(global::System.Xml.XmlException e)
+                {
+                    throw new global::System.Xml.XmlException("Failed to create an XmlReader from the stream. Check if the resource exists.", e);
+                }
             }
+<#+
+        }
 #>
         }
 <#+

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EnvDTE" version="8.0.2" targetFramework="net472" />
   <package id="Microsoft.OData.Client" version="7.6.3" targetFramework="net472" />
   <package id="Microsoft.OData.Core" version="7.6.3" targetFramework="net472" />
   <package id="Microsoft.OData.Edm" version="7.6.3" targetFramework="net472" />
@@ -24,4 +25,6 @@
   <package id="Microsoft.VisualStudio.Validation" version="15.0.82" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="NuGet.VisualStudio" version="4.0.0" targetFramework="net45" />
+  <package id="stdole" version="7.0.3302" targetFramework="net472" />
+  <package id="VSLangProj" version="7.0.3301" targetFramework="net472" />
 </packages>

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
@@ -40,7 +40,7 @@ namespace ODataConnectedService.Tests
         private static string T4TemplatePath;
         private static string T4IncludeTemplatePath;
         private static string T4IncludeFileManagePath;
-        private static string TempFilePath;
+        private static string MetadataFilePath;
 
         [TestInitialize]
         public void Init()
@@ -462,12 +462,12 @@ namespace ODataConnectedService.Tests
         [TestMethod]
         public void CodeGenUsingTempMetadataFileTest()
         {
-            TempFilePath = "tempMetadata.xml";
-            File.Delete(TempFilePath);
-            CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.AbstractEntityTypeWithoutKey.Metadata, null, true, true, false, false, null, true, tempFilePath : TempFilePath);
-            Action action = () => ODataT4CodeGeneratorTestDescriptors.ValidateXMLFile(TempFilePath);
+            MetadataFilePath = "tempMetadata.xml";
+            File.Delete(MetadataFilePath);
+            CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.AbstractEntityTypeWithoutKey.Metadata, null, true, true, false, false, null, true, MetadataFilePath);
+            Action action = () => ODataT4CodeGeneratorTestDescriptors.ValidateXMLFile(MetadataFilePath);
             action.ShouldNotThrow<XmlException>();
-            ODataT4CodeGeneratorTestDescriptors.ValidateEdmx(TempFilePath);
+            ODataT4CodeGeneratorTestDescriptors.ValidateEdmx(MetadataFilePath);
         }
 
         [TestMethod]
@@ -497,7 +497,7 @@ namespace ODataConnectedService.Tests
             bool useDataServiceCollection, bool enableNamingAlias = false,
             bool ignoreUnexpectedElementsAndAttributes = false,
             Func<Uri, WebProxy, IList<string>, XmlReader> getReferencedModelReaderFunc = null,
-            bool appendDSCSuffix = false, string tempFilePath = null, bool generateMultipleFiles = false,
+            bool appendDSCSuffix = false, string MetadataFilePath = null, bool generateMultipleFiles = false,
             IEnumerable<string> excludedSchemaTypes = default(List<string>))
 
         {
@@ -527,9 +527,10 @@ namespace ODataConnectedService.Tests
                 ExcludedSchemaTypes = excludedSchemaTypes
             };
 
-            if (!String.IsNullOrEmpty(tempFilePath))
+            if (!String.IsNullOrEmpty(MetadataFilePath))
             {
-                t4CodeGenerator.TempFilePath = TempFilePath;
+                t4CodeGenerator.MetadataFilePath = MetadataFilePath;
+                t4CodeGenerator.MetadataFileRelativePath = MetadataFilePath;
             }
 
             if (useDataServiceCollection)


### PR DESCRIPTION
Fixes Issue: #54 
_Background_
The current directory when the connected service is running during code generation may be different from when the project itself is running. Therefore we need a way for the generated Csdl.xml to be accessed by the connected service.
Using `relative path` requires us to handle the paths to the working directory for project and connected service which create additional complexity.
`Absolute path` would solve this. The main drawback is that when you move the project folder to another folder, we will need to regenerate the files afresh since the path will be invalid.

**Solution**
We make the Csdl.xml an embedded resource which will be shipped with the executable. With this we will not have to worry about paths.