### PR TITLE
Fix #114: Unselecting all schema types does not deselect dependent function imports

### DIFF
--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OData.ConnectedService
 
             ConfigODataEndpointViewModel = new ConfigODataEndpointViewModel(this.UserSettings, this);
             AdvancedSettingsViewModel = new AdvancedSettingsViewModel(this.UserSettings);
-            SchemaTypesViewModel = new SchemaTypesViewModel(this.UserSettings);
+            SchemaTypesViewModel = new SchemaTypesViewModel(this.UserSettings, this);
             OperationImportsViewModel = new OperationImportsViewModel(this.UserSettings);
 
             OperationImportsViewModel.PageEntering += OperationImportsViewModel_PageEntering;

--- a/src/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedServiceWizard.cs
@@ -51,18 +51,19 @@ namespace Microsoft.OData.ConnectedService
 
             ConfigODataEndpointViewModel = new ConfigODataEndpointViewModel(this.UserSettings, this);
             AdvancedSettingsViewModel = new AdvancedSettingsViewModel(this.UserSettings);
-            SchemaTypesViewModel = new SchemaTypesViewModel(this.UserSettings, this);
+            SchemaTypesViewModel = new SchemaTypesViewModel(this.UserSettings);
             OperationImportsViewModel = new OperationImportsViewModel(this.UserSettings);
 
             OperationImportsViewModel.PageEntering += OperationImportsViewModel_PageEntering;
 
             SchemaTypesViewModel.PageEntering += SchemaTypeSelectionViewModel_PageEntering;
+            SchemaTypesViewModel.PageLeaving += SchemaTypeSelectionViewModel_PageLeaving;
             if (this.Context != null && this.Context.IsUpdating)
             {
-                ConfigODataEndpointViewModel.Endpoint = this._serviceConfig.Endpoint;
-                ConfigODataEndpointViewModel.EdmxVersion = this._serviceConfig.EdmxVersion;
-                ConfigODataEndpointViewModel.ServiceName = this._serviceConfig.ServiceName;
-                ConfigODataEndpointViewModel.CustomHttpHeaders = this._serviceConfig.CustomHttpHeaders;
+                ConfigODataEndpointViewModel.Endpoint = this._serviceConfig?.Endpoint;
+                ConfigODataEndpointViewModel.EdmxVersion = this._serviceConfig?.EdmxVersion;
+                ConfigODataEndpointViewModel.ServiceName = this._serviceConfig?.ServiceName;
+                ConfigODataEndpointViewModel.CustomHttpHeaders = this._serviceConfig?.CustomHttpHeaders;
 
                 // Restore the main settings to UI elements.
                 ConfigODataEndpointViewModel.PageEntering += ConfigODataEndpointViewModel_PageEntering;
@@ -231,6 +232,7 @@ namespace Microsoft.OData.ConnectedService
                         operationImportsViewModel.IsSupportedODataVersion = false;
                         return;
                     }
+
                     var model = EdmHelper.GetEdmModelFromFile(ConfigODataEndpointViewModel.MetadataTempPath);
                     var operations = EdmHelper.GetOperationImports(model);
                     OperationImportsViewModel.LoadOperationImports(operations, new HashSet<string>(SchemaTypesViewModel.ExcludedSchemaTypeNames), SchemaTypesViewModel.SchemaTypeModelMap);
@@ -263,6 +265,22 @@ namespace Microsoft.OData.ConnectedService
                 }
 
                 this.ProcessedEndpointForSchemaTypes = ConfigODataEndpointViewModel.Endpoint;
+            }
+        }
+
+        public void SchemaTypeSelectionViewModel_PageLeaving(object sender, EventArgs args)
+        {
+            // exclude related operationimports for excluded types
+            var model = EdmHelper.GetEdmModelFromFile(ConfigODataEndpointViewModel.MetadataTempPath);
+            var operations = EdmHelper.GetOperationImports(model);
+            var operationsToExclude = operations.Where(x => !OperationImportsViewModel.IsOperationImportIncluded(x,
+                SchemaTypesViewModel.ExcludedSchemaTypeNames.ToList())).ToList();
+            foreach (var operationImport in OperationImportsViewModel.OperationImports)
+            {
+                if (operationsToExclude.Any(x => x.Name == operationImport.Name))
+                {
+                    operationImport.IsSelected = false;
+                }
             }
         }
 

