### PR TITLE
Add EdmHelper Tests

### DIFF
--- a/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
@@ -18,14 +18,7 @@ using System.Collections.Generic;
 using System.Net;
 using ODataConnectedService.Tests;
 using System.Text;
-using Microsoft.VisualStudio.ComponentModelHost;
-using System.ComponentModel.Composition.Primitives;
-using System.ComponentModel.Composition.Hosting;
-using System.ComponentModel.Composition;
-using NuGet.VisualStudio;
-using NuGet;
 using System;
-using System.Reflection;
 using System.Linq;
 using ODataConnectedService.Tests.TestHelpers;
 

--- a/test/ODataConnectedService.Tests/Common/EdmHelperTests.cs
+++ b/test/ODataConnectedService.Tests/Common/EdmHelperTests.cs
@@ -1,0 +1,134 @@
+﻿//-----------------------------------------------------------------------------------
+// <copyright file="EdmHelperTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.OData.ConnectedService.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.OData.Edm;
+
+namespace ODataConnectedService.Tests
+{
+    [TestClass]
+    public class EdmHelperTests
+    {
+        readonly string MetadataPath = Path.GetFullPath("TestMetadataCsdl.xml");
+        [TestMethod]
+        public void TestGetEdmFromFile()
+        {
+            var model = EdmHelper.GetEdmModelFromFile(MetadataPath);
+            Assert.IsNotNull(model);
+        }
+
+        [TestMethod]
+        public void TestGetTypeNameFromFullName()
+        {
+            var employeeFullName = "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee";
+            var personFullName = "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person";
+            var personGenderFullName = "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender";
+
+            var employeeTypeName = EdmHelper.GetTypeNameFromFullName(employeeFullName);
+            var personTypeName = EdmHelper.GetTypeNameFromFullName(personFullName);
+            var personGenderTypeName = EdmHelper.GetTypeNameFromFullName(personGenderFullName);
+
+            Assert.AreEqual(employeeTypeName, "Employee");
+            Assert.AreEqual(personTypeName, "Person");
+            Assert.AreEqual(personGenderTypeName, "PersonGender");
+        }
+
+        [TestMethod]
+        public void TestGetSchemaTypes()
+        {
+            var model = EdmHelper.GetEdmModelFromFile(MetadataPath);
+            var schemaTypes = EdmHelper.GetSchemaTypes(model);
+            var actualSchemaTypes = new List<string>();
+
+            foreach(var type in schemaTypes)
+            {
+                actualSchemaTypes.Add(type.FullName());
+            }
+
+            var expectedSchemaTypes = new List<string>()
+            {
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airline",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.City",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Employee",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Flight",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Location",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.PersonGender",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip",
+            };
+
+            // Sort the Lists in ascending order
+            expectedSchemaTypes.Sort();
+            actualSchemaTypes.Sort();
+
+            //In order to get compare lists you should use the CollectionAssert
+            CollectionAssert.AreEqual(expectedSchemaTypes, actualSchemaTypes);
+        }
+
+        [TestMethod]
+        public void TestGetOperationImports()
+        {
+            var model = EdmHelper.GetEdmModelFromFile(MetadataPath);
+            var operationImports = EdmHelper.GetOperationImports(model);
+
+            var actualOperationImports = new List<string>();
+
+            foreach (var operation in operationImports)
+            {
+                actualOperationImports.Add(operation.Name);
+            }
+
+            var expectedOperationImports = new List<string>()
+            {
+                "GetNearestAirport",
+                "GetPersonWithMostFriends",
+                "ResetDataSource",
+            };
+
+            // Sort the Lists in ascending order
+            expectedOperationImports.Sort();
+            actualOperationImports.Sort();
+
+            //In order to get compare lists you should use the CollectionAssert
+            CollectionAssert.AreEqual(expectedOperationImports, actualOperationImports);
+        }
+
+        [TestMethod]
+        public void TestGetBoundOperations()
+        {
+            var model = EdmHelper.GetEdmModelFromFile(MetadataPath);
+            var boundOperations = EdmHelper.GetBoundOperations(model);
+
+            var actualBoundOperations = new List<string>();
+
+            foreach (var operation in boundOperations)
+            {
+                foreach(var boundValue in operation.Value)
+                {
+                    actualBoundOperations.Add(boundValue.FullName());
+                }
+            }
+
+            var expectedBoundOperations = new List<string>()
+            {
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.GetFriendsTrips",
+                "Microsoft.OData.Service.Sample.TrippinInMemory.Models.ShareTrip",
+            };
+
+            // Sort the Lists in ascending order
+            actualBoundOperations.Sort();
+            expectedBoundOperations.Sort();
+
+            //In order to get compare lists you should use the CollectionAssert
+            CollectionAssert.AreEqual(expectedBoundOperations, actualBoundOperations);
+        }
+    }
+}

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -62,6 +62,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\EdmHelperTests.cs" />
     <Compile Include="ODataConnectedServiceWizardTests.cs" />
     <Compile Include="ViewModels\ConfigOdataEndPointViewModelTests.cs" />
     <Compile Include="Properties\AssemblyRefs.cs" />

--- a/test/ODataConnectedService.Tests/TestMetadataCsdl.xml
+++ b/test/ODataConnectedService.Tests/TestMetadataCsdl.xml
@@ -64,6 +64,16 @@
         <Parameter Name="lon" Nullable="false" Type="Edm.Double"/>
         <ReturnType Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport"/>
       </Function>
+      <Function Name="GetFriendsTrips" IsBound="true">
+        <Parameter Name="person" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"/>
+        <Parameter Name="userName" Nullable="false" Type="Edm.String" Unicode="false"/>
+        <ReturnType Type="Collection(Microsoft.OData.Service.Sample.TrippinInMemory.Models.Trip)"/>
+      </Function>
+      <Action Name="ShareTrip" IsBound="true">
+        <Parameter Name="personInstance" Type="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person"/>
+        <Parameter Name="userName" Nullable="false" Type="Edm.String" Unicode="false"/>
+        <Parameter Name="tripId" Nullable="false" Type="Edm.Int32"/>
+      </Action>
       <Action Name="ResetDataSource"/>
       <EntityContainer Name="Container">
         <EntitySet Name="People" EntityType="Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person">


### PR DESCRIPTION
Added the tests below:
- [x] GetEdmFromFile reads and returns an edm model from the given file
- [x] GetOperationImports returns operation imports from the model
- [x] GetBoundOperations returns bound operations from the model
- [x] GetSchemaTypes returns all schema types (entity, enum, complex, etc.) from the model
- [x] GetTypeNameFromFullName extract the type name without the namespace from a fully qualified name