### PR TITLE
Enable multiple files generation using design-time T4 templates

### DIFF
--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -110,6 +110,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 text = Regex.Replace(text, "(public const bool EnableNamingAlias = )true;", "$1" + this.ServiceConfiguration.EnableNamingAlias.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 text = Regex.Replace(text, "(public const bool IgnoreUnexpectedElementsAndAttributes = )true;", "$1" + this.ServiceConfiguration.IgnoreUnexpectedElementsAndAttributes.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 text = Regex.Replace(text, "(public const bool MakeTypesInternal = )false;", "$1" + ServiceConfiguration.MakeTypesInternal.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
+                text = Regex.Replace(text, "(public const bool GenerateMultipleFiles = )false;", "$1" + ServiceConfiguration.GenerateMultipleFiles.ToString().ToLower(CultureInfo.InvariantCulture) + ";");
                 var customHeaders = ServiceConfiguration.CustomHttpHeaders ?? "";
                 text = Regex.Replace(text, "(public const string CustomHttpHeaders = )\"\";", "$1@\"" + customHeaders + "\";");
                 text = Regex.Replace(text, "(public const string MetadataFilePath = )\"\";", "$1@\"" + metadataFile + "\";");

--- a/src/Templates/ODataT4CodeGenFilesManager.ttinclude
+++ b/src/Templates/ODataT4CodeGenFilesManager.ttinclude
@@ -168,7 +168,7 @@ public class FilesManager {
             {
                 if(block.IsContainer) continue;
                 string fileName = Path.Combine(outputPath, block.Name);
-                
+
                 if(fileCreated)
                 {
                     string outputFile = Path.Combine(referenceFolder, block.Name);

--- a/src/Templates/ODataT4CodeGenFilesManager.ttinclude
+++ b/src/Templates/ODataT4CodeGenFilesManager.ttinclude
@@ -10,6 +10,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */#><#@ assembly name="System.Core.dll"
 #><#@ assembly name="System.Xml.dll"
+#><#@ assembly name="EnvDTE.dll"
 #><#@ assembly name="Microsoft.OData.ConnectedService.dll"
 #><#@ assembly name="Microsoft.VisualStudio.ConnectedServices.dll"
 #><#@ assembly name="System.Xml.Linq.dll"
@@ -22,6 +23,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 #><#@ import namespace="System.Xml.Linq"
 #><#@ import namespace="Microsoft.VisualStudio.TextTemplating"
 #><#@ import namespace="Microsoft.VisualStudio.ConnectedServices"
+#><#@ import namespace="EnvDTE"
 #><#+
 /// <summary>
 /// Creates an instance of the FilesManager. The object used to generate and manage
@@ -65,7 +67,7 @@ public class FilesManager {
     private ITextTemplatingEngineHost _host;
 
     /// <summary> A list of file names to be generated.</summary>
-    protected List<String> generatedFileNames = new List<String>();
+    protected List<String> _generatedFileNames = new List<String>();
 
     /// <summary> Contains generated text.</summary>
     public StringBuilder Template
@@ -140,7 +142,7 @@ public class FilesManager {
     /// Generated multiple files depending on the number of blocks.
     /// </summary>
     /// <param name="split">If true the function is executed and multiple files generated
-    /// otherwoise only a single file is generated.</param>
+    /// otherwise only a single file is generated.</param>
     [SecurityCritical]
     public virtual void GenerateFiles(bool split, ConnectedServiceHandlerHelper handlerHelper, ConnectedServiceLogger logger, string referenceFolder, bool fileCreated, bool OpenGeneratedFilesInIDE)
     {
@@ -149,15 +151,24 @@ public class FilesManager {
             EndBlock();
             string headerText = Template.ToString(_header.Start, _header.Length);
             string footerText = Template.ToString(_footer.Start, _footer.Length);
-
+            string outputPath ="";
+            
+            if(_host != null)
+            {
+                outputPath = Path.GetDirectoryName(_host.TemplateFile);
+            }
+            else
+            {
+                outputPath = Path.GetTempPath();
+            }
+            
             _files.Reverse();
 
             foreach(Block block in _files)
             {
-
                 if(block.IsContainer) continue;
-                string fileName = Path.Combine(Path.GetTempPath(),block.Name);
-
+                string fileName = Path.Combine(outputPath, block.Name);
+                
                 if(fileCreated)
                 {
                     string outputFile = Path.Combine(referenceFolder, block.Name);
@@ -172,7 +183,7 @@ public class FilesManager {
                 else
                 {
                     string content = headerText + Template.ToString(block.Start, block.Length) + footerText;
-                    generatedFileNames.Add(fileName);
+                    _generatedFileNames.Add(fileName);
                     CreateFile(fileName, content);
                     Template.Remove(block.Start, block.Length);
                 }
@@ -189,9 +200,8 @@ public class FilesManager {
     {
         if (IsFileContentDifferent(fileName, content))
         {
-            File.WriteAllText(fileName, content);
-        }
-
+                 File.WriteAllText(fileName, content);
+        }           
     }
 
     public virtual string GetCustomToolNamespace(string fileName)
@@ -250,17 +260,11 @@ public class FilesManager {
     }
 
     private class VSManager : FilesManager {
-
-        /// <summary>
-        /// Generated multiple files depending on the number of blocks.
-        /// </summary>
-        /// <param name="split">If true the function is executed and multiple files generated
-        /// otherwoise only a single file is generated.</param>
-        [SecurityCritical]
-        public override void GenerateFiles(bool split, ConnectedServiceHandlerHelper handlerHelper, ConnectedServiceLogger logger, string referenceFolder, bool fileCreated, bool OpenGeneratedFilesInIDE)
-        {
-            base.GenerateFiles(split, handlerHelper, logger, referenceFolder, fileCreated, OpenGeneratedFilesInIDE);
-        }
+        
+        private readonly EnvDTE.ProjectItem _templateProjectItem;
+        private readonly EnvDTE.DTE _dte;
+        private readonly Action<string> _checkOutAction;
+        private readonly Action<IEnumerable<string>> _projectSyncAction;
 
         /// <summary>
         ///Creates a file with the name <paramref name="fileName"> and content <paramref name="content">.
@@ -271,8 +275,26 @@ public class FilesManager {
         {
             if (IsFileContentDifferent(fileName, content))
             {
+                CheckoutFileIfRequired(fileName);
                 File.WriteAllText(fileName, content);
             }
+        }
+
+        /// <summary>
+        /// Generates multiple files depending on the number of blocks.
+        /// </summary>
+        /// <param name="split">If true the function is executed and multiple files generated
+        /// otherwise only a single file is generated.</param>
+        [SecurityCritical]
+        public override void GenerateFiles(bool split, ConnectedServiceHandlerHelper handlerHelper, ConnectedServiceLogger logger, string referenceFolder, bool fileCreated, bool OpenGeneratedFilesInIDE) 
+        {
+            if (_templateProjectItem.ProjectItems == null)
+            {
+                    return;
+            }               
+
+            base.GenerateFiles(split, handlerHelper, logger, referenceFolder, fileCreated, OpenGeneratedFilesInIDE);
+            _projectSyncAction.Invoke(_generatedFileNames);
         }
 
         /// <summary>
@@ -287,6 +309,55 @@ public class FilesManager {
             {
                 throw new ArgumentNullException("Could not obtain IServiceProvider");
             }
+            
+            _dte = hostServiceProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
+
+            if (_dte == null)
+            {
+                throw new ArgumentNullException("Could not obtain DTE from host");
+            }
+
+            _templateProjectItem = _dte.Solution.FindProjectItem(host.TemplateFile);
+            _checkOutAction = (fileName) => _dte.SourceControl.CheckOutItem(fileName);
+            _projectSyncAction = (fileNames) => ProjectSync(_templateProjectItem, fileNames);
+        }
+
+        /// <summary>
+        /// Synchronizes the project by adding the generated files to the VS project file.
+        /// This ensures the generated files are referenced in the project file and can be built when building the project
+        /// <param name="templateProjectItem">T4 project item as returned by EnvDTE</param>
+        /// <param name="fileNames">Names of the files generated</param>
+        /// </summary>
+        private static void ProjectSync(EnvDTE.ProjectItem templateProjectItem, IEnumerable<string> fileNames) 
+        {
+            HashSet<string> fileNameSet = new HashSet<string>(fileNames);
+            Dictionary<string, EnvDTE.ProjectItem> projectFiles = new Dictionary<string, EnvDTE.ProjectItem>();
+            string originalFilePrefix = Path.GetFileNameWithoutExtension(templateProjectItem.get_FileNames(0));
+
+            foreach(EnvDTE.ProjectItem projectItem in templateProjectItem.ProjectItems)
+            {
+                var fileName = projectItem.get_FileNames(0);
+                if (!fileNameSet.Contains(fileName) && !(Path.GetFileNameWithoutExtension(fileName)).StartsWith(originalFilePrefix))
+                {
+                    projectItem.Delete();
+                }
+
+                fileNameSet.Remove(fileName);
+            }
+            // then the loop that comes after will be
+            foreach(string fileName in fileNameSet)
+            {
+                templateProjectItem.ProjectItems.AddFromFile(fileName);
+            }
+        }
+        
+        private void CheckoutFileIfRequired(string fileName) 
+        {
+            var sourceControl = _dte.SourceControl;
+            if (sourceControl != null && sourceControl.IsItemUnderSCC(fileName) && !sourceControl.IsItemCheckedOut(fileName))
+            {
+                _checkOutAction.Invoke(fileName);
+            }    
         }
     }
 } #>

--- a/src/Templates/ODataT4CodeGenerator.cs
+++ b/src/Templates/ODataT4CodeGenerator.cs
@@ -7907,7 +7907,7 @@ public class FilesManager {
             {
                 if(block.IsContainer) continue;
                 string fileName = Path.Combine(outputPath, block.Name);
-                
+
                 if(fileCreated)
                 {
                     string outputFile = Path.Combine(referenceFolder, block.Name);

--- a/src/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Templates/ODataT4CodeGenerator.ttinclude
@@ -1629,7 +1629,14 @@ public abstract class ODataClientTemplate : TemplateBase
         if (schemaElements.OfType<IEdmEntityType>().Any() ||
             schemaElements.OfType<IEdmOperation>().Any(o => o.IsBound))
         {
+            if(context.GenerateMultipleFiles) 
+            {
+                context.MultipleFilesManager.StartNewFile($"ExtensionMethods{(this.context.TargetLanguage == LanguageOption.VB ? ".vb" : ".cs")}",false);
+                this.WriteNamespaceStart(this.context.GetPrefixedNamespace(fullNamespace, this, true, false));
+            }
+
             this.WriteExtensionMethodsStart();
+
             foreach (IEdmEntityType type in schemaElements.OfType<IEdmEntityType>())
             {
 
@@ -1827,6 +1834,11 @@ public abstract class ODataClientTemplate : TemplateBase
             }
 
             this.WriteExtensionMethodsEnd();
+            if(context.GenerateMultipleFiles) 
+            {
+                this.WriteNamespaceEnd();
+                context.MultipleFilesManager.EndBlock();
+            }
         }
 
         this.WriteNamespaceEnd();

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -48,9 +48,6 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
@@ -72,6 +69,9 @@
     <Compile Include="ViewModels\OperationImportsViewModelTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="EnvDTE">
+      <Version>8.0.2</Version>
+    </PackageReference>
     <PackageReference Include="FluentAssertions">
       <Version>2.0.0.1</Version>
     </PackageReference>

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
@@ -165,7 +165,6 @@ namespace ODataConnectedService.Tests
         public void CodeGenSimpleEdmxMultipleFiles()
         {
             string code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.SimpleMultipleFiles.Metadata, null, true, false, generateMultipleFiles : true);
-            ODataT4CodeGeneratorTestDescriptors.SimpleMultipleFiles.Verify(code, true/*isCSharp*/, false/*useDSC*/);
 
             string expectedTestType = ODataT4CodeGeneratorTest.NormalizeGeneratedCode(ODataT4CodeGeneratorTestDescriptors.GetFilecontent("SimpleMultipleTestType.cs"));
             string actualTestType = ODataT4CodeGeneratorTest.NormalizeGeneratedCode(File.ReadAllText(Path.Combine(Path.GetTempPath(), "TestType.cs")));
@@ -176,9 +175,13 @@ namespace ODataConnectedService.Tests
             string expectedCity = ODataT4CodeGeneratorTest.NormalizeGeneratedCode(ODataT4CodeGeneratorTestDescriptors.GetFilecontent("SimpleMultipleFilesCity.cs"));
             string actualCity = ODataT4CodeGeneratorTest.NormalizeGeneratedCode(File.ReadAllText(Path.Combine(Path.GetTempPath(), "City.cs")));
 
+            string expectedExtensionMethods = ODataT4CodeGeneratorTest.NormalizeGeneratedCode(ODataT4CodeGeneratorTestDescriptors.GetFilecontent("SimpleMultipleFilesMain.cs"));
+            string actualExtenisonMethods = ODataT4CodeGeneratorTest.NormalizeGeneratedCode(File.ReadAllText(Path.Combine(Path.GetTempPath(), "ExtensionMethods.cs")));
+
             Assert.AreEqual(expectedTestType, actualTestType);
             Assert.AreEqual(expectedPersonGender, actualPersonGender);
             Assert.AreEqual(expectedCity, actualCity);
+            Assert.AreEqual(expectedExtensionMethods, actualExtenisonMethods);
         }
 
         [TestMethod]


### PR DESCRIPTION
This pull request fixes #57 
It was made possible to generate multiple files using connected service. However, it was only possible while adding this option in connected service UI that executes T4 templates at runtime. This changes allows users to set configuration `GenerateMultipleFiles ` in .`tt` file to true and generate multiple files at desin-time. 

In addition this change also generates `ExtensionMethods `class in a separate file as suggested.