### PR TITLE
Add connected service wizard tests

### DIFF
--- a/src/Common/UserSettingsPersistenceHelper.cs
+++ b/src/Common/UserSettingsPersistenceHelper.cs
@@ -34,8 +34,6 @@ namespace Microsoft.OData.ConnectedService.Common
                             stream = file.OpenFile(fileName, FileMode.Create);
                             using (var writer = XmlWriter.Create(stream))
                             {
-                                stream = null;
-
                                 var dcs = new DataContractSerializer(userSettings.GetType());
                                 dcs.WriteObject(writer, userSettings);
 
@@ -85,7 +83,6 @@ namespace Microsoft.OData.ConnectedService.Common
 
                                 using (var reader = XmlReader.Create(stream, settings))
                                 {
-                                    stream = null;
 
                                     var dcs = new DataContractSerializer(typeof(T));
                                     result = dcs.ReadObject(reader) as T;
@@ -133,7 +130,7 @@ namespace Microsoft.OData.ConnectedService.Common
             }
             catch (Exception ex)
             {
-                logger.WriteMessageAsync(LoggerMessageCategory.Warning, failureMessage, failureMessageArg, ex);
+                logger?.WriteMessageAsync(LoggerMessageCategory.Warning, failureMessage, failureMessageArg, ex);
             }
         }
     }

--- a/src/Models/SchemaTypeModel.cs
+++ b/src/Models/SchemaTypeModel.cs
@@ -6,6 +6,16 @@ namespace Microsoft.OData.ConnectedService.Models
     {
         private bool _isSelected;
 
+        public SchemaTypeModel(): this(null, null)
+        {
+        }
+
+        public SchemaTypeModel(string name, string shortName)
+        {
+            Name = name;
+            ShortName = shortName;
+        }
+
         public string Name { get; set; }
 
         public string ShortName { get; set; }

--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -35,6 +35,8 @@ namespace Microsoft.OData.ConnectedService
 
         private readonly ServiceConfigurationV4 _serviceConfig;
 
+        public ServiceConfigurationV4 ServiceConfig { get { return _serviceConfig; } }
+
         internal string ProcessedEndpointForOperationImports;
 
         internal string ProcessedEndpointForSchemaTypes;

--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                         {
                             if (schemaTypeModels.TryGetValue(parameter.Type.FullName(), out SchemaTypeModel model) && !model.IsSelected)
                             {
-                                model.IsSelected = true;
+                                model.IsSelected = (s as OperationImportModel).IsSelected;
                             }
                         }
 
@@ -114,7 +114,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
                         if(returnTypeName != null && schemaTypeModels.TryGetValue(returnTypeName, out SchemaTypeModel schemaTypeModel) && !schemaTypeModel.IsSelected)
                         {
-                            schemaTypeModel.IsSelected = true;
+                            schemaTypeModel.IsSelected = (s as OperationImportModel).IsSelected;
                         }
                     };
                     toLoad.Add(operationImportModel);

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -133,6 +133,12 @@
     <Content Include="TestMetadataCsdl.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestMetadataCsdlSimple.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestMetadataCsdlV3.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -97,6 +97,14 @@
     <PackageReference Include="System.Xml.ReaderWriter">
       <Version>4.3.1</Version>
     </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.4.1</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.4.1</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ODataConnectedServiceWizardTests.cs" />
     <Compile Include="Properties\AssemblyRefs.cs" />
     <Compile Include="Templates\CodeGenerationContextTest.cs" />
     <Compile Include="CodeGeneration\V4CodeGenDescriptorTest.cs" />
@@ -80,6 +81,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ConnectedServices">
       <Version>2.0.0</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.11.0">
+      <Version>11.0.50727</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.13.1</Version>

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -129,6 +129,11 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="TestMetadataCsdl.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.ConnectedServices;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.OData.ConnectedService;
 using System.ComponentModel;
@@ -13,17 +12,28 @@ using System.IO;
 using System.Windows.Documents;
 using System.Windows;
 using System.Linq;
+using Xunit;
 
 namespace ODataConnectedService.Tests
 {
-    [TestClass]
-    public class ODataConnectedServiceWizardTests
+
+    public class ODataConnectedServiceWizardTests: IDisposable
     {
 
         UserSettings initialSettings = UserSettings.Load(null);
         readonly string MetadataPath = Path.GetFullPath("TestMetadataCsdl.xml");
         readonly string MetadataPathV3 = Path.GetFullPath("TestMetadataCsdlV3.xml");
         readonly string MetadataPathSimple = Path.GetFullPath("TestMetadataCsdlSimple.xml");
+
+        public ODataConnectedServiceWizardTests()
+        {
+            ResetUserSettings();
+        }
+
+        public void Dispose()
+        {
+            RestoreUserSettings();
+        }
 
         private ServiceConfigurationV4 GetTestConfig()
         {
@@ -64,20 +74,18 @@ namespace ODataConnectedService.Tests
             };
         }
 
-        [TestInitialize]
-        public void ResetUserSettings()
+        private void ResetUserSettings()
         {
             var settings = new UserSettings();
             settings.Save();
         }
 
-        [TestCleanup]
-        public void RestoreUserSettings()
+        private void RestoreUserSettings()
         {
             initialSettings.Save();
         }
 
-        [TestMethod]
+        [Fact]
         public void TestLoadUserSettingsWhenWizardIsCreated()
         {
             var settings = new UserSettings();
@@ -88,13 +96,13 @@ namespace ODataConnectedService.Tests
             var context = new TestConnectedServiceProviderContext();
             var wizard = new ODataConnectedServiceWizard(context);
 
-            Assert.AreEqual("Some Service", wizard.UserSettings.ServiceName);
-            Assert.IsTrue(wizard.UserSettings.MruEndpoints.Contains("Endpoint"));
+            Assert.Equal("Some Service", wizard.UserSettings.ServiceName);
+            Assert.Contains("Endpoint", wizard.UserSettings.MruEndpoints);
         }
 
         
 
-        [TestMethod]
+        [Fact]
         public void TestConstructor_ShouldUseDefaultSettingsWhenNotUpdating()
         {
             var savedConfig = GetTestConfig();
@@ -104,17 +112,17 @@ namespace ODataConnectedService.Tests
 
             var endpointPage = wizard.ConfigODataEndpointViewModel;
             endpointPage.OnPageEnteringAsync(new WizardEnteringArgs(null)).Wait();
-            Assert.AreEqual(Constants.DefaultServiceName, endpointPage.ServiceName);
-            Assert.IsNull(endpointPage.Endpoint);
-            Assert.IsNull(endpointPage.EdmxVersion);
-            Assert.IsFalse(endpointPage.IncludeCustomHeaders);
-            Assert.IsNull(endpointPage.CustomHttpHeaders);
-            Assert.IsFalse(endpointPage.IncludeWebProxy);
-            Assert.IsNull(endpointPage.WebProxyHost);
-            Assert.IsFalse(endpointPage.IncludeWebProxyNetworkCredentials);
-            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsDomain);
-            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsUsername);
-            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsPassword);
+            Assert.Equal(Constants.DefaultServiceName, endpointPage.ServiceName);
+            Assert.Null(endpointPage.Endpoint);
+            Assert.Null(endpointPage.EdmxVersion);
+            Assert.False(endpointPage.IncludeCustomHeaders);
+            Assert.Null(endpointPage.CustomHttpHeaders);
+            Assert.False(endpointPage.IncludeWebProxy);
+            Assert.Null(endpointPage.WebProxyHost);
+            Assert.False(endpointPage.IncludeWebProxyNetworkCredentials);
+            Assert.Null(endpointPage.WebProxyNetworkCredentialsDomain);
+            Assert.Null(endpointPage.WebProxyNetworkCredentialsUsername);
+            Assert.Null(endpointPage.WebProxyNetworkCredentialsPassword);
 
             var operationsPage = wizard.OperationImportsViewModel;
             endpointPage.Endpoint = MetadataPath;