--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             return await base.OnPageLeavingAsync(args);
         }
 
-        /// <summary> 
+        /// <summary>
         /// Loads operation imports except the ones that require a type that is excluded
         /// </summary>
         /// <param name="operationImports">a list of all the operation imports.</param>
@@ -100,21 +100,24 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
                     operationImportModel.PropertyChanged += (s, args) =>
                     {
-                        IEnumerable<IEdmOperationParameter> parameters = operation.Operation.Parameters;
-
-                        foreach (var parameter in parameters)
+                        if (s is OperationImportModel currentOperationImportModel)
                         {
-                            if (schemaTypeModels.TryGetValue(parameter.Type.FullName(), out SchemaTypeModel model) && !model.IsSelected)
+                            IEnumerable<IEdmOperationParameter> parameters = operation.Operation.Parameters;
+
+                            foreach (var parameter in parameters)
                             {
-                                model.IsSelected = (s as OperationImportModel).IsSelected;
+                                if (schemaTypeModels.TryGetValue(parameter.Type.FullName(), out SchemaTypeModel model) && !model.IsSelected)
+                                {
+                                    model.IsSelected = currentOperationImportModel.IsSelected;
+                                }
                             }
-                        }
 
-                        string returnTypeName = operation.Operation.ReturnType?.FullName();
+                            string returnTypeName = operation.Operation.ReturnType?.FullName();
 
-                        if(returnTypeName != null && schemaTypeModels.TryGetValue(returnTypeName, out SchemaTypeModel schemaTypeModel) && !schemaTypeModel.IsSelected)
-                        {
-                            schemaTypeModel.IsSelected = (s as OperationImportModel).IsSelected;
+                            if (returnTypeName != null && schemaTypeModels.TryGetValue(returnTypeName, out SchemaTypeModel schemaTypeModel) && !schemaTypeModel.IsSelected)
+                            {
+                                schemaTypeModel.IsSelected = currentOperationImportModel.IsSelected;
+                            }
                         }
                     };
                     toLoad.Add(operationImportModel);
@@ -126,12 +129,12 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             OperationImports = toLoad.OrderBy(o => o.Name).ToList();
         }
 
-        /// <summary> 
+        /// <summary>
         /// Checks if the operation import should be included
         /// </summary>
         /// <param name="operationImport">operation import.</param>
         /// <param name="excludedTypes">A collection of excluded types.</param>
