### PR TITLE
Feature #127 : Option to show operation return types and list of operation parameters

### DIFF
--- a/src/Common/EdmHelper.cs
+++ b/src/Common/EdmHelper.cs
@@ -10,6 +10,7 @@ using Microsoft.OData.Edm.Csdl;
 using Microsoft.VisualStudio.ConnectedServices;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Xml;
 
 namespace Microsoft.OData.ConnectedService.Common
@@ -128,6 +129,33 @@ namespace Microsoft.OData.ConnectedService.Common
             string[] nameArr = fullName.Split('.');
 
             return nameArr[nameArr.Length - 1];
+        }
+
+        /// <summary>
+        /// Gets the operation parameters string like '(Type1 par1, Type2 par2)'
+        /// </summary>
+        /// <param name="parameters">Collection of parameters.</param>
+        /// <returns>An operation parameters string like '(Type1 par1, Type2, par2)'</returns>
+        public static string GetParametersString(IEnumerable<IEdmOperationParameter> parameters)
+        {
+            var result = new StringBuilder("(");
+            var isFirst = true;
+            foreach (var parameter in parameters)
+            {
+                if (!isFirst)
+                {
+                    result.Append(", ");
+                }
+                else
+                {
+                    isFirst = false;
+                }
+                result.Append(parameter.Type?.Definition?.FullTypeName() ?? "void");
+                result.Append($" {parameter.Name}");
+            }
+
+            result.Append(")");
+            return result.ToString();
         }
     }
 }