@@ -145,19 +153,19 @@ namespace ODataConnectedService.Tests
 
             var advancedPage = wizard.AdvancedSettingsViewModel;
             advancedPage.OnPageEnteringAsync(new WizardEnteringArgs(typesPage)).Wait();
-            Assert.AreEqual(Constants.DefaultReferenceFileName, advancedPage.GeneratedFileNamePrefix);
-            Assert.IsFalse(advancedPage.UseNamespacePrefix);
-            Assert.AreEqual(Constants.DefaultReferenceFileName, advancedPage.NamespacePrefix);
-            Assert.IsFalse(advancedPage.UseDataServiceCollection);
-            Assert.IsFalse(advancedPage.EnableNamingAlias);
-            Assert.IsFalse(advancedPage.OpenGeneratedFilesInIDE);
-            Assert.IsFalse(advancedPage.IncludeT4File);
-            Assert.IsFalse(advancedPage.GenerateMultipleFiles);
-            Assert.IsFalse(advancedPage.IgnoreUnexpectedElementsAndAttributes);
-            Assert.IsFalse(advancedPage.MakeTypesInternal);
+            Assert.Equal(Constants.DefaultReferenceFileName, advancedPage.GeneratedFileNamePrefix);
+            Assert.False(advancedPage.UseNamespacePrefix);
+            Assert.Equal(Constants.DefaultReferenceFileName, advancedPage.NamespacePrefix);
+            Assert.False(advancedPage.UseDataServiceCollection);
+            Assert.False(advancedPage.EnableNamingAlias);
+            Assert.False(advancedPage.OpenGeneratedFilesInIDE);
+            Assert.False(advancedPage.IncludeT4File);
+            Assert.False(advancedPage.GenerateMultipleFiles);
+            Assert.False(advancedPage.IgnoreUnexpectedElementsAndAttributes);
+            Assert.False(advancedPage.MakeTypesInternal);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestConstructor_LoadsSavedConfigWhenUpdating()
         {
             var savedConfig = GetTestConfig();
@@ -165,21 +173,21 @@ namespace ODataConnectedService.Tests
 
             var wizard = new ODataConnectedServiceWizard(context);
 
-            Assert.AreEqual(savedConfig, wizard.ServiceConfig);
+            Assert.Equal(savedConfig, wizard.ServiceConfig);
 
             var endpointPage = wizard.ConfigODataEndpointViewModel;
             endpointPage.OnPageEnteringAsync(new WizardEnteringArgs(null)).Wait();
-            Assert.AreEqual("https://service/$metadata", endpointPage.Endpoint);
-            Assert.AreEqual("MyService", endpointPage.ServiceName);
-            Assert.IsTrue(endpointPage.IncludeCustomHeaders);
-            Assert.AreEqual("Key1:Val1\nKey2:Val2", endpointPage.CustomHttpHeaders);
-            Assert.IsTrue(endpointPage.IncludeWebProxy);
-            Assert.AreEqual("http://localhost:8080", endpointPage.WebProxyHost);
-            Assert.IsTrue(endpointPage.IncludeWebProxyNetworkCredentials);
-            Assert.AreEqual("domain", endpointPage.WebProxyNetworkCredentialsDomain);
+            Assert.Equal("https://service/$metadata", endpointPage.Endpoint);
+            Assert.Equal("MyService", endpointPage.ServiceName);
+            Assert.True(endpointPage.IncludeCustomHeaders);
+            Assert.Equal("Key1:Val1\nKey2:Val2", endpointPage.CustomHttpHeaders);
+            Assert.True(endpointPage.IncludeWebProxy);
+            Assert.Equal("http://localhost:8080", endpointPage.WebProxyHost);
+            Assert.True(endpointPage.IncludeWebProxyNetworkCredentials);
+            Assert.Equal("domain", endpointPage.WebProxyNetworkCredentialsDomain);
             // username and password are not restored from the config
-            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsUsername);
-            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsPassword);
+            Assert.Null(endpointPage.WebProxyNetworkCredentialsUsername);
+            Assert.Null(endpointPage.WebProxyNetworkCredentialsPassword);
 
             var operationsPage = wizard.OperationImportsViewModel;
             endpointPage.MetadataTempPath = MetadataPath;
@@ -209,19 +217,19 @@ namespace ODataConnectedService.Tests
 
             var advancedPage = wizard.AdvancedSettingsViewModel;
             advancedPage.OnPageEnteringAsync(new WizardEnteringArgs(typesPage)).Wait();
-            Assert.AreEqual("GeneratedCode", advancedPage.GeneratedFileNamePrefix);
-            Assert.IsTrue(advancedPage.UseNamespacePrefix);
-            Assert.AreEqual("Namespace", advancedPage.NamespacePrefix);
-            Assert.IsTrue(advancedPage.UseDataServiceCollection);
-            Assert.IsTrue(advancedPage.EnableNamingAlias);
-            Assert.IsTrue(advancedPage.OpenGeneratedFilesInIDE);
-            Assert.IsTrue(advancedPage.IncludeT4File);
-            Assert.IsTrue(advancedPage.GenerateMultipleFiles);
-            Assert.IsTrue(advancedPage.IgnoreUnexpectedElementsAndAttributes);
-            Assert.IsTrue(advancedPage.MakeTypesInternal);
+            Assert.Equal("GeneratedCode", advancedPage.GeneratedFileNamePrefix);
+            Assert.True(advancedPage.UseNamespacePrefix);
+            Assert.Equal("Namespace", advancedPage.NamespacePrefix);
+            Assert.True(advancedPage.UseDataServiceCollection);
+            Assert.True(advancedPage.EnableNamingAlias);
+            Assert.True(advancedPage.OpenGeneratedFilesInIDE);
+            Assert.True(advancedPage.IncludeT4File);
+            Assert.True(advancedPage.GenerateMultipleFiles);
+            Assert.True(advancedPage.IgnoreUnexpectedElementsAndAttributes);
+            Assert.True(advancedPage.MakeTypesInternal);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestDisableReaOonlyFieldsWhenUpdating()
         {
             ServiceConfigurationV4 savedConfig = GetTestConfig();
@@ -233,24 +241,24 @@ namespace ODataConnectedService.Tests
             endpointPage.OnPageEnteringAsync(new WizardEnteringArgs(null)).Wait();
             var endpointView = endpointPage.View as ConfigODataEndpoint;
 
-            Assert.IsFalse(endpointView.ServiceName.IsEnabled);
-            Assert.IsFalse(endpointView.Endpoint.IsEnabled);
-            Assert.IsFalse(endpointView.OpenConnectedServiceJsonFileButton.IsEnabled);
+            Assert.False(endpointView.ServiceName.IsEnabled);
+            Assert.False(endpointView.Endpoint.IsEnabled);
+            Assert.False(endpointView.OpenConnectedServiceJsonFileButton.IsEnabled);
 
             // if endpoint is a http address, then file dialog should be disabled
             savedConfig.Endpoint = "http://service";
             endpointPage.OnPageEnteringAsync(null).Wait();
-            Assert.IsFalse(endpointView.OpenEndpointFileButton.IsEnabled);
+            Assert.False(endpointView.OpenEndpointFileButton.IsEnabled);
 
             // advanced settings page
             var advancedPage = wizard.AdvancedSettingsViewModel;
             advancedPage.OnPageEnteringAsync(new WizardEnteringArgs(endpointPage)).Wait();
             var advancedView = advancedPage.View as AdvancedSettings;
-            Assert.IsFalse(advancedView.IncludeT4File.IsEnabled);
-            Assert.IsFalse(advancedView.GenerateMultipleFiles.IsEnabled);
+            Assert.False(advancedView.IncludeT4File.IsEnabled);
+            Assert.False(advancedView.GenerateMultipleFiles.IsEnabled);
         }
 