-        /// <returns>true if the operation import should be included, otherwise false.<returns>
+        /// <returns>true if the operation import should be included, otherwise false.</returns>
         public bool IsOperationImportIncluded(IEdmOperationImport operationImport, ICollection<string> excludedTypes)
         {
             IEnumerable<IEdmOperationParameter> parameters = operationImport.Operation.Parameters;

--- a/src/ViewModels/SchemaTypesViewModel.cs
+++ b/src/ViewModels/SchemaTypesViewModel.cs
@@ -34,11 +34,11 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
         public event EventHandler<EventArgs> PageEntering;
 
+        public event EventHandler<EventArgs> PageLeaving;
+
         internal bool IsEntered;
 
-        private readonly ODataConnectedServiceWizard _wizard;
-
-        public SchemaTypesViewModel(UserSettings userSettings = null, ODataConnectedServiceWizard wizard = null) : base()
+        public SchemaTypesViewModel(UserSettings userSettings = null) : base()
         {
             Title = "Schema Types";
             Description = "Select schema types to include in the generated code.";
@@ -47,7 +47,6 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             SchemaTypeModelMap = new Dictionary<string, SchemaTypeModel>();
             RelatedTypes = new Dictionary<string, ICollection<string>>();
             this.UserSettings = userSettings;
-            this._wizard = wizard;
         }
 
         /// <summary>
@@ -77,21 +76,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
             var correctTypeSelection = true;
 
-            // exclude related operationimports for excluded types
-            if (this._wizard != null)
-            {
-                IEdmModel model = EdmHelper.GetEdmModelFromFile(this._wizard.ConfigODataEndpointViewModel.MetadataTempPath);
-                IEnumerable<IEdmOperationImport> operations = EdmHelper.GetOperationImports(model);
-                IEnumerable<IEdmOperationImport> operationsToExclude = operations.Where(x => !this._wizard.OperationImportsViewModel.IsOperationImportIncluded(x,
-                    ExcludedSchemaTypeNames.ToList())).ToList();
-                foreach (var operationImport in this._wizard.OperationImportsViewModel.OperationImports)
-                {
-                    if (operationsToExclude.Any(x => x.Name == operationImport.Name))
-                    {
-                        operationImport.IsSelected = false;
-                    }
-                }
-            }
+            PageLeaving?.Invoke(this, EventArgs.Empty);
 
             //check each excluded schema type and check if they are required. If so, then automatically select them.
             foreach (var schemaType in ExcludedSchemaTypeNames)

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="TestHelpers\TestVsPackageInstaller.cs" />
     <Compile Include="TestHelpers\TestVsPackageInstallerServices.cs" />
     <Compile Include="ViewModels\OperationImportsViewModelTests.cs" />
+    <Compile Include="ViewModels\SchemaTypesViewModelTests.cs" />
     <Compile Include="Views\UserSettingsTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
@@ -1,0 +1,247 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.OData.ConnectedService.Models;
+using Microsoft.OData.ConnectedService.ViewModels;
+using Microsoft.OData.Edm;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ODataConnectedService.Tests.ViewModels
+{
+    [TestClass]
+    public class SchemaTypesViewModelTests
+    {
+        [TestMethod]
+        public void LoadSchemaTypes_ShouldSetAllSchemaTypesAsSelectedAndOrderedByName()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {Name = "Type1", IsSelected = false},
+                    new SchemaTypeModel {Name = "Type2", IsSelected = true},
+                    new SchemaTypeModel {Name = "Type3", IsSelected = false}
+                }
+            };
+
+            var listToLoad = new List<IEdmSchemaType>
+            {
+                new EdmEnumType("Test", "EnumType"),
+                new EdmComplexType("Test", "ComplexType"),
+                new EdmUntypedStructuredType("Test", "UntypedStructuredType"),
+                new EdmEntityType("Test", "EntityType"),
+                new EdmTypeDefinition("Test", "TypeDef", EdmPrimitiveTypeKind.Boolean)
+            };
+
+            objectSelection.LoadSchemaTypes(listToLoad, new Dictionary<IEdmStructuredType, List<IEdmOperation>>());
+
+            objectSelection.SchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
+            {
+                new SchemaTypeModel { ShortName = "ComplexType", Name = "Test.ComplexType", IsSelected = true },
+                new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true },
+                new SchemaTypeModel { ShortName = "EnumType", Name = "Test.EnumType", IsSelected = true },
+                new SchemaTypeModel { ShortName = "TypeDef", Name = "Test.TypeDef", IsSelected = true },
+                new SchemaTypeModel { ShortName = "UntypedStructuredType", Name = "Test.UntypedStructuredType", IsSelected = true }
+            });
+        }
+
+        [TestMethod]
+        public void LoadSchemaTypes_ShouldAddRelatedTypesForStructuredTypesWithBaseType()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {Name = "Type1", IsSelected = false},
+                    new SchemaTypeModel {Name = "Type2", IsSelected = true},
+                    new SchemaTypeModel {Name = "Type3", IsSelected = false}
+                }
+            };
+
+            var listToLoad = new List<IEdmSchemaType>
+            {
+                new EdmComplexType("Test", "ComplexType", new EdmComplexType("Test", "BaseComplexType")),
+                new EdmEntityType("Test", "EntityType", new EdmEntityType("Test", "BaseEntityType")),
+                new EdmEnumType("Test", "EnumType"),
+                new EdmTypeDefinition("Test", "TypeDef", EdmPrimitiveTypeKind.Boolean),
+                new EdmUntypedStructuredType("Test", "UntypedStructuredType")
+            };
+
+            objectSelection.LoadSchemaTypes(listToLoad, new Dictionary<IEdmStructuredType, List<IEdmOperation>>());
+
+            var expectedRelatedTypes = new Dictionary<string, ICollection<string>>
+            {
+                {"Test.BaseComplexType", new List<string> {"Test.ComplexType"}},
+                {"Test.BaseEntityType", new List<string> {"Test.EntityType"}},
+            };
+
+            objectSelection.RelatedTypes.ShouldBeEquivalentTo(expectedRelatedTypes);
+        }
+
+        [TestMethod]
+        public void SelectSchemaType_ShouldSelectItsRelatedTypes()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {Name = "Type1", IsSelected = false},
+                    new SchemaTypeModel {Name = "Type2", IsSelected = true},
+                    new SchemaTypeModel {Name = "Type3", IsSelected = false}
+                }
+            };
+
+            var relatedEntityType = new EdmEntityType("Test", "RelatedEntityType");
+            var listToLoad = new List<IEdmSchemaType>
+            {
+                relatedEntityType,
+                new EdmComplexType("Test", "ComplexType", new EdmComplexType("Test", "BaseComplexType")),
+                new EdmEntityType("Test", "EntityType", relatedEntityType)
+            };
+
+            objectSelection.LoadSchemaTypes(listToLoad, new Dictionary<IEdmStructuredType, List<IEdmOperation>>());
+            objectSelection.DeselectAllSchemaTypes();
+
+            objectSelection.SchemaTypes.First(x => x.ShortName == "EntityType").IsSelected = true;
+
+            objectSelection.SchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
+            {
+                new SchemaTypeModel { ShortName = "ComplexType", Name = "Test.ComplexType", IsSelected = false },
+                new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true },
+                new SchemaTypeModel { ShortName = "RelatedEntityType", Name = "Test.RelatedEntityType", IsSelected = true }
+            });
+        }
+
+        [TestMethod]
+        public void DeselectSchemaType_ShouldDeselectItsRelatedTypes()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>()
+            };
+
+            var listToLoad = new List<IEdmSchemaType>
+            {
+                new EdmEntityType("Test", "EntityType", new EdmEntityType("Test", "BaseEntityType")),
+                new EdmEntityType("Test", "BaseEntityType")
+            };
+
+            objectSelection.LoadSchemaTypes(listToLoad, new Dictionary<IEdmStructuredType, List<IEdmOperation>>());
+
+            objectSelection.SchemaTypes.First(x => x.ShortName == "BaseEntityType").IsSelected = false;
+
+            objectSelection.SchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
+            {
+                new SchemaTypeModel { ShortName = "BaseEntityType", Name = "Test.BaseEntityType", IsSelected = false },
+                new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = false }
+            });
+        }
+
+        [TestMethod]
+        public void ExcludeSchemaTypes_ShouldDeselectTheSpecifiedTypes()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {ShortName = "Type1", Name = "Test.Type1", IsSelected = true},
+                    new SchemaTypeModel {ShortName = "Type2", Name = "Test.Type2", IsSelected = true},
+                    new SchemaTypeModel {ShortName = "Type3", Name = "Test.Type3", IsSelected = false},
+                    new SchemaTypeModel {ShortName = "Type4", Name = "Test.Type4", IsSelected = true}
+                }
+            };
+
+            objectSelection.ExcludeSchemaTypes(new string[] { "Test.Type1", "Test.Type3", "Test.Type4" });
+
+            objectSelection.SchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>()
+            {
+                new SchemaTypeModel { ShortName = "Type1", Name = "Test.Type1", IsSelected = false },
+                new SchemaTypeModel { ShortName = "Type2", Name = "Test.Type2", IsSelected = true },
+                new SchemaTypeModel { ShortName = "Type3", Name = "Test.Type3", IsSelected = false },
+                new SchemaTypeModel { ShortName = "Type4", Name = "Test.Type4", IsSelected = false }
+            });
+        }
+
+        [TestMethod]
+        public void ExcludedSchemaTypeNames_ShouldReturnNamesOfDeselectedTypes()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {ShortName = "Type1", Name = "Test.Type1", IsSelected = false},
+                    new SchemaTypeModel {ShortName = "Type2", Name = "Test.Type2", IsSelected = true},
+                    new SchemaTypeModel {ShortName = "Type3", Name = "Test.Type3", IsSelected = false}
+                }
+            };
+
+            var excluded = objectSelection.ExcludedSchemaTypeNames.ToList();
+
+            excluded.ShouldBeEquivalentTo(new List<string> { "Test.Type1", "Test.Type3" });
+        }
+
+        [TestMethod]
+        public void ClearSchemaTypes_ShouldResetSchemaTypesToAnEmptyCollection()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {ShortName = "Type1", Name = "Test.Type1", IsSelected = false},
+                    new SchemaTypeModel {ShortName = "Type2", Name = "Test.Type2", IsSelected = true},
+                    new SchemaTypeModel {ShortName = "Type3", Name = "Test.Type3", IsSelected = false}
+                }
+            };
+
+            objectSelection.ClearSchemaTypes();
+
+            objectSelection.SchemaTypes.Count().Should().Be(0);
+        }
+
+        [TestMethod]
+        public void SelectAllSchemaTypes_ShouldMarkAllTypesAsSelected()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {ShortName = "Type1", Name = "Test.Type1", IsSelected = false},
+                    new SchemaTypeModel {ShortName = "Type2", Name = "Test.Type2", IsSelected = true},
+                    new SchemaTypeModel {ShortName = "Type3", Name = "Test.Type3", IsSelected = false}
+                }
+            };
+
+            objectSelection.SelectAllSchemaTypes();
+
+            objectSelection.SchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
+            {
+                new SchemaTypeModel {ShortName = "Type1", Name = "Test.Type1", IsSelected = true},
+                new SchemaTypeModel {ShortName = "Type2", Name = "Test.Type2", IsSelected = true},
+                new SchemaTypeModel {ShortName = "Type3", Name = "Test.Type3", IsSelected = true}
+            });
+        }
+
+        [TestMethod]
+        public void DeselectAllSchemaTypes_ShouldMarkAllTypesAsNotSelected()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {ShortName = "Type1", Name = "Test.Type1", IsSelected = false},
+                    new SchemaTypeModel {ShortName = "Type2", Name = "Test.Type2", IsSelected = true},
+                    new SchemaTypeModel {ShortName = "Type3", Name = "Test.Type3", IsSelected = false}
+                }
+            };
+
+            objectSelection.DeselectAllSchemaTypes();
+
+            objectSelection.SchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
+            {
+                new SchemaTypeModel {ShortName = "Type1", Name = "Test.Type1", IsSelected = false},
+                new SchemaTypeModel {ShortName = "Type2", Name = "Test.Type2", IsSelected = false},
+                new SchemaTypeModel {ShortName = "Type3", Name = "Test.Type3", IsSelected = false}
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fix #114 :
* when an schema type is deselected, all the types of its Navigational properties are automatically deselected;
* deselect all operations that require the deselected types.

Added the tests below:

To **ODataConnectedServiceWizardTests**:
- [x] `ShouldDeselectOperations_WhenRelatedTypeIsDeselectedBefore`.

To **SchemaTypesViewModelTests**:
- [x] `LoadSchemaTypes_ShouldSetAllSchemaTypesAsSelectedAndOrderedByName`;
- [x] `LoadSchemaTypes_ShouldAddRelatedTypesForStructuredTypesWithBaseType`;
- [x] `SelectSchemaType_ShouldSelectItsRelatedTypes`;
- [x] `DeselectSchemaType_ShouldDeselectRelatedTypes`;
- [x] `ExcludeSchemaTypes_ShouldDeselectTheSpecifiedTypes`;
- [x] `ExcludedSchemaTypeNames_ShouldReturnNamesOfDeselectedTypes`;
- [x] `ClearSchemaTypes_ShouldResetSchemaTypesToAnEmptyCollection`;
- [x] `SelectAllSchemaTypes_ShouldMarkAllTypesAsSelected`;
- [x] `DeselectAllSchemaTypes_ShouldMarkAllTypesAsNotSelected`.