### PR TITLE
Adding test cases for ConfigODataEndPointViewModel Class

### DIFF
--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -39,6 +39,7 @@ namespace Microsoft.OData.ConnectedService.Common
         public const string DefaultServiceName = "OData Service";
 
         public const string SchemaTypesWillAutomaticallyBeIncluded = "type(s) will automatically be included to ensure the generated code compiles successfully.";
+        public const string InputServiceEndpointMsg = "Please input the service endpoint";
         public const string CsdlFileName = "Csdl.xml";
 
         public static string[] V3NuGetPackages = {

--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -107,6 +107,11 @@ namespace Microsoft.OData.ConnectedService.Models
 
         public static void AddToTopOfMruList<T>(ObservableCollection<T> mruList, T item)
         {
+            if (mruList == null)
+            {
+                return;
+            }
+
             var index = mruList.IndexOf(item);
             if (index >= 0)
             {

--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -44,10 +44,10 @@ namespace Microsoft.OData.ConnectedService
         public ODataConnectedServiceWizard(ConnectedServiceProviderContext context)
         {
             this.Context = context;
-            this.UserSettings = UserSettings.Load(context.Logger);
+            this.UserSettings = UserSettings.Load(context?.Logger);
 
             // Since ServiceConfigurationV4 is a derived type of ServiceConfiguration. So we can deserialize a ServiceConfiguration into a ServiceConfigurationV4.
-            this._serviceConfig = this.Context.GetExtendedDesignerData<ServiceConfigurationV4>();
+            this._serviceConfig = this.Context?.GetExtendedDesignerData<ServiceConfigurationV4>();
 
             ConfigODataEndpointViewModel = new ConfigODataEndpointViewModel(this.UserSettings, this);
             AdvancedSettingsViewModel = new AdvancedSettingsViewModel(this.UserSettings);
@@ -57,7 +57,7 @@ namespace Microsoft.OData.ConnectedService
             OperationImportsViewModel.PageEntering += OperationImportsViewModel_PageEntering;
 
             SchemaTypesViewModel.PageEntering += SchemaTypeSelectionViewModel_PageEntering;
-            if (this.Context.IsUpdating)
+            if (this.Context != null && this.Context.IsUpdating)
             {
                 ConfigODataEndpointViewModel.Endpoint = this._serviceConfig.Endpoint;
                 ConfigODataEndpointViewModel.EdmxVersion = this._serviceConfig.EdmxVersion;

--- a/src/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ViewModels/ConfigODataEndpointViewModel.cs
@@ -91,7 +91,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         {
             if (string.IsNullOrEmpty(this.Endpoint))
             {
-                throw new ArgumentNullException("OData Service Endpoint", "Please input the service endpoint");
+                throw new ArgumentNullException("OData Service Endpoint", Constants.InputServiceEndpointMsg);
             }
 
             if (this.Endpoint.StartsWith("https:", StringComparison.Ordinal)

--- a/test/ODataConnectedService.Tests/CodeGenReferences/TempSimple.xml
+++ b/test/ODataConnectedService.Tests/CodeGenReferences/TempSimple.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?><edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Simple" xmlns:d="http://docs.oasis-open.org/odata/ns/data" xmlns:m="http://docs.oasis-open.org/odata/ns/metadata" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="TestType">
+        <Key>
+          <PropertyRef Name="KeyProp" />
+        </Key>
+        <Property Name="KeyProp" Type="Edm.Int32" Nullable="false" />
+        <Property Name="ValueProp" Type="Edm.String" Nullable="false" />
+      </EntityType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ODataConnectedServiceWizardTests.cs" />
+    <Compile Include="ViewModels\ConfigOdataEndPointViewModelTests.cs" />
     <Compile Include="Properties\AssemblyRefs.cs" />
     <Compile Include="Templates\CodeGenerationContextTest.cs" />
     <Compile Include="CodeGeneration\V4CodeGenDescriptorTest.cs" />

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTest.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTest.cs
@@ -111,7 +111,7 @@ namespace Microsoft.OData.ConnectedService.Tests.Templates
         static Assembly Assembly = Assembly.GetExecutingAssembly();
         const string ReferenceResourcePrefix = "ODataConnectedService.Tests.CodeGenReferences.";
 
-        static string LoadReferenceContent(string name)
+        public static string LoadReferenceContent(string name)
         {
             var fullName = $"{ReferenceResourcePrefix}{name}";
             using (var stream = Assembly.GetManifestResourceStream(fullName))

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.OData.ConnectedService;
+using Microsoft.OData.ConnectedService.Common;
+using Microsoft.OData.ConnectedService.Models;
+using Microsoft.OData.ConnectedService.Tests.Templates;
+using Microsoft.OData.ConnectedService.ViewModels;
+using Microsoft.VisualStudio.ConnectedServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ODataConnectedService.Tests.ViewModels
+{
+    [TestClass]
+    public class ConfigOdataEndPointViewModelTests
+    {
+        private static ConfigODataEndpointViewModel configOdataEndPointViewModel;
+        private static UserSettings userSettings;
+        private static ODataConnectedServiceWizard serviceWizard;
+
+        [TestInitialize]
+        public void Init()
+        {
+            userSettings = new UserSettings();
+            serviceWizard = new ODataConnectedServiceWizard(null);
+            configOdataEndPointViewModel = new ConfigODataEndpointViewModel(userSettings, serviceWizard);
+        }
+
+        [TestMethod]
+        public void OnPageLeavingConfigODataEndpointPageTest()
+        {
+            string edmx = ODataT4CodeGeneratorTest.LoadReferenceContent("Simple.xml");
+            string expectedTempfileContent = ODataT4CodeGeneratorTest.LoadReferenceContent("TempSimple.xml");
+            Task<PageNavigationResult> pageNavigationResultTask;
+            PageNavigationResult pageNavigationResult;
+
+            File.WriteAllText("EdmxFile.xml",edmx);
+
+            //Check if an error is thrown if the on leaving the page without providing the endpoint
+            pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
+
+            pageNavigationResult = pageNavigationResultTask?.Result;
+            Assert.IsNotNull(pageNavigationResult.ErrorMessage);
+            Assert.IsTrue(pageNavigationResult.ErrorMessage.Contains(Constants.InputServiceEndpointMsg),"User is not prompted to enter endpoint");
+            Assert.IsFalse(pageNavigationResult.IsSuccess);
+            Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
+
+            //Provide a url without $metadata
+            configOdataEndPointViewModel.Endpoint = "http://localhost/ODataService";
+            pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
+
+            //Check if $metadata is apended if the url does not have it added at the end
+            Assert.AreEqual(configOdataEndPointViewModel.Endpoint, "http://localhost/ODataService/$metadata");
+
+            //Check if an exception is thrown for an invalid url and the user is notified
+            pageNavigationResult = pageNavigationResultTask?.Result;
+            Assert.IsNotNull(pageNavigationResult.ErrorMessage);
+            Assert.IsTrue(pageNavigationResult.ErrorMessage.Contains("The remote server returned an error: (404) Not Found."));
+            Assert.IsFalse(pageNavigationResult.IsSuccess);
+            Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
+
+
+            configOdataEndPointViewModel.Endpoint = Path.Combine(Directory.GetCurrentDirectory(),"EdmxFile.xml");
+            pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
+
+            //Check if any errors were reported
+            pageNavigationResult = pageNavigationResultTask?.Result;
+            Assert.IsNull(pageNavigationResult.ErrorMessage);
+            Assert.IsTrue(pageNavigationResult.IsSuccess);
+            Assert.IsFalse(pageNavigationResult.ShowMessageBoxOnFailure);
+
+            //Check if the content writtent to the temp file is correct
+            string actualTempFileContent = File.ReadAllText(configOdataEndPointViewModel.MetadataTempPath);
+            Assert.AreEqual(expectedTempfileContent.Trim(), actualTempFileContent.Trim(), "temp metadata file not properly written");
+
+            //Check if Edmx verison of has correctly been detected
+            Assert.AreEqual(configOdataEndPointViewModel.EdmxVersion.ToString(),"4.0.0.0","Version not properly detected");
+        }
+    }
+}


### PR DESCRIPTION
### ConfigODataEndpointViewModel

Handles the endpoint config page of the wizard, also fetches the model from the provided endpoint.
`OnPageLeavingAsync()` is called when the page is leaving, and it handles a lot of logic that's not tested:

- [ ] Should add the provided endpoint to the user setting's most-recently used list when leaving the page
- [x] Should fetch metadata when from the provided endpoint when leaving the page and save it to a temporary file
- [x] Should detect and set the edmx version from the metadata
- [x] Should be able to fetch metadata if the endpoint is a local file
- [ ] Should pass provided custom headers to the web request when fetching metadata from a service
- [ ] Should be able to fetch metadata when behind web proxy