-        [TestMethod]
+        [Fact]
         public void TestGetFinishedServiceInstanceAsync_SavesUserSettingsAndReturnsServiceInstanceWithConfigFromTheWizard()
         {
             var context = new TestConnectedServiceProviderContext(false);
@@ -311,16 +319,19 @@ namespace ODataConnectedService.Tests
 
             // saved user settings
             var settings = UserSettings.Load(null);
-            Assert.AreEqual("TestService", settings.ServiceName);
-            Assert.AreEqual(MetadataPath, settings.Endpoint);
-            Assert.AreEqual(true, settings.IncludeCustomHeaders);
-            Assert.AreEqual("Key:val", settings.CustomHttpHeaders);
-            Assert.AreEqual(true, settings.IncludeWebProxy);
-            Assert.AreEqual("http://localhost:8080", settings.WebProxyHost);
-            Assert.AreEqual(true, settings.IncludeWebProxyNetworkCredentials);
-            Assert.AreEqual("domain", settings.WebProxyNetworkCredentialsDomain);
-            Assert.AreEqual("user", settings.WebProxyNetworkCredentialsUsername);
-            Assert.AreEqual("pass", settings.WebProxyNetworkCredentialsPassword);
+            Assert.Equal("TestService", settings.ServiceName);
+            Assert.Equal(MetadataPath, settings.Endpoint);
+            // moves endpoint to top of mru list
+            Assert.Equal(MetadataPath, settings.MruEndpoints.First());
+            Assert.Equal(1, settings.MruEndpoints.Count(e => e == MetadataPath));
+            Assert.True(settings.IncludeCustomHeaders);
+            Assert.Equal("Key:val", settings.CustomHttpHeaders);
+            Assert.True(settings.IncludeWebProxy);
+            Assert.Equal("http://localhost:8080", settings.WebProxyHost);
+            Assert.True(settings.IncludeWebProxyNetworkCredentials);
+            Assert.Equal("domain", settings.WebProxyNetworkCredentialsDomain);
+            Assert.Equal("user", settings.WebProxyNetworkCredentialsUsername);
+            Assert.Equal("pass", settings.WebProxyNetworkCredentialsPassword);
             settings.ExcludedOperationImports.ShouldBeEquivalentTo(new List<string>() { "GetNearestAirport", "ResetDataSource" });
             settings.ExcludedSchemaTypes.ShouldBeEquivalentTo(new List<string>()
             {
@@ -328,31 +339,31 @@ namespace ODataConnectedService.Tests
                 "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport",
                 "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
             });
-            Assert.AreEqual("GeneratedFile", config.GeneratedFileNamePrefix);
-            Assert.AreEqual(true, config.UseNamespacePrefix);
-            Assert.AreEqual("TestNamespace", settings.NamespacePrefix);
-            Assert.AreEqual(true, settings.EnableNamingAlias);
-            Assert.AreEqual(true, settings.MakeTypesInternal);
-            Assert.AreEqual(true, settings.IncludeT4File);
-            Assert.AreEqual(true, settings.GenerateMultipleFiles);
-            Assert.AreEqual(true, settings.OpenGeneratedFilesInIDE);
+            Assert.Equal("GeneratedFile", config.GeneratedFileNamePrefix);
+            Assert.True(config.UseNamespacePrefix);
+            Assert.Equal("TestNamespace", settings.NamespacePrefix);
+            Assert.True(settings.EnableNamingAlias);
+            Assert.True(settings.MakeTypesInternal);
+            Assert.True(settings.IncludeT4File);
+            Assert.True(settings.GenerateMultipleFiles);
+            Assert.True(settings.OpenGeneratedFilesInIDE);
 
 
             // service configuration created
-            Assert.AreEqual("GeneratedFile", serviceInstance.InstanceId);
-            Assert.AreEqual("TestService", serviceInstance.Name);
-            Assert.AreEqual(endpointPage.MetadataTempPath, serviceInstance.MetadataTempFilePath);
-            Assert.AreEqual("TestService", config.ServiceName);
-            Assert.AreEqual(MetadataPath, config.Endpoint);
-            Assert.AreEqual(Constants.EdmxVersion4, config.EdmxVersion);
-            Assert.AreEqual(true, config.IncludeCustomHeaders);
-            Assert.AreEqual("Key:val", config.CustomHttpHeaders);
-            Assert.AreEqual(true, config.IncludeWebProxy);
-            Assert.AreEqual("http://localhost:8080", config.WebProxyHost);
-            Assert.AreEqual(true, config.IncludeWebProxyNetworkCredentials);
-            Assert.AreEqual("domain", config.WebProxyNetworkCredentialsDomain);
-            Assert.AreEqual("user", config.WebProxyNetworkCredentialsUsername);
-            Assert.AreEqual("pass", config.WebProxyNetworkCredentialsPassword);
+            Assert.Equal("GeneratedFile", serviceInstance.InstanceId);
+            Assert.Equal("TestService", serviceInstance.Name);
+            Assert.Equal(endpointPage.MetadataTempPath, serviceInstance.MetadataTempFilePath);
+            Assert.Equal("TestService", config.ServiceName);
+            Assert.Equal(MetadataPath, config.Endpoint);
+            Assert.Equal(Constants.EdmxVersion4, config.EdmxVersion);
+            Assert.True(config.IncludeCustomHeaders);
+            Assert.Equal("Key:val", config.CustomHttpHeaders);
+            Assert.True(config.IncludeWebProxy);
+            Assert.Equal("http://localhost:8080", config.WebProxyHost);
+            Assert.True(config.IncludeWebProxyNetworkCredentials);
+            Assert.Equal("domain", config.WebProxyNetworkCredentialsDomain);
+            Assert.Equal("user", config.WebProxyNetworkCredentialsUsername);
+            Assert.Equal("pass", config.WebProxyNetworkCredentialsPassword);
             config.ExcludedOperationImports.ShouldBeEquivalentTo(new List<string>() { "GetNearestAirport", "ResetDataSource" });
             config.ExcludedSchemaTypes.ShouldBeEquivalentTo(new List<string>()
             {
@@ -360,17 +371,17 @@ namespace ODataConnectedService.Tests
                 "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport",
                 "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee"
             });
-            Assert.AreEqual("GeneratedFile", config.GeneratedFileNamePrefix);
-            Assert.AreEqual(true, config.UseNamespacePrefix);
-            Assert.AreEqual("TestNamespace", config.NamespacePrefix);
-            Assert.AreEqual(true, config.EnableNamingAlias);
-            Assert.AreEqual(true, config.MakeTypesInternal);
-            Assert.AreEqual(true, config.IncludeT4File);
-            Assert.AreEqual(true, config.GenerateMultipleFiles);
-            Assert.AreEqual(true, config.OpenGeneratedFilesInIDE);
+            Assert.Equal("GeneratedFile", config.GeneratedFileNamePrefix);
+            Assert.True(config.UseNamespacePrefix);
+            Assert.Equal("TestNamespace", config.NamespacePrefix);
+            Assert.True(config.EnableNamingAlias);
+            Assert.True(config.MakeTypesInternal);
+            Assert.True(config.IncludeT4File);
+            Assert.True(config.GenerateMultipleFiles);
+            Assert.True(config.OpenGeneratedFilesInIDE);
         }
 
