### PR TITLE
Add OdataConnectedServiceHandler tests

### DIFF
--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -52,12 +52,6 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 await AddGeneratedCodeAsync();
             }
 
-            this.ServiceConfiguration.CustomHttpHeaders = null;
-
-            // Since all the code is generated make sure we don't write the username and password for the network credentials
-            this.ServiceConfiguration.WebProxyNetworkCredentialsUsername = null;
-            this.ServiceConfiguration.WebProxyNetworkCredentialsPassword = null;
-
         }
 
         private async Task AddT4FileAsync()

--- a/src/ODataConnectedServiceHandler.cs
+++ b/src/ODataConnectedServiceHandler.cs
@@ -45,6 +45,11 @@ namespace Microsoft.OData.ConnectedService
             var serviceInstance = (ODataConnectedServiceInstance)context.ServiceInstance;
 
             var codeGenDescriptor = await GenerateCodeAsync(serviceInstance.ServiceConfig.Endpoint, serviceInstance.ServiceConfig.EdmxVersion, context, project);
+            // We don't save headers and proxy details to designer data
+            serviceInstance.ServiceConfig.CustomHttpHeaders = null;
+            serviceInstance.ServiceConfig.WebProxyNetworkCredentialsUsername = null;
+            serviceInstance.ServiceConfig.WebProxyNetworkCredentialsPassword = null;
+
             context.SetExtendedDesignerData(serviceInstance.ServiceConfig);
             return codeGenDescriptor;
         }

--- a/test/ODataConnectedService.Tests/Views/UserSettingsTest.cs
+++ b/test/ODataConnectedService.Tests/Views/UserSettingsTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.OData.ConnectedService.Models;
+﻿// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License.  See License.txt in the project root for license information.
+
+using Microsoft.OData.ConnectedService.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ODataConnectedService.Tests.Views


### PR DESCRIPTION
Add the tests below:
- [x] CustomHttpHeaders  should not be saved to the designer data
- [x] WebProxy username and password credentials should not be saved to the designer data