### PR TITLE
Auto selects last metadata endpoint

### DIFF
--- a/src/Views/ConfigODataEndpoint.xaml
+++ b/src/Views/ConfigODataEndpoint.xaml
@@ -12,6 +12,7 @@
     d:DataContext="{d:DesignInstance Type=viewModels:ConfigODataEndpointViewModel}"
     d:DesignHeight="300"
     d:DesignWidth="500"
+	Loaded="UserControl_Loaded"
     mc:Ignorable="d">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />

--- a/src/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/Views/ConfigODataEndpoint.xaml.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OData.ConnectedService.Views
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
-            if (Endpoint.Items.Count > 0)
+            if (Endpoint.Items.Count > 0 && !((ConfigODataEndpointViewModel)this.DataContext).ServiceWizard.Context.IsUpdating)
             {
                 Endpoint.SelectedItem = Endpoint.Items[0];
             }

--- a/src/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/Views/ConfigODataEndpoint.xaml.cs
@@ -25,6 +25,14 @@ namespace Microsoft.OData.ConnectedService.Views
             InitializeComponent();
         }
 
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (Endpoint.Items.Count > 0)
+            {
+                Endpoint.SelectedItem = Endpoint.Items[0];
+            }
+        }
+
         private void OpenMetadataFileButton_OnClick(object sender, RoutedEventArgs e)
         {
             var openFileDialog = new Win32.OpenFileDialog


### PR DESCRIPTION
Hi,

The endpoint drop-down contains the recent endpoints that were used.

![image](https://user-images.githubusercontent.com/2716316/77905822-9a218800-728f-11ea-8c68-0dcb1b0031e3.png)

When working on a server-client app that requires frequent changes to the server and re-generation of the client entities, any redundant click is tedious.
This PR changes the `ComboBox` to auto-select the first URL.