### PR TITLE
Fix exception when there are multiple cdsl files

### DIFF
--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -84,7 +84,10 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
 
             tempFile = Path.GetTempFileName();
 
-            var metadataFile = Path.Combine(referenceFolder, Common.Constants.CsdlFileName);
+            // Csdl file name is this format [ServiceName]Csdl.xml
+            var csdlFileName = string.Concat(ServiceConfiguration.ServiceName, Common.Constants.CsdlFileNameSuffix);
+            var metadataFile = Path.Combine(referenceFolder, csdlFileName);
+
             await this.Context.HandlerHelper.AddFileAsync(tempFile, metadataFile, new AddFileOptions() { SuppressOverwritePrompt = true });
 
             // Hack!
@@ -93,7 +96,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             var dte = VisualStudio.Shell.Package.GetGlobalService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
             if (dte != null)
             {
-                var projectItem = this.GetCsdlFileProjectItem(Common.Constants.CsdlFileName);
+                var projectItem = this.GetCsdlFileProjectItem(csdlFileName);
                 projectItem.Properties.Item("BuildAction").Value = prjBuildAction.prjBuildActionEmbeddedResource;
             }
 
@@ -122,7 +125,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 var customHeaders = ServiceConfiguration.CustomHttpHeaders ?? "";
                 text = Regex.Replace(text, "(public const string CustomHttpHeaders = )\"\";", "$1@\"" + customHeaders + "\";");
                 text = Regex.Replace(text, "(public const string MetadataFilePath = )\"\";", "$1@\"" + metadataFile + "\";");
-                text = Regex.Replace(text, "(public const string MetadataFileRelativePath = )\"\";", "$1@\"" + Common.Constants.CsdlFileName + "\";");
+                text = Regex.Replace(text, "(public const string MetadataFileRelativePath = )\"\";", "$1@\"" + csdlFileName + "\";");
                 await writer.WriteAsync(text);
                 await writer.FlushAsync();
             }
@@ -172,7 +175,9 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             var tempFile = Path.GetTempFileName();
             var referenceFolder = GetReferenceFileFolder();
 
-            var metadataFile = Path.Combine(referenceFolder, Common.Constants.CsdlFileName);
+            // Csdl file name is this format [ServiceName]Csdl.xml
+            var csdlFileName = string.Concat(ServiceConfiguration.ServiceName, Common.Constants.CsdlFileNameSuffix);
+            var metadataFile = Path.Combine(referenceFolder, csdlFileName);
             await this.Context.HandlerHelper.AddFileAsync(tempFile, metadataFile, new AddFileOptions() { SuppressOverwritePrompt = true });
 
             // Hack!
@@ -181,12 +186,12 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             var dte = VisualStudio.Shell.Package.GetGlobalService(typeof(EnvDTE.DTE)) as EnvDTE.DTE;
             if(dte != null)
             {
-                var projectItem = this.GetCsdlFileProjectItem(Common.Constants.CsdlFileName);
+                var projectItem = this.GetCsdlFileProjectItem(csdlFileName);
                 projectItem.Properties.Item("BuildAction").Value = prjBuildAction.prjBuildActionEmbeddedResource;
             }
 
             t4CodeGenerator.MetadataFilePath = metadataFile;
-            t4CodeGenerator.MetadataFileRelativePath = Common.Constants.CsdlFileName;
+            t4CodeGenerator.MetadataFileRelativePath = csdlFileName;
 
             using (StreamWriter writer = File.CreateText(tempFile))
             {

--- a/src/Common/Constants.cs
+++ b/src/Common/Constants.cs
@@ -40,7 +40,7 @@ namespace Microsoft.OData.ConnectedService.Common
 
         public const string SchemaTypesWillAutomaticallyBeIncluded = "type(s) will automatically be included to ensure the generated code compiles successfully.";
         public const string InputServiceEndpointMsg = "Please input the service endpoint";
-        public const string CsdlFileName = "Csdl.xml";
+        public const string CsdlFileNameSuffix = "Csdl.xml";
 
         public static string[] V3NuGetPackages = {
             V3ClientNuGetPackage,

--- a/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasic.txt
+++ b/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasic.txt
@@ -23,7 +23,7 @@ public static class Configuration
 	public const string MetadataFilePath = @"$$CsdlFullPath$$";
 
 	// The relative path for the MetadataFilePath.
-	public const string MetadataFileRelativePath = @"Csdl.xml";
+	public const string MetadataFileRelativePath = @"$$CsdlRelativePath$$";
 
 	// This flag indicates whether to enable naming alias. The value must be set to true or false.
 	public const bool EnableNamingAlias = false;

--- a/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasicVB.txt
+++ b/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasicVB.txt
@@ -23,7 +23,7 @@ public static class Configuration
 	public const string MetadataFilePath = @"$$CsdlFullPath$$";
 
 	// The relative path for the MetadataFilePath.
-	public const string MetadataFileRelativePath = @"Csdl.xml";
+	public const string MetadataFileRelativePath = @"$$CsdlRelativePath$$";
 
 	// This flag indicates whether to enable naming alias. The value must be set to true or false.
 	public const bool EnableNamingAlias = false;

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -49,16 +49,16 @@ namespace ODataConnectedService.Tests.ViewModels
             Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
 
             //Provide a url without $metadata
-            configOdataEndPointViewModel.Endpoint = "http://localhost/ODataService";
+            configOdataEndPointViewModel.Endpoint = "http://mysite/ODataService";
             pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
             //Check if $metadata is apended if the url does not have it added at the end
-            Assert.AreEqual(configOdataEndPointViewModel.Endpoint, "http://localhost/ODataService/$metadata");
+            Assert.AreEqual(configOdataEndPointViewModel.Endpoint, "http://mysite/ODataService/$metadata");
 
             //Check if an exception is thrown for an invalid url and the user is notified
             pageNavigationResult = pageNavigationResultTask?.Result;
             Assert.IsNotNull(pageNavigationResult.ErrorMessage);
-            Assert.IsTrue(pageNavigationResult.ErrorMessage.Contains("The remote server returned an error: (404) Not Found."));
+            Assert.IsTrue(pageNavigationResult.ErrorMessage.Contains("The remote name could not be resolved"));
             Assert.IsFalse(pageNavigationResult.IsSuccess);
             Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
 


### PR DESCRIPTION
Fix #111 
When you add multiple connected services in one project, all csdl files are named `Cdsl.xml`
This causes an exception when reading the embedded resource file since we were trying to read `Csdl.xml` file yet there are multiple of them.

Solution
We are renaming `Csdl.xml` to `[ServiceName]Csdl.xml` to make them unique.