-        [TestMethod]
+        [Fact]
         public void GetFinishedServiceInstanceAsync_WhenUpdating_ShouldUseSavedConfigWhenUserDoesNotVisitPages()
         {
             var savedConfig = GetTestConfig();
@@ -384,20 +395,20 @@ namespace ODataConnectedService.Tests
             var serviceInstance = wizard.GetFinishedServiceInstanceAsync().Result as ODataConnectedServiceInstance;
             var config = serviceInstance.ServiceConfig as ServiceConfigurationV4;
 
-            Assert.AreEqual("GeneratedCode", serviceInstance.InstanceId);
-            Assert.AreEqual("MyService", serviceInstance.Name);
-            Assert.IsNotNull(serviceInstance.MetadataTempFilePath);
-            Assert.AreEqual("MyService", config.ServiceName);
-            Assert.AreEqual(MetadataPath, config.Endpoint);
-            Assert.AreEqual(Constants.EdmxVersion4, config.EdmxVersion);
-            Assert.AreEqual(true, config.IncludeCustomHeaders);
-            Assert.AreEqual("Key1:Val1\nKey2:Val2", config.CustomHttpHeaders);
-            Assert.AreEqual(true, config.IncludeWebProxy);
-            Assert.AreEqual("http://localhost:8080", config.WebProxyHost);
-            Assert.AreEqual(true, config.IncludeWebProxyNetworkCredentials);
-            Assert.AreEqual("domain", config.WebProxyNetworkCredentialsDomain);
-            Assert.AreEqual(null, config.WebProxyNetworkCredentialsUsername);
-            Assert.AreEqual(null, config.WebProxyNetworkCredentialsPassword);
+            Assert.Equal("GeneratedCode", serviceInstance.InstanceId);
+            Assert.Equal("MyService", serviceInstance.Name);
+            Assert.NotNull(serviceInstance.MetadataTempFilePath);
+            Assert.Equal("MyService", config.ServiceName);
+            Assert.Equal(MetadataPath, config.Endpoint);
+            Assert.Equal(Constants.EdmxVersion4, config.EdmxVersion);
+            Assert.True(config.IncludeCustomHeaders);
+            Assert.Equal("Key1:Val1\nKey2:Val2", config.CustomHttpHeaders);
+            Assert.True(config.IncludeWebProxy);
+            Assert.Equal("http://localhost:8080", config.WebProxyHost);
+            Assert.True(config.IncludeWebProxyNetworkCredentials);
+            Assert.Equal("domain", config.WebProxyNetworkCredentialsDomain);
+            Assert.Null(config.WebProxyNetworkCredentialsUsername);
+            Assert.Null(config.WebProxyNetworkCredentialsPassword);
             config.ExcludedOperationImports.ShouldBeEquivalentTo(new List<string>() { "GetPersonWithMostFriends", "ResetDataSource" });
             config.ExcludedSchemaTypes.ShouldBeEquivalentTo(new List<string>()
             {
@@ -405,17 +416,17 @@ namespace ODataConnectedService.Tests
                 "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person",
                 "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"
             });
-            Assert.AreEqual("GeneratedCode", config.GeneratedFileNamePrefix);
-            Assert.AreEqual(true, config.UseNamespacePrefix);
-            Assert.AreEqual("Namespace", config.NamespacePrefix);
-            Assert.AreEqual(true, config.EnableNamingAlias);
-            Assert.AreEqual(true, config.MakeTypesInternal);
-            Assert.AreEqual(true, config.IncludeT4File);
-            Assert.AreEqual(true, config.GenerateMultipleFiles);
-            Assert.AreEqual(true, config.OpenGeneratedFilesInIDE);
+            Assert.Equal("GeneratedCode", config.GeneratedFileNamePrefix);
+            Assert.True(config.UseNamespacePrefix);
+            Assert.Equal("Namespace", config.NamespacePrefix);
+            Assert.True(config.EnableNamingAlias);
+            Assert.True(config.MakeTypesInternal);
+            Assert.True(config.IncludeT4File);
+            Assert.True(config.GenerateMultipleFiles);
+            Assert.True(config.OpenGeneratedFilesInIDE);
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldPreserveState_WhenMovingBetweenPagesAndBack()
         {
             var context = new TestConnectedServiceProviderContext();
@@ -446,17 +457,17 @@ namespace ODataConnectedService.Tests
             advancedPage.OnPageLeavingAsync(null).Wait();
 
             endpointPage.OnPageEnteringAsync(null).Wait();
-            Assert.AreEqual(Constants.DefaultServiceName, endpointPage.ServiceName);
-            Assert.AreEqual(MetadataPath, endpointPage.Endpoint);
+            Assert.Equal(Constants.DefaultServiceName, endpointPage.ServiceName);
+            Assert.Equal(MetadataPath, endpointPage.Endpoint);
             endpointPage.ServiceName = "Service";
             endpointPage.IncludeCustomHeaders = true;
             endpointPage.CustomHttpHeaders = "A:b";
             endpointPage.OnPageLeavingAsync(null).Wait();
 
             advancedPage.OnPageEnteringAsync(null).Wait();
-            Assert.IsTrue(advancedPage.UseNamespacePrefix);
-            Assert.IsTrue(advancedPage.UseDataServiceCollection);
-            Assert.IsTrue(advancedPage.MakeTypesInternal);
+            Assert.True(advancedPage.UseNamespacePrefix);
+            Assert.True(advancedPage.UseDataServiceCollection);
+            Assert.True(advancedPage.MakeTypesInternal);
             advancedPage.NamespacePrefix = "MyNamespace";
             advancedPage.GenerateMultipleFiles = true;
             advancedPage.UseDataServiceCollection = false;
@@ -464,14 +475,14 @@ namespace ODataConnectedService.Tests
 
             operationsPage.OnPageEnteringAsync(null).Wait();
             operationNearestAirport = operationsPage.OperationImports.FirstOrDefault(o => o.Name == "GetNearestAirport");
-            Assert.IsFalse(operationNearestAirport.IsSelected);
+            Assert.False(operationNearestAirport.IsSelected);
             var operationResetDataSource = operationsPage.OperationImports.FirstOrDefault(o => o.Name == "ResetDataSource");
             operationResetDataSource.IsSelected = false;
             operationsPage.OnPageLeavingAsync(null).Wait();
 
             typesPage.OnPageEnteringAsync(null).Wait();
             typeEmployee = typesPage.SchemaTypes.FirstOrDefault(t => t.ShortName == "Employee");
-            Assert.IsFalse(typeEmployee.IsSelected);
+            Assert.False(typeEmployee.IsSelected);
             typeEmployee.IsSelected = true;
             var typeFlight = typesPage.SchemaTypes.FirstOrDefault(t => t.ShortName == "Flight");
             typeFlight.IsSelected = false;
@@ -480,15 +491,15 @@ namespace ODataConnectedService.Tests
             var serviceInstance = wizard.GetFinishedServiceInstanceAsync().Result as ODataConnectedServiceInstance;
             var config = serviceInstance.ServiceConfig as ServiceConfigurationV4;
 
-            Assert.AreEqual("Service", config.ServiceName);
-            Assert.AreEqual(MetadataPath, config.Endpoint);
-            Assert.IsTrue(config.IncludeCustomHeaders);
-            Assert.AreEqual("A:b", config.CustomHttpHeaders);
-            Assert.IsTrue(config.GenerateMultipleFiles);
-            Assert.IsTrue(config.MakeTypesInternal);
-            Assert.IsTrue(config.UseNamespacePrefix);
-            Assert.AreEqual("MyNamespace", config.NamespacePrefix);
-            Assert.IsFalse(config.UseDataServiceCollection);
+            Assert.Equal("Service", config.ServiceName);
+            Assert.Equal(MetadataPath, config.Endpoint);
+            Assert.True(config.IncludeCustomHeaders);
+            Assert.Equal("A:b", config.CustomHttpHeaders);
+            Assert.True(config.GenerateMultipleFiles);
+            Assert.True(config.MakeTypesInternal);
+            Assert.True(config.UseNamespacePrefix);
+            Assert.Equal("MyNamespace", config.NamespacePrefix);
+            Assert.False(config.UseDataServiceCollection);
             config.ExcludedOperationImports.ShouldAllBeEquivalentTo(new List<string>()
             {
                 "GetNearestAirport",
@@ -500,7 +511,7 @@ namespace ODataConnectedService.Tests
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void ShouldReloadOperationsAndTypesForNewEndpoint_WhenEndpointIsChangedBeforeFinishing()
         {
             var context = new TestConnectedServiceProviderContext();
@@ -546,12 +557,12 @@ namespace ODataConnectedService.Tests
             var serviceInstance = wizard.GetFinishedServiceInstanceAsync().Result as ODataConnectedServiceInstance;
             var config = serviceInstance.ServiceConfig as ServiceConfigurationV4;
 
-            Assert.AreEqual(MetadataPathSimple, config.Endpoint);
+            Assert.Equal(MetadataPathSimple, config.Endpoint);
             config.ExcludedOperationImports.ShouldBeEquivalentTo(new List<string>() { "ResetThings" });
             config.ExcludedSchemaTypes.ShouldBeEquivalentTo(new List<string>() { "SimpleService.Models.OtherThing" });
         }
 
-        [TestMethod]
+        [Fact]
         public void UnsupportedFeaturesAreDisabledOrHidden_WhenServiceIsV3OrLess()
         {
             var context = new TestConnectedServiceProviderContext();
@@ -559,18 +570,31 @@ namespace ODataConnectedService.Tests
             var endpointPage = wizard.ConfigODataEndpointViewModel;
             endpointPage.Endpoint = MetadataPathV3;
             endpointPage.OnPageLeavingAsync(null).Wait();
-            Assert.AreEqual(Constants.EdmxVersion1, endpointPage.EdmxVersion);
+            Assert.Equal(Constants.EdmxVersion1, endpointPage.EdmxVersion);
 
             var operationsPage = wizard.OperationImportsViewModel;
             operationsPage.OnPageEnteringAsync(null).Wait();
-            Assert.IsFalse(operationsPage.View.IsEnabled);
-            Assert.IsFalse(operationsPage.IsSupportedODataVersion);
+            Assert.False(operationsPage.View.IsEnabled);
+            Assert.False(operationsPage.IsSupportedODataVersion);
 
             var advancedPage = wizard.AdvancedSettingsViewModel;
             advancedPage.OnPageEnteringAsync(null).Wait();
             var advancedView = advancedPage.View as AdvancedSettings;
             advancedView.settings.RaiseEvent(new RoutedEventArgs(Hyperlink.ClickEvent));
-            Assert.AreEqual(advancedView.AdvancedSettingsForv4.Visibility, Visibility.Hidden);
+            Assert.Equal(Visibility.Hidden, advancedView.AdvancedSettingsForv4.Visibility);
+        }
+    }
+
+    internal class OperationImportModelComparer : IEqualityComparer<OperationImportModel>
+    {
+        public bool Equals(OperationImportModel x, OperationImportModel y)
+        {
+            return x.Name == y.Name && x.IsSelected == y.IsSelected;
+        }
+
+        public int GetHashCode(OperationImportModel obj)
+        {
+            return obj.Name.GetHashCode();
         }
     }
 

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.ConnectedServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.OData.ConnectedService;
+using System.ComponentModel;
+using Microsoft.OData.ConnectedService.Models;
+using FluentAssertions;
+using Microsoft.OData.ConnectedService.Common;
+using Microsoft.OData.ConnectedService.Views;
+
+namespace ODataConnectedService.Tests
+{
+    [TestClass]
+    public class ODataConnectedServiceWizardTests
+    {
+
+        private ServiceConfigurationV4 GetTestConfig()
+        {
+            return new ServiceConfigurationV4()
+            {
+                Endpoint = "https://service/$metadata",
+                EdmxVersion = Constants.EdmxVersion4,
+                ServiceName = "MyService",
+                IncludeCustomHeaders = true,
+                CustomHttpHeaders = "Key1:Val1\nKey2:Val2",
+                IncludeWebProxy = true,
+                WebProxyHost = "http://localhost:8080",
+                IncludeWebProxyNetworkCredentials = true,
+                WebProxyNetworkCredentialsDomain = "domain",
+                WebProxyNetworkCredentialsUsername = "username",
+                WebProxyNetworkCredentialsPassword = "password",
+                UseDataServiceCollection = true,
+                GenerateMultipleFiles = true,
+                UseNamespacePrefix = true,
+                NamespacePrefix = "Namespace",
+                GeneratedFileNamePrefix = "GeneratedCode",
+                EnableNamingAlias = true,
+                OpenGeneratedFilesInIDE = true,
+                MakeTypesInternal = true,
+                IgnoreUnexpectedElementsAndAttributes = true,
+                IncludeT4File = true
+            };
+        }
+
+        [TestMethod]
+        public void TestConstructor_ShouldUseDefaultSettingsWhenNotUpdating()
+        {
+            var savedConfig = GetTestConfig();
+            var context = new TestConnectedServiceProviderContext(false, savedConfig);
+
+            var wizard = new ODataConnectedServiceWizard(context);
+
+            var endpointPage = wizard.ConfigODataEndpointViewModel;
+            endpointPage.OnPageEnteringAsync(new WizardEnteringArgs(null)).Wait();
+            Assert.AreEqual(Constants.DefaultServiceName, endpointPage.ServiceName);
+            Assert.IsNull(endpointPage.Endpoint);
+            Assert.IsNull(endpointPage.EdmxVersion);
+            Assert.IsFalse(endpointPage.IncludeCustomHeaders);
+            Assert.IsNull(endpointPage.CustomHttpHeaders);
+            Assert.IsFalse(endpointPage.IncludeWebProxy);
+            Assert.IsNull(endpointPage.WebProxyHost);
+            Assert.IsFalse(endpointPage.IncludeWebProxyNetworkCredentials);
+            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsDomain);
+            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsUsername);
+            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsPassword);
+
+            var advancedPage = wizard.AdvancedSettingsViewModel;
+            advancedPage.OnPageEnteringAsync(new WizardEnteringArgs(endpointPage)).Wait();
+            Assert.AreEqual(Constants.DefaultReferenceFileName, advancedPage.GeneratedFileNamePrefix);
+            Assert.IsFalse(advancedPage.UseNamespacePrefix);
+            Assert.AreEqual(Constants.DefaultReferenceFileName, advancedPage.NamespacePrefix);
+            Assert.IsFalse(advancedPage.UseDataServiceCollection);
+            Assert.IsFalse(advancedPage.EnableNamingAlias);
+            Assert.IsFalse(advancedPage.OpenGeneratedFilesInIDE);
+            Assert.IsFalse(advancedPage.IncludeT4File);
+            Assert.IsFalse(advancedPage.GenerateMultipleFiles);
+            Assert.IsFalse(advancedPage.IgnoreUnexpectedElementsAndAttributes);
+            Assert.IsFalse(advancedPage.MakeTypesInternal);
+        }
+
+        [TestMethod]
+        public void TestConstructor_LoadsSavedConfigWhenUpdating()
+        {
+            var savedConfig = GetTestConfig();
+            var context = new TestConnectedServiceProviderContext(true, savedConfig);
+
+            var wizard = new ODataConnectedServiceWizard(context);
+
+            Assert.AreEqual(savedConfig, wizard.ServiceConfig);
+
+            var endpointPage = wizard.ConfigODataEndpointViewModel;
+            endpointPage.OnPageEnteringAsync(new WizardEnteringArgs(null)).Wait();
+            Assert.AreEqual("https://service/$metadata", endpointPage.Endpoint);
+            Assert.AreEqual("MyService", endpointPage.ServiceName);
+            Assert.IsTrue(endpointPage.IncludeCustomHeaders);
+            Assert.AreEqual("Key1:Val1\nKey2:Val2", endpointPage.CustomHttpHeaders);
+            Assert.IsTrue(endpointPage.IncludeWebProxy);
+            Assert.AreEqual("http://localhost:8080", endpointPage.WebProxyHost);
+            Assert.IsTrue(endpointPage.IncludeWebProxyNetworkCredentials);
+            Assert.AreEqual("domain", endpointPage.WebProxyNetworkCredentialsDomain);
+            // username and password are not restored from the config
+            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsUsername);
+            Assert.IsNull(endpointPage.WebProxyNetworkCredentialsPassword);
+
+            var advancedPage = wizard.AdvancedSettingsViewModel;
+            advancedPage.OnPageEnteringAsync(new WizardEnteringArgs(endpointPage)).Wait();
+            Assert.AreEqual("GeneratedCode", advancedPage.GeneratedFileNamePrefix);
+            Assert.IsTrue(advancedPage.UseNamespacePrefix);
+            Assert.AreEqual("Namespace", advancedPage.NamespacePrefix);
+            Assert.IsTrue(advancedPage.UseDataServiceCollection);
+            Assert.IsTrue(advancedPage.EnableNamingAlias);
+            Assert.IsTrue(advancedPage.OpenGeneratedFilesInIDE);
+            Assert.IsTrue(advancedPage.IncludeT4File);
+            Assert.IsTrue(advancedPage.GenerateMultipleFiles);
+            Assert.IsTrue(advancedPage.IgnoreUnexpectedElementsAndAttributes);
+            Assert.IsTrue(advancedPage.MakeTypesInternal);
+        }
+
+        [TestMethod]
+        public void TestDisableReaOonlyFieldsWhenUpdating()
+        {
+            ServiceConfigurationV4 savedConfig = GetTestConfig();
+            var context = new TestConnectedServiceProviderContext(true, savedConfig);
+            var wizard = new ODataConnectedServiceWizard(context);
+            
+            // endpoint page
+            var endpointPage = wizard.ConfigODataEndpointViewModel;
+            endpointPage.OnPageEnteringAsync(new WizardEnteringArgs(null)).Wait();
+            var endpointView = endpointPage.View as ConfigODataEndpoint;
+
+            Assert.IsFalse(endpointView.ServiceName.IsEnabled);
+            Assert.IsFalse(endpointView.Endpoint.IsEnabled);
+
+            // advanced settings page
+            var advancedPage = wizard.AdvancedSettingsViewModel;
+            advancedPage.OnPageEnteringAsync(new WizardEnteringArgs(endpointPage)).Wait();
+            var advancedView = advancedPage.View as AdvancedSettings;
+            Assert.IsFalse(advancedView.IncludeT4File.IsEnabled);
+            Assert.IsFalse(advancedView.GenerateMultipleFiles.IsEnabled);
+        }
+    }
+
+    internal class TestConnectedServiceProviderContext: ConnectedServiceProviderContext
+    {
+        ServiceConfigurationV4 savedData;
+
+        public TestConnectedServiceProviderContext(bool isUpdating = false, ServiceConfigurationV4 savedData = null) : base()
+        {
+            this.savedData = savedData;
+
+            if (isUpdating)
+            {
+                UpdateContext = new ConnectedServiceUpdateContext(new Version(), new TestVsHierarchyItem());
+            }
+        }
+
+        public override IDictionary<string, object> Args => throw new NotImplementedException();
+
+        public override XmlConfigHelper CreateReadOnlyXmlConfigHelper()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override TData GetExtendedDesignerData<TData>()
+        {
+            return savedData as TData;
+        }
+
+        public override Microsoft.VisualStudio.Shell.IVsHierarchyItem GetServiceFolder(string serviceFolderName)
+        {
+            return new TestVsHierarchyItem();
+        }
+
+        public override void InitializeUpdateContext(Microsoft.VisualStudio.Shell.IVsHierarchyItem serviceFolder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetExtendedDesignerData<TData>(TData data)
+        {
+            savedData = data as ServiceConfigurationV4;
+        }
+
+        public override IDisposable StartBusyIndicator(string message = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class TestVsHierarchyItem : IVsHierarchyItem
+    {
+        public IVsHierarchyItemIdentity HierarchyIdentity => throw new NotImplementedException();
+
+        public IVsHierarchyItem Parent => throw new NotImplementedException();
+
+        public IEnumerable<IVsHierarchyItem> Children => throw new NotImplementedException();
+
+        public bool AreChildrenRealized => throw new NotImplementedException();
+
+        public string Text => "Item";
+
+        public string CanonicalName => "CanonicalName";
+
+        public bool IsBold { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool IsCut { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public bool IsDisposed => false;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangingEventHandler PropertyChanging;
+    }
+
+    //public abstract class Test
+    //{
+    //    public abstract IVsHierarchyItem Stuff();
+    //}
+
+    //public class TestSub : Test
+    //{
+    //    public override IVsHierarchyItem Stuff()
+    //    {
+    //        return new TestVsHierarchyItem();
+    //    }
+    //}
+}

--- a/test/ODataConnectedService.Tests/Properties/AssemblyInfo.cs
+++ b/test/ODataConnectedService.Tests/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
+using ODataConnectedService.Tests;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
 [assembly: AssemblyTitle("ODataConnectedService.Tests")]
 [assembly: AssemblyDescription("")]
@@ -18,3 +20,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// disable pararellization to ensure tests don't touch UI code from background threads
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/test/ODataConnectedService.Tests/TestMetadataCsdl.xml
+++ b/test/ODataConnectedService.Tests/TestMetadataCsdl.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Microsoft.OData.Service.Sample.TrippinInMemory.Models">
+      <EntityType Name="Person">
+        <Key>
+          <PropertyRef Name="UserName"/>
+        </Key>
+        <Property Name="UserName" Nullable="false" Type="Edm.String"/>
+        <Property Name="Gender" Nullable="false" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender"/>
+        <Property Name="Age" Type="Edm.Int64"/>
+        <Property Name="HomeAddress" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location"/>
+        <NavigationProperty Name="Friends" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)"/>
+        <NavigationProperty Name="Trips" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)"/>
+      </EntityType>
+      <EntityType Name="Airline">
+        <Key>
+          <PropertyRef Name="AirlineCode"/>
+        </Key>
+        <Property Name="AirlineCode" Nullable="false" Type="Edm.String"/>
+        <Property Name="Name" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="Airport">
+        <Key>
+          <PropertyRef Name="IcaoCode"/>
+        </Key>
+        <Property Name="Name" Type="Edm.String"/>
+        <Property Name="IcaoCode" Nullable="false" Type="Edm.String"/>
+      </EntityType>
+      <ComplexType Name="Location">
+        <Property Name="Address" Type="Edm.String"/>
+        <Property Name="City" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.City"/>
+      </ComplexType>
+      <ComplexType Name="City">
+        <Property Name="Name" Type="Edm.String"/>
+      </ComplexType>
+      <EntityType Name="Trip">
+        <Key>
+          <PropertyRef Name="TripId"/>
+        </Key>
+        <Property Name="TripId" Nullable="false" Type="Edm.Int32"/>
+        <Property Name="Name" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="Flight" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.PublicTransportation">
+        <Property Name="FlightNumber" Type="Edm.String"/>
+        <NavigationProperty Name="Airline" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline"/>
+        <NavigationProperty Name="From" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"/>
+        <NavigationProperty Name="To" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"/>
+      </EntityType>
+      <EntityType Name="Employee" BaseType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+        <Property Name="Cost" Nullable="false" Type="Edm.Int64"/>
+        <NavigationProperty Name="Peers" Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person)"/>
+      </EntityType>
+      <EnumType Name="PersonGender">
+        <Member Name="Male" Value="0"/>
+        <Member Name="Female" Value="1"/>
+        <Member Name="Unknow" Value="2"/>
+      </EnumType>
+      <Function Name="GetPersonWithMostFriends">
+        <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"/>
+      </Function>
+      <Function Name="GetNearestAirport">
+        <Parameter Name="lat" Nullable="false" Type="Edm.Double"/>
+        <Parameter Name="lon" Nullable="false" Type="Edm.Double"/>
+        <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"/>
+      </Function>
+      <Action Name="ResetDataSource"/>
+      <EntityContainer Name="Container">
+        <EntitySet Name="People" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">
+          <NavigationPropertyBinding Target="People" Path="Friends"/>
+        </EntitySet>
+        <EntitySet Name="Airlines" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline" />
+        <EntitySet Name="Airports" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"/>
+        <Singleton Name="Me" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"/>
+        <FunctionImport Name="GetPersonWithMostFriends" EntitySet="People" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetPersonWithMostFriends"/>
+        <FunctionImport Name="GetNearestAirport" EntitySet="Airports" Function="Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetNearestAirport"/>
+        <ActionImport Name="ResetDataSource" Action="Microsoft.OData.Service.Sample.TrippinInMemory.Models.ResetDataSource"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/test/ODataConnectedService.Tests/TestMetadataCsdlSimple.xml
+++ b/test/ODataConnectedService.Tests/TestMetadataCsdlSimple.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SimpleService.Models">
+      <EntityType Name="Thing">
+        <Key>
+          <PropertyRef Name="Code"/>
+        </Key>
+        <Property Name="Code" Nullable="false" Type="Edm.String"/>
+        <Property Name="Name" Nullable="false" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="OtherThing">
+        <Key>
+          <PropertyRef Name="Code"/>
+        </Key>
+        <Property Name="Code" Nullable="false" Type="Edm.String"/>
+        <Property Name="Name" Nullable="false" Type="Edm.String"/>
+      </EntityType>
+      <Function Name="GetRandomThing">
+        <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Thing"/>
+      </Function>
+      <Action Name="ResetThings"/>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Things" EntityType="SimpleService.Models.Thing" />
+        <EntitySet Name="OtherThings" EntityType="SimpleService.Models.OtherThing" />
+        <FunctionImport Name="GetRandomThing" EntitySet="Airports" Function="SimpleService.Models.GetRandomThing"/>
+        <ActionImport Name="ResetThings" Action="SimpleService.Models.ResetThings"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/test/ODataConnectedService.Tests/TestMetadataCsdlV3.xml
+++ b/test/ODataConnectedService.Tests/TestMetadataCsdlV3.xml
@@ -1,0 +1,176 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx">
+  <edmx:DataServices m:DataServiceVersion="3.0" m:MaxDataServiceVersion="3.0" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata">
+    <Schema Namespace="ODataDemo" xmlns="http://schemas.microsoft.com/ado/2009/11/edm">
+      <EntityType Name="Product">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" m:FC_TargetPath="SyndicationTitle" m:FC_ContentKind="text" m:FC_KeepInContent="false" />
+        <Property Name="Description" Type="Edm.String" m:FC_TargetPath="SyndicationSummary" m:FC_ContentKind="text" m:FC_KeepInContent="false" />
+        <Property Name="ReleaseDate" Type="Edm.DateTime" Nullable="false" />
+        <Property Name="DiscontinuedDate" Type="Edm.DateTime" />
+        <Property Name="Rating" Type="Edm.Int16" Nullable="false" />
+        <Property Name="Price" Type="Edm.Double" Nullable="false" />
+        <NavigationProperty Name="Categories" Relationship="ODataDemo.Product_Categories_Category_Products" ToRole="Category_Products" FromRole="Product_Categories" />
+        <NavigationProperty Name="Supplier" Relationship="ODataDemo.Product_Supplier_Supplier_Products" ToRole="Supplier_Products" FromRole="Product_Supplier" />
+        <NavigationProperty Name="ProductDetail" Relationship="ODataDemo.Product_ProductDetail_ProductDetail_Product" ToRole="ProductDetail_Product" FromRole="Product_ProductDetail" />
+      </EntityType>
+      <EntityType Name="FeaturedProduct" BaseType="ODataDemo.Product">
+        <NavigationProperty Name="Advertisement" Relationship="ODataDemo.FeaturedProduct_Advertisement_Advertisement_FeaturedProduct" ToRole="Advertisement_FeaturedProduct" FromRole="FeaturedProduct_Advertisement" />
+      </EntityType>
+      <EntityType Name="ProductDetail">
+        <Key>
+          <PropertyRef Name="ProductID" />
+        </Key>
+        <Property Name="ProductID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Details" Type="Edm.String" />
+        <NavigationProperty Name="Product" Relationship="ODataDemo.Product_ProductDetail_ProductDetail_Product" ToRole="Product_ProductDetail" FromRole="ProductDetail_Product" />
+      </EntityType>
+      <EntityType Name="Category" OpenType="true">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" m:FC_TargetPath="SyndicationTitle" m:FC_ContentKind="text" m:FC_KeepInContent="true" />
+        <NavigationProperty Name="Products" Relationship="ODataDemo.Product_Categories_Category_Products" ToRole="Product_Categories" FromRole="Category_Products" />
+      </EntityType>
+      <EntityType Name="Supplier">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" m:FC_TargetPath="SyndicationTitle" m:FC_ContentKind="text" m:FC_KeepInContent="true" />
+        <Property Name="Address" Type="ODataDemo.Address" />
+        <Property Name="Location" Type="Edm.GeographyPoint" SRID="Variable" />
+        <Property Name="Concurrency" Type="Edm.Int32" ConcurrencyMode="Fixed" Nullable="false" />
+        <NavigationProperty Name="Products" Relationship="ODataDemo.Product_Supplier_Supplier_Products" ToRole="Product_Supplier" FromRole="Supplier_Products" />
+      </EntityType>
+      <ComplexType Name="Address">
+        <Property Name="Street" Type="Edm.String" />
+        <Property Name="City" Type="Edm.String" />
+        <Property Name="State" Type="Edm.String" />
+        <Property Name="ZipCode" Type="Edm.String" />
+        <Property Name="Country" Type="Edm.String" />
+      </ComplexType>
+      <EntityType Name="Person">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+        <NavigationProperty Name="PersonDetail" Relationship="ODataDemo.Person_PersonDetail_PersonDetail_Person" ToRole="PersonDetail_Person" FromRole="Person_PersonDetail" />
+      </EntityType>
+      <EntityType Name="Customer" BaseType="ODataDemo.Person">
+        <Property Name="TotalExpense" Type="Edm.Decimal" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Employee" BaseType="ODataDemo.Person">
+        <Property Name="EmployeeID" Type="Edm.Int64" Nullable="false" />
+        <Property Name="HireDate" Type="Edm.DateTime" Nullable="false" />
+        <Property Name="Salary" Type="Edm.Single" Nullable="false" />
+      </EntityType>
+      <EntityType Name="PersonDetail">
+        <Key>
+          <PropertyRef Name="PersonID" />
+        </Key>
+        <Property Name="PersonID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Age" Type="Edm.Byte" Nullable="false" />
+        <Property Name="Gender" Type="Edm.Boolean" Nullable="false" />
+        <Property Name="Phone" Type="Edm.String" />
+        <Property Name="Address" Type="ODataDemo.Address" />
+        <Property Name="Photo" Type="Edm.Stream" Nullable="false" />
+        <NavigationProperty Name="Person" Relationship="ODataDemo.Person_PersonDetail_PersonDetail_Person" ToRole="Person_PersonDetail" FromRole="PersonDetail_Person" />
+      </EntityType>
+      <EntityType Name="Advertisement" m:HasStream="true">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.Guid" Nullable="false" />
+        <Property Name="Name" Type="Edm.String" />
+        <Property Name="AirDate" Type="Edm.DateTime" Nullable="false" />
+        <NavigationProperty Name="FeaturedProduct" Relationship="ODataDemo.FeaturedProduct_Advertisement_Advertisement_FeaturedProduct" ToRole="FeaturedProduct_Advertisement" FromRole="Advertisement_FeaturedProduct" />
+      </EntityType>
+      <Association Name="Product_Categories_Category_Products">
+        <End Type="ODataDemo.Category" Role="Category_Products" Multiplicity="*" />
+        <End Type="ODataDemo.Product" Role="Product_Categories" Multiplicity="*" />
+      </Association>
+      <Association Name="Product_Supplier_Supplier_Products">
+        <End Type="ODataDemo.Supplier" Role="Supplier_Products" Multiplicity="0..1" />
+        <End Type="ODataDemo.Product" Role="Product_Supplier" Multiplicity="*" />
+      </Association>
+      <Association Name="Product_ProductDetail_ProductDetail_Product">
+        <End Type="ODataDemo.ProductDetail" Role="ProductDetail_Product" Multiplicity="0..1" />
+        <End Type="ODataDemo.Product" Role="Product_ProductDetail" Multiplicity="0..1" />
+      </Association>
+      <Association Name="FeaturedProduct_Advertisement_Advertisement_FeaturedProduct">
+        <End Type="ODataDemo.Advertisement" Role="Advertisement_FeaturedProduct" Multiplicity="0..1" />
+        <End Type="ODataDemo.FeaturedProduct" Role="FeaturedProduct_Advertisement" Multiplicity="0..1" />
+      </Association>
+      <Association Name="Person_PersonDetail_PersonDetail_Person">
+        <End Type="ODataDemo.PersonDetail" Role="PersonDetail_Person" Multiplicity="0..1" />
+        <End Type="ODataDemo.Person" Role="Person_PersonDetail" Multiplicity="0..1" />
+      </Association>
+      <EntityContainer Name="DemoService" m:IsDefaultEntityContainer="true">
+        <EntitySet Name="Products" EntityType="ODataDemo.Product" />
+        <EntitySet Name="ProductDetails" EntityType="ODataDemo.ProductDetail" />
+        <EntitySet Name="Categories" EntityType="ODataDemo.Category" />
+        <EntitySet Name="Suppliers" EntityType="ODataDemo.Supplier" />
+        <EntitySet Name="Persons" EntityType="ODataDemo.Person" />
+        <EntitySet Name="PersonDetails" EntityType="ODataDemo.PersonDetail" />
+        <EntitySet Name="Advertisements" EntityType="ODataDemo.Advertisement" />
+        <FunctionImport Name="GetProductsByRating" ReturnType="Collection(ODataDemo.Product)" EntitySet="Products" m:HttpMethod="GET">
+          <Parameter Name="rating" Type="Edm.Int16" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="Discount" ReturnType="Edm.Double" IsBindable="true" m:IsAlwaysBindable="true">
+          <Parameter Name="product" Type="ODataDemo.Product" />
+          <Parameter Name="discountPercentage" Type="Edm.Int32" Nullable="false" />
+        </FunctionImport>
+        <FunctionImport Name="IncreaseSalaries">
+          <Parameter Name="percentage" Type="Edm.Int32" Nullable="false" />
+        </FunctionImport>
+        <AssociationSet Name="Products_Advertisement_Advertisements" Association="ODataDemo.FeaturedProduct_Advertisement_Advertisement_FeaturedProduct">
+          <End Role="FeaturedProduct_Advertisement" EntitySet="Products" />
+          <End Role="Advertisement_FeaturedProduct" EntitySet="Advertisements" />
+        </AssociationSet>
+        <AssociationSet Name="Products_Categories_Categories" Association="ODataDemo.Product_Categories_Category_Products">
+          <End Role="Product_Categories" EntitySet="Products" />
+          <End Role="Category_Products" EntitySet="Categories" />
+        </AssociationSet>
+        <AssociationSet Name="Products_Supplier_Suppliers" Association="ODataDemo.Product_Supplier_Supplier_Products">
+          <End Role="Product_Supplier" EntitySet="Products" />
+          <End Role="Supplier_Products" EntitySet="Suppliers" />
+        </AssociationSet>
+        <AssociationSet Name="Products_ProductDetail_ProductDetails" Association="ODataDemo.Product_ProductDetail_ProductDetail_Product">
+          <End Role="Product_ProductDetail" EntitySet="Products" />
+          <End Role="ProductDetail_Product" EntitySet="ProductDetails" />
+        </AssociationSet>
+        <AssociationSet Name="Persons_PersonDetail_PersonDetails" Association="ODataDemo.Person_PersonDetail_PersonDetail_Person">
+          <End Role="Person_PersonDetail" EntitySet="Persons" />
+          <End Role="PersonDetail_Person" EntitySet="PersonDetails" />
+        </AssociationSet>
+      </EntityContainer>
+      <Annotations Target="ODataDemo.DemoService">
+        <ValueAnnotation Term="Org.OData.Display.V1.Description" String="This is a sample OData service with vocabularies" />
+      </Annotations>
+      <Annotations Target="ODataDemo.Product">
+        <ValueAnnotation Term="Org.OData.Display.V1.Description" String="All Products available in the online store" />
+      </Annotations>
+      <Annotations Target="ODataDemo.Product/Name">
+        <ValueAnnotation Term="Org.OData.Display.V1.DisplayName" String="Product Name" />
+      </Annotations>
+      <Annotations Target="ODataDemo.DemoService/Suppliers">
+        <ValueAnnotation Term="Org.OData.Publication.V1.PublisherName" String="Microsoft Corp." />
+        <ValueAnnotation Term="Org.OData.Publication.V1.PublisherId" String="MSFT" />
+        <ValueAnnotation Term="Org.OData.Publication.V1.Keywords" String="Inventory, Supplier, Advertisers, Sales, Finance" />
+        <ValueAnnotation Term="Org.OData.Publication.V1.AttributionUrl" String="http://www.odata.org/" />
+        <ValueAnnotation Term="Org.OData.Publication.V1.AttributionDescription" String="All rights reserved" />
+        <ValueAnnotation Term="Org.OData.Publication.V1.DocumentationUrl " String="http://www.odata.org/" />
+        <ValueAnnotation Term="Org.OData.Publication.V1.TermsOfUseUrl" String="All rights reserved" />
+        <ValueAnnotation Term="Org.OData.Publication.V1.PrivacyPolicyUrl" String="http://www.odata.org/" />
+        <ValueAnnotation Term="Org.OData.Publication.V1.LastModified" String="4/2/2013" />
+        <ValueAnnotation Term="Org.OData.Publication.V1.ImageUrl " String="http://www.odata.org/" />
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
Addresses #59 

Tests the following functionality:

- [x] user settings are loaded when the wizard is created
- [x] When the service is being updated, it should load saved config from `GetExtendedDesignerData()`
and use it to populate the view models accordingly. Test that the right fields are set to the view
models based on the saved config
- [x] Some fields should not be modified after code generation. When the connected service is updating,
ensure that these fields are disabled (e.g. T4 templates, Service Name, Service Endpoint, Generate multiple files, etc.)
- [x] `CreateServiceConfiguration()` returns a `ServiceConfiguration` instance with values corresponding to fields
in the view models.
- [x] `GetFinishedServiceInstanceAsync()` saves user settings, creates a service instance based on the view models values
and service config, and returns that. The result of this method will be passed to the `ODataConnectedServiceHandler` so
testing this is critical in ensuring that values will be correctly propagated to the handler
- [x] when entering the schema types page, the page is populated with all schema types from the edm, and they're initially all selected
- [x] When entering the operation imports page, the page is populated with operation imports from the edm and they're initial all selected
- [x] the state of each page is persisted when the user navigates between pages and back
- [x] the state of each page is persisted between page switches even during updating
- [x] when the user goes back to change the endpoint, the schema types and operation imports page should be repopulated with data from the new model
- [x] when updating a connected service, if the user clicks the finish button without visiting all the pages, the saved config should still be applied to the updated connected service
- [x] unsupported features should be hidden or disabled when using a V3 service

- I also fixed this bug (which I discovered because it caused some tests to fail): #120 
- **Note** These tests set and reset user settings multiple times. This functionality is not mocked, and it does at least affect the settings in the experimental VS instance (i.e. if you run the tests, you might find that your list of recently used endpoints has been cleared).

I didn't a test for the following item in the original issue's list:
- Some fields should only be saved to config (and loaded from saved config) when connected to a V4 endpoint
because `ServiceConfiguration` base class is used for lower versions, and that class should (ideally) not have the V4 properties. Also, it doesn't appear that there would be any problem in having v4 properties on a v3 service config, since they'd just be ignored.