### PR TITLE
Feature #145 : Showing the operation imports count

### DIFF
--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -1,6 +1,6 @@
 ﻿//---------------------------------------------------------------------------------
 // <copyright file="OperationImportsViewModel.cs" company=".NET Foundation">
-//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //---------------------------------------------------------------------------------
@@ -22,6 +22,9 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         private bool _isSupportedVersion;
 
         public UserSettings UserSettings { get; set; }
+
+        private long _operationImportsCount = 0;
+        public long OperationImportsCount => this._operationImportsCount;
 
         internal bool IsEntered;
 
@@ -76,6 +79,10 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             await base.OnPageEnteringAsync(args);
             this.View = new OperationImports { DataContext = this };
             this.PageEntering?.Invoke(this, EventArgs.Empty);
+            if (this.View is OperationImports view)
+            {
+                view.SelectedOperationImportsCount.Text = OperationImports.Count(x => x.IsSelected).ToString();
+            }
         }
 
         public override async Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
@@ -126,6 +133,11 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                                 schemaTypeModel.IsSelected = currentOperationImportModel.IsSelected;
                             }
                         }
+
+                        if (this.View is OperationImports view)
+                        {
+                            view.SelectedOperationImportsCount.Text = OperationImports.Count(x => x.IsSelected).ToString();
+                        }
                     };
                     toLoad.Add(operationImportModel);
 
@@ -134,6 +146,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
 
             OperationImports = toLoad.OrderBy(o => o.Name).ToList();
+
+            _operationImportsCount = OperationImports.Count();
         }
 
         /// <summary>
@@ -175,6 +189,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         public void EmptyList()
         {
             OperationImports = Enumerable.Empty<OperationImportModel>();
+            _operationImportsCount = 0;
         }
 
         public void SelectAll()

--- a/src/Views/OperationImports.xaml
+++ b/src/Views/OperationImports.xaml
@@ -1,25 +1,24 @@
-﻿<UserControl x:Class="Microsoft.OData.ConnectedService.Views.OperationImports"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Microsoft.OData.ConnectedService.Views"
-             xmlns:viewModels="clr-namespace:Microsoft.OData.ConnectedService.ViewModels"
-             d:DataContext="{d:DesignInstance Type=viewModels:OperationImportsViewModel}"
-             mc:Ignorable="d" 
-             d:DesignHeight="300" d:DesignWidth="500">
+﻿<UserControl
+    x:Class="Microsoft.OData.ConnectedService.Views.OperationImports"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:Microsoft.OData.ConnectedService.Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="clr-namespace:Microsoft.OData.ConnectedService.ViewModels"
+    d:DataContext="{d:DesignInstance Type=viewModels:OperationImportsViewModel}"
+    d:DesignHeight="300"
+    d:DesignWidth="500"
+    mc:Ignorable="d">
     <StackPanel>
-        <TextBlock
-            Margin="0, 5, 0, 5">
+        <TextBlock Margin="0,5,0,5">
             Select which function and action imports will be included in the generated code.
         </TextBlock>
-        <StackPanel
-            Margin="0, 5, 0, 5"
-            Orientation="Horizontal">
+        <StackPanel Margin="0,5,0,5" Orientation="Horizontal">
             <Button
                 x:Name="SelectAll"
-                Margin="0, 0, 2, 0"
                 MinWidth="75"
+                Margin="0,0,2,0"
                 Click="SelectAll_Click">
                 Select All
             </Button>
@@ -29,12 +28,21 @@
                 Click="UnselectAll_Click">
                 Unselect All
             </Button>
+            <DockPanel Margin="5,5,0,0">
+                <TextBlock Text="Selected operation imports:" />
+                <TextBlock
+                    x:Name="SelectedOperationImportsCount"
+                    Margin="5,0,0,0"
+                    Text="0" />
+                <TextBlock Text="/" />
+                <TextBlock Text="{Binding OperationImportsCount}" />
+            </DockPanel>
         </StackPanel>
         <ListBox
             x:Name="OperationImportsList"
-            ItemsSource="{Binding OperationImports}"
             MinHeight="150"
             MaxHeight="150"
+            ItemsSource="{Binding OperationImports}"
             ScrollViewer.HorizontalScrollBarVisibility="Auto"
             ScrollViewer.VerticalScrollBarVisibility="Auto"
             Visibility="Visible">
@@ -43,20 +51,18 @@
                     <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                         <CheckBox
                             Width="16"
-                            Margin="0, 5, 5, 0"
+                            Margin="0,5,5,0"
                             VerticalAlignment="Center"
-                            IsChecked="{Binding IsSelected, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" />
-                        <TextBlock
-                            VerticalAlignment="Bottom"
-                            Text="{Binding Name}" />
+                            IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <TextBlock VerticalAlignment="Bottom" Text="{Binding Name}" />
                     </StackPanel>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
         <TextBlock
-            Visibility="{Binding VersionWarningVisibility}"
-            Margin="0, 10, 0, 0"
-            FontWeight="Bold">
+            Margin="0,10,0,0"
+            FontWeight="Bold"
+            Visibility="{Binding VersionWarningVisibility}">
             This feature is only available for OData v4 services.
         </TextBlock>
     </StackPanel>

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -617,17 +617,33 @@ namespace ODataConnectedService.Tests
 
             var typesPage = wizard.SchemaTypesViewModel;
             typesPage.OnPageEnteringAsync(null).Wait();
+            var typesPageView = typesPage.View as SchemaTypes;
+            Assert.Equal(typesPage.SchemaTypesCount, typesPage.SchemaTypes.Count());
+            Assert.Equal(typesPage.BoundOperationsCount, typesPage.SchemaTypes.SelectMany(x => x.BoundOperations).Count());
+            Assert.Equal(typesPageView?.SelectedSchemaTypesCount.Text, typesPage.SchemaTypes.Count().ToString());
+            Assert.Equal(typesPageView?.SelectedBoundOperationsCount.Text, typesPage.SchemaTypes.SelectMany(x => x.BoundOperations).Count().ToString());
             var typeEmployee = typesPage.SchemaTypes.FirstOrDefault(t => t.ShortName == "Employee");
             typeEmployee.IsSelected = false;
+            Assert.Equal(typesPageView?.SelectedSchemaTypesCount.Text,
+                (typesPage.SchemaTypesCount - typesPage.ExcludedSchemaTypeNames.Count()).ToString());
             var boundOperationGetInvolvedPeople = typesPage.SchemaTypes.FirstOrDefault(t => t.ShortName == "Trip")
                 ?.BoundOperations.FirstOrDefault(o => o.Name.Contains("GetInvolvedPeople"));
             boundOperationGetInvolvedPeople.IsSelected = false;
+            Assert.Equal(typesPageView?.SelectedBoundOperationsCount.Text,
+                (typesPage.BoundOperationsCount -
+                 typesPage.ExcludedBoundOperationsNames.Count()).ToString());
             typesPage.OnPageLeavingAsync(null).Wait();
 
             var operationsPage = wizard.OperationImportsViewModel;
             operationsPage.OnPageEnteringAsync(null).Wait();
+            var operationsPageView = operationsPage.View as OperationImports;
+            Assert.Equal(operationsPage.OperationImportsCount, operationsPage.OperationImports.Count());
+            Assert.Equal(operationsPageView?.SelectedOperationImportsCount.Text, operationsPage.OperationImportsCount.ToString());
             var operationNearestAirport = operationsPage.OperationImports.FirstOrDefault(o => o.Name == "GetNearestAirport");
             operationNearestAirport.IsSelected = false;
+            Assert.Equal(operationsPageView?.SelectedOperationImportsCount.Text,
+                (operationsPage.OperationImportsCount - operationsPage.ExcludedOperationImportsNames.Count())
+                .ToString());
             operationsPage.OnPageLeavingAsync(null).Wait();
 
             var advancedPage = wizard.AdvancedSettingsViewModel;
@@ -657,6 +673,9 @@ namespace ODataConnectedService.Tests
             operationsPage.OnPageEnteringAsync(null).Wait();
             operationNearestAirport = operationsPage.OperationImports.FirstOrDefault(o => o.Name == "GetNearestAirport");
             Assert.False(operationNearestAirport.IsSelected);
+            Assert.Equal(operationsPageView?.SelectedOperationImportsCount.Text,
+                (operationsPage.OperationImportsCount - operationsPage.ExcludedOperationImportsNames.Count())
+                .ToString());
             var operationResetDataSource = operationsPage.OperationImports.FirstOrDefault(o => o.Name == "ResetDataSource");
             operationResetDataSource.IsSelected = false;
             operationsPage.OnPageLeavingAsync(null).Wait();
@@ -664,6 +683,8 @@ namespace ODataConnectedService.Tests
             typesPage.OnPageEnteringAsync(null).Wait();
             typeEmployee = typesPage.SchemaTypes.FirstOrDefault(t => t.ShortName == "Employee");
             Assert.False(typeEmployee.IsSelected);
+            Assert.Equal(typesPageView?.SelectedSchemaTypesCount.Text,
+                (typesPage.SchemaTypesCount - typesPage.ExcludedSchemaTypeNames.Count()).ToString());
             typeEmployee.IsSelected = true;
             var typeFlight = typesPage.SchemaTypes.FirstOrDefault(t => t.ShortName == "Flight");
             typeFlight.IsSelected = false;


### PR DESCRIPTION
Add a feature #145:

![selected_operations_count](https://user-images.githubusercontent.com/29679226/84510254-923d8580-accd-11ea-9c85-008a56f19da8.gif)

Updated the tests below:

In **ODataConnectedServiceWizardTests:**

- [x] `ShouldPreserveState_WhenMovingBetweenPagesAndBack`.