--- a/src/Converters/BoolToVisibilityConverter.cs
+++ b/src/Converters/BoolToVisibilityConverter.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="BoolToVisibilityConverter.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//----------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Microsoft.OData.ConnectedService.Converters
+{
+    public class BoolToVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (targetType == typeof(Visibility))
+            {
+                if (value is bool boolValue)
+                    return boolValue ? Visibility.Visible : Visibility.Collapsed;
+
+                throw new NotSupportedException();
+            }
+
+            throw new NotSupportedException();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Models/OperationImportModel.cs
+++ b/src/Models/OperationImportModel.cs
@@ -1,6 +1,6 @@
 ﻿//-----------------------------------------------------------------------------
 // <copyright file="OperationImportModel.cs" company=".NET Foundation">
-//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //----------------------------------------------------------------------------
@@ -14,9 +14,15 @@ namespace Microsoft.OData.ConnectedService.Models
         private bool _isSelected;
 
         public string Name { get; set; }
+
+        public string ReturnType { get; set; }
+
+        public string ParametersString { get; set; }
+
+
         public bool IsSelected
         {
-            get { return _isSelected; }
+            get => _isSelected;
             set
             {
                 _isSelected = value;

--- a/src/ODataConnectedService.csproj
+++ b/src/ODataConnectedService.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Common\ExtensionsHelper.cs" />
     <Compile Include="Common\ProjectHelper.cs" />
     <Compile Include="Common\UserSettingsPersistenceHelper.cs" />
+    <Compile Include="Converters\BoolToVisibilityConverter.cs" />
     <Compile Include="Converters\SchemaTypeModelToVisibilityConverter.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Models\BoundOperationModel.cs" />

--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using Microsoft.OData.ConnectedService.Common;
 using Microsoft.OData.ConnectedService.Models;
 using Microsoft.OData.ConnectedService.Views;
 using Microsoft.OData.Edm;
@@ -109,6 +110,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                     var operationImportModel = new OperationImportModel()
                     {
                         Name = operation.Name,
+                        ReturnType = operation.Operation?.ReturnType?.FullName() ?? "void",
+                        ParametersString = EdmHelper.GetParametersString(operation.Operation?.Parameters),
                         IsSelected = IsOperationImportIncluded(operation, excludedSchemaTypes)
                     };
 

--- a/src/Views/OperationImports.xaml
+++ b/src/Views/OperationImports.xaml
@@ -2,6 +2,7 @@
     x:Class="Microsoft.OData.ConnectedService.Views.OperationImports"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:Microsoft.OData.ConnectedService.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:Microsoft.OData.ConnectedService.Views"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,6 +11,9 @@
     d:DesignHeight="300"
     d:DesignWidth="500"
     mc:Ignorable="d">
+    <UserControl.Resources>
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+    </UserControl.Resources>
     <StackPanel>
         <TextBlock Margin="0,5,0,5">
             Select which function and action imports will be included in the generated code.
@@ -54,11 +58,33 @@
                             Margin="0,5,5,0"
                             VerticalAlignment="Center"
                             IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBlock
+                            Margin="0,5,5,0"
+                            VerticalAlignment="Bottom"
+                            FontSize="10"
+                            Text="{Binding ReturnType}"
+                            Visibility="{Binding ElementName=ShowReturnTypeAndParameters, Path=IsChecked, Converter={StaticResource BoolToVisibilityConverter}}" />
                         <TextBlock VerticalAlignment="Bottom" Text="{Binding Name}" />
+                        <TextBlock
+                            Margin="2,5,8,0"
+                            Text="{Binding ParametersString}"
+                            Visibility="{Binding ElementName=ShowReturnTypeAndParameters, Path=IsChecked, Converter={StaticResource BoolToVisibilityConverter}}" />
                     </StackPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
+        <DockPanel Margin="0,5,0,0">
+            <CheckBox
+                x:Name="ShowReturnTypeAndParameters"
+                Width="16"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Content="Show return types and parameters for operations."
+                IsChecked="False" />
+            <TextBlock Margin="5,0,0,0" FontWeight="Bold">
+                Show return types and parameters for operations.
+            </TextBlock>
+        </DockPanel>
         <TextBlock
             Margin="0,10,0,0"
             FontWeight="Bold"

--- a/test/ODataConnectedService.Tests/Common/EdmHelperTests.cs
+++ b/test/ODataConnectedService.Tests/Common/EdmHelperTests.cs
@@ -7,9 +7,11 @@
 
 using System.Collections.Generic;
 using System.IO;
+using FluentAssertions;
 using Microsoft.OData.ConnectedService.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Vocabularies;
 
 namespace ODataConnectedService.Tests
 {
@@ -134,6 +136,47 @@ namespace ODataConnectedService.Tests
 
             //In order to get compare lists you should use the CollectionAssert
             CollectionAssert.AreEqual(expectedBoundOperations, actualBoundOperations);
+        }
+
+        [TestMethod]
+        public void TestGetParametersString_WithEmptyParameters()
+        {
+            string actualResult = EdmHelper.GetParametersString(new List<IEdmOperationParameter>());
+
+            string expectedResult = "()";
+
+            actualResult.ShouldBeEquivalentTo(expectedResult);
+        }
+
+        [TestMethod]
+        public void TestGetParametersString_WithSingleParameter()
+        {
+            var typeReference = new EdmTypeReferenceForTest(new EdmSchemaTypeForTest("Type1", "Test"), false);
+            List<IEdmOperationParameter> parameters = new List<IEdmOperationParameter>
+            {
+                new EdmOperationParameter(new EdmAction("Test", "Action", typeReference, false, new EdmPropertyPathExpression("TestPath")), "par1", typeReference)
+            };
+            string actualResult = EdmHelper.GetParametersString(parameters);
+
+            string expectedResult = "(Test.Type1 par1)";
+
+            actualResult.ShouldBeEquivalentTo(expectedResult);
+        }
+
+        [TestMethod]
+        public void TestGetParametersString_WithAFewParameters()
+        {
+            var typeReference = new EdmTypeReferenceForTest(new EdmSchemaTypeForTest("Type1", "Test"), false);
+            List<IEdmOperationParameter> parameters = new List<IEdmOperationParameter>
+            {
+                new EdmOperationParameter(new EdmAction("Test", "Action", typeReference, false, new EdmPropertyPathExpression("TestPath")), "par1", typeReference),
+                new EdmOperationParameter(new EdmAction("Test", "Action", typeReference, false, new EdmPropertyPathExpression("TestPath")), "par2", typeReference)
+            };
+            string actualResult = EdmHelper.GetParametersString(parameters);
+
+            string expectedResult = "(Test.Type1 par1, Test.Type1 par2)";
+
+            actualResult.ShouldBeEquivalentTo(expectedResult);
         }
     }
 }

--- a/test/ODataConnectedService.Tests/Converters/BoolToVisibilityConverterTests.cs
+++ b/test/ODataConnectedService.Tests/Converters/BoolToVisibilityConverterTests.cs
@@ -1,0 +1,76 @@
+﻿//-----------------------------------------------------------------------------------
+// <copyright file="BoolToVisibilityConverterTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Windows;
+using FluentAssertions;
+using Microsoft.OData.ConnectedService.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ODataConnectedService.Tests.Converters
+{
+    [TestClass]
+    public class BoolToVisibilityConverterTests
+    {
+        [TestMethod]
+        public void Convert_ShouldReturnVisible_ForTrueValue()
+        {
+            var result = new BoolToVisibilityConverter()
+                .Convert(true, typeof(Visibility), null, CultureInfo.CurrentCulture);
+
+            result.Should()
+                .Be(Visibility.Visible);
+        }
+
+        [TestMethod]
+        public void Convert_ShouldReturnCollapsed_ForFalseValue()
+        {
+            var result = new BoolToVisibilityConverter()
+                .Convert(false, typeof(Visibility), null, CultureInfo.CurrentCulture);
+
+            result.Should()
+                .Be(Visibility.Collapsed);
+        }
+
+        [TestMethod]
+        public void Convert_ShouldThrowNotSupportedException_ForNonVisibilityTargetType()
+        {
+            Action convertAction = () =>
+            {
+                new BoolToVisibilityConverter()
+                    .Convert(null, typeof(bool), null, CultureInfo.CurrentCulture);
+            };
+
+            convertAction.ShouldThrow<NotSupportedException>();
+        }
+
+        [TestMethod]
+        public void Convert_ShouldThrowNotSupportedException_ForNonBooleanValue()
+        {
+            Action convertAction = () =>
+            {
+                new BoolToVisibilityConverter()
+                    .Convert("string", typeof(Visibility), null, CultureInfo.CurrentCulture);
+            };
+
+            convertAction.ShouldThrow<NotSupportedException>();
+        }
+
+        [TestMethod]
+        public void ConvertBack_ShouldThrowNotSupportedException()
+        {
+            Action convertBackAction = () =>
+            {
+                new BoolToVisibilityConverter()
+                    .ConvertBack(null, typeof(bool), null, CultureInfo.CurrentCulture);
+            };
+
+            convertBackAction.ShouldThrow<NotSupportedException>();
+        }
+    }
+}

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\EdmHelperTests.cs" />
+    <Compile Include="Converters\BoolToVisibilityConverterTests.cs" />
     <Compile Include="Converters\SchemaTypeModelToVisibilityConverterTests.cs" />
     <Compile Include="ODataConnectedServiceWizardTests.cs" />
     <Compile Include="Common\ProjectHelperTests.cs" />

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -145,9 +145,27 @@ namespace ODataConnectedService.Tests
             operationsPage.OnPageEnteringAsync(new WizardEnteringArgs(endpointPage)).Wait();
             operationsPage.OperationImports.ShouldBeEquivalentTo(new List<OperationImportModel>()
             {
-                new OperationImportModel() { Name = "GetNearestAirport", IsSelected = true },
-                new OperationImportModel() { Name = "GetPersonWithMostFriends", IsSelected = true },
-                new OperationImportModel() { Name = "ResetDataSource", IsSelected = true }
+                new OperationImportModel
+                {
+                    ReturnType = "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport",
+                    ParametersString = "(Edm.Double lat, Edm.Double lon)",
+                    Name = "GetNearestAirport",
+                    IsSelected = true
+                },
+                new OperationImportModel
+                {
+                    ReturnType = "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person",
+                    ParametersString = "()",
+                    Name = "GetPersonWithMostFriends",
+                    IsSelected = true
+                },
+                new OperationImportModel
+                {
+                    ReturnType = "void",
+                    ParametersString = "()",
+                    Name = "ResetDataSource",
+                    IsSelected = true
+                }
             });
 
             var typesPage = wizard.SchemaTypesViewModel;
@@ -278,9 +296,27 @@ namespace ODataConnectedService.Tests
             operationsPage.OnPageEnteringAsync(new WizardEnteringArgs(endpointPage)).Wait();
             operationsPage.OperationImports.ShouldBeEquivalentTo(new List<OperationImportModel>()
             {
-                new OperationImportModel() { Name = "GetNearestAirport", IsSelected = true },
-                new OperationImportModel() { Name = "GetPersonWithMostFriends", IsSelected = false },
-                new OperationImportModel() { Name = "ResetDataSource", IsSelected = false }
+                new OperationImportModel
+                {
+                    ReturnType = "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Airport",
+                    ParametersString = "(Edm.Double lat, Edm.Double lon)",
+                    Name = "GetNearestAirport",
+                    IsSelected = true
+                },
+                new OperationImportModel
+                {
+                    ReturnType = "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Person",
+                    ParametersString = "()",
+                    Name = "GetPersonWithMostFriends",
+                    IsSelected = false
+                },
+                new OperationImportModel
+                {
+                    ReturnType = "void",
+                    ParametersString = "()",
+                    Name = "ResetDataSource",
+                    IsSelected = false
+                }
             });
 
             var typesPage = wizard.SchemaTypesViewModel;
@@ -878,8 +914,20 @@ namespace ODataConnectedService.Tests
             operationsPage.OnPageEnteringAsync(null).Wait();
             operationsPage.OperationImports.ShouldBeEquivalentTo(new List<OperationImportModel>()
             {
-                new OperationImportModel() { Name = "GetRandomThing", IsSelected = true },
-                new OperationImportModel() { Name = "ResetThings", IsSelected = true }
+                new OperationImportModel
+                {
+                    ReturnType = "Microsoft.OData.Service.Sample.TrippinInMemory.Models.Thing",
+                    ParametersString = "()",
+                    Name = "GetRandomThing",
+                    IsSelected = true
+                },
+                new OperationImportModel
+                {
+                    ReturnType = "void",
+                    ParametersString = "()",
+                    Name = "ResetThings",
+                    IsSelected = true
+                }
             });
             operationsPage.OperationImports.FirstOrDefault(o => o.Name == "ResetThings").IsSelected = false;
 

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -1,6 +1,6 @@
 ﻿//-----------------------------------------------------------------------------------
 // <copyright file="ConfigOdataEndPointViewModelTests.cs" company=".NET Foundation">
-//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //-----------------------------------------------------------------------------------

--- a/test/ODataConnectedService.Tests/ViewModels/OperationImportsViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/OperationImportsViewModelTests.cs
@@ -1,6 +1,6 @@
 ﻿//-----------------------------------------------------------------------------------
 // <copyright file="OperationImportsViewModelTests.cs" company=".NET Foundation">
-//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //-----------------------------------------------------------------------------------
@@ -47,8 +47,20 @@ namespace ODataConnectedService.Tests.ViewModels
 
             objectSelection.OperationImports.ShouldBeEquivalentTo(new List<OperationImportModel>()
             {
-                new OperationImportModel() { Name = "GetTotal", IsSelected = true },
-                new OperationImportModel() { Name = "Update", IsSelected = true }
+                new OperationImportModel
+                {
+                    ReturnType = "Test.TypeDef",
+                    ParametersString = "()",
+                    Name = "GetTotal",
+                    IsSelected = true
+                },
+                new OperationImportModel
+                {
+                    ReturnType = "void",
+                    ParametersString = "()",
+                    Name = "Update",
+                    IsSelected = true
+                }
             });
         }
 
@@ -108,7 +120,7 @@ namespace ODataConnectedService.Tests.ViewModels
 
             objectSelection.OperationImports.Count().Should().Be(0);
         }
-        
+
         [TestMethod]
         public void SelectAll_ShouldMarkAllOperationsAsSelected()
         {


### PR DESCRIPTION
Add feature #127

![show_operation](https://user-images.githubusercontent.com/29679226/84497553-b1c9b380-acb7-11ea-9fed-8a5f7ae33d46.gif)

Added the tests below:

To **EdmHelperTests:**

- [x] `TestGetParametersString_WithEmptyParameters`;
- [x] `TestGetParametersString_WithSingleParameter`;
- [x] `TestGetParametersString_WithAFewParameters`.

To **BoolToVisibilityConverterTests:**

- [x] `Convert_ShouldReturnVisible_ForTrueValue`;
- [x] `Convert_ShouldReturnCollapsed_ForFalseValue`;
- [x] `Convert_ShouldThrowNotSupportedException_ForNonVisibilityTargetType`;
- [x] `Convert_ShouldThrowNotSupportedException_ForNonBooleanValue`;
- [x] `ConvertBack_ShouldThrowNotSupportedException`.