### PR TITLE
Fix #135 : Collection of enum properties is not added to related types Dictionary for structured types

### DIFF
--- a/src/ViewModels/SchemaTypesViewModel.cs
+++ b/src/ViewModels/SchemaTypesViewModel.cs
@@ -238,25 +238,23 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                             }
                         }
 
-                        // Check the required navigational property types and ensure they are selected as well
+                        // Check the required property types and ensure they are selected as well
                         foreach (var property in structuredType.DeclaredProperties)
                         {
-                            string propertyName = property is IEdmNavigationProperty
-                                ? property.Type.ToStructuredType().FullTypeName()
-                                : property.Type.FullName();
+                            IEdmTypeReference propertyType = property.Type.IsCollection()
+                                ? property.Type.AsCollection().ElementType()
+                                : property.Type;
 
-                            if (property.Type.ToStructuredType() != null || property.Type.IsEnum())
+                            if (propertyType.ToStructuredType() != null || propertyType.IsEnum())
                             {
-                                propertyName = property.Type.ToStructuredType()?.FullTypeName() ??
-                                               property.Type.FullName();
-                                AddRelatedType(propertyName, structuredType.FullTypeName());
+                                string propertyTypeName = propertyType.ToStructuredType()?.FullTypeName() ?? propertyType.FullName();
+                                AddRelatedType(propertyTypeName, structuredType.FullTypeName());
 
-                                bool hasProperty = SchemaTypeModelMap.TryGetValue(propertyName,
-                                    out SchemaTypeModel navigationPropertyModel);
+                                bool hasProperty = SchemaTypeModelMap.TryGetValue(propertyTypeName, out SchemaTypeModel propertySchemaTypeModel);
 
-                                if (hasProperty && !navigationPropertyModel.IsSelected)
+                                if (hasProperty && !propertySchemaTypeModel.IsSelected)
                                 {
-                                    navigationPropertyModel.IsSelected = true;
+                                    propertySchemaTypeModel.IsSelected = true;
                                 }
                             }
                         }

--- a/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
@@ -86,6 +86,40 @@ namespace ODataConnectedService.Tests.ViewModels
         }
 
         [TestMethod]
+        public void LoadSchemaTypes_ShouldAddRelatedPropertyTypeForStructuredType_WherePropertyIsCollectionOfEnum()
+        {
+            var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel {Name = "Type1", IsSelected = false},
+                    new SchemaTypeModel {Name = "Type2", IsSelected = true},
+                    new SchemaTypeModel {Name = "Type3", IsSelected = false}
+                }
+            };
+
+            var enumType = new EdmEnumType("Test", "EnumType");
+            var entityType = new EdmEntityType("Test", "EntityType");
+            entityType.AddStructuralProperty("collectionOfEnumProperty",
+                new EdmCollectionTypeReference(
+                    new EdmCollectionType(new EdmEnumTypeReference(enumType, false))));
+            var listToLoad = new List<IEdmSchemaType>
+            {
+                entityType,
+                enumType
+            };
+
+            objectSelection.LoadSchemaTypes(listToLoad, new Dictionary<IEdmType, List<IEdmOperation>>());
+
+            var expectedRelatedTypes = new Dictionary<string, ICollection<string>>
+            {
+                {"Test.EnumType", new List<string> {"Test.EntityType"}},
+            };
+
+            objectSelection.RelatedTypes.ShouldBeEquivalentTo(expectedRelatedTypes);
+        }
+
+        [TestMethod]
         public void SelectSchemaType_ShouldSelectItsRelatedTypes()
         {
             var objectSelection = new SchemaTypesViewModel


### PR DESCRIPTION
Fix #135

Added the tests below:

To **SchemaTypesViewModelTests:**

- [x] `LoadSchemaTypes_ShouldAddRelatedPropertyTypeForStructuredType_WherePropertyIsCollectionOfEnum`.