### PR TITLE
Fix #158 : Search box for oData entitities to add

### DIFF
--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -41,6 +41,30 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         }
 
         public IEnumerable<OperationImportModel> OperationImports { get; set; }
+
+        private string _searchText;
+        public string SearchText
+        {
+            get { return _searchText; }
+            set
+            {
+                _searchText = value;
+
+                this.OnPropertyChanged(nameof(SearchText));
+                this.OnPropertyChanged(nameof(FilteredOperationImports));
+            }
+        }
+
+        public IEnumerable<OperationImportModel> FilteredOperationImports
+        {
+            get
+            {
+                return SearchText == null
+                    ? OperationImports
+                    : OperationImports.Where(x => x.Name.StartsWith(SearchText, StringComparison.InvariantCultureIgnoreCase));
+            }
+        }
+
         /// <summary>
         /// Whether the connected service supports operation selection feature for the current OData version, default is true
         /// </summary>

--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -23,9 +23,19 @@ namespace Microsoft.OData.ConnectedService.ViewModels
     {
         private bool _isSupportedVersion;
 
+        /// <summary>
+        /// User settings.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Models.UserSettings"/>
+        /// </remarks>
         public UserSettings UserSettings { get; set; }
 
         private long _operationImportsCount = 0;
+
+        /// <summary>
+        /// Gets the operation imports count.
+        /// </summary>
         public long OperationImportsCount => this._operationImportsCount;
 
         internal bool IsEntered;
@@ -40,9 +50,16 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             this.UserSettings = userSettings;
         }
 
+        /// <summary>
+        /// A list of operation imports.
+        /// </summary>
         public IEnumerable<OperationImportModel> OperationImports { get; set; }
 
         private string _searchText;
+
+        /// <summary>
+        /// Text to filter displayed operation imports.
+        /// </summary>
         public string SearchText
         {
             get { return _searchText; }
@@ -55,6 +72,9 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
+        /// <summary>
+        /// Gets the operation imports that start with the search text.
+        /// </summary>
         public IEnumerable<OperationImportModel> FilteredOperationImports
         {
             get
@@ -89,6 +109,9 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
+        /// <summary>
+        /// Gets the operation imports that will be excluded while generating code.
+        /// </summary>
         public IEnumerable<string> ExcludedOperationImportsNames
         {
             get
@@ -99,6 +122,12 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
         public event EventHandler<EventArgs> PageEntering;
 
+        /// <summary>
+        /// Executed when entering the page for selecting operation imports.
+        /// It fires PageEntering event which ensures all types are loaded on the UI.
+        /// It also ensures all related entities are computed and cached.
+        /// </summary>
+        /// <param name="args">Event arguments being passed to the method.</param>
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
             this.IsEntered = true;
@@ -111,6 +140,10 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
+        /// <summary>
+        /// Executed when leaving the page for selecting operation imports.
+        /// </summary>
+        /// <param name="args">Event arguments being passed to the method.</param>
         public override async Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
         {
             SaveToUserSettings();
@@ -118,11 +151,11 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         }
 
         /// <summary>
-        /// Loads operation imports except the ones that require a type that is excluded
+        /// Loads operation imports except the ones that require a type that is excluded.
         /// </summary>
-        /// <param name="operationImports">a list of all the operation imports.</param>
+        /// <param name="operationImports">A list of all the operation imports.</param>
         /// <param name="excludedSchemaTypes">A collection of schema types that will be excluded from generated code.</param>
-        /// <param name="schemaTypeModels">a dictionary of schema type and the associated schematypemodel.</param>
+        /// <param name="schemaTypeModels">A dictionary of schema type and the associated schematypemodel.</param>
         public void LoadOperationImports(IEnumerable<IEdmOperationImport> operationImports, ICollection<string> excludedSchemaTypes, IDictionary<string, SchemaTypeModel> schemaTypeModels)
         {
             var toLoad = new List<OperationImportModel>();
@@ -179,9 +212,9 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         }
 
         /// <summary>
-        /// Checks if the operation import should be included
+        /// Checks if the operation import should be included.
         /// </summary>
-        /// <param name="operationImport">operation import.</param>
+        /// <param name="operationImport">Operation import.</param>
         /// <param name="excludedTypes">A collection of excluded types.</param>
         /// <returns>true if the operation import should be included, otherwise false.</returns>
         public bool IsOperationImportIncluded(IEdmOperationImport operationImport, ICollection<string> excludedTypes)
@@ -206,6 +239,13 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             return true;
         }
 
+        /// <summary>
+        /// Excludes the operation imports from code generation.
+        /// </summary>
+        /// <remarks>
+        /// Sets operationModel isSelected property to be excluded to false.
+        /// </remarks>
+        /// <param name="operationsToExclude">A list of operation imports to be exclude.</param>
         public void ExcludeOperationImports(IEnumerable<string> operationsToExclude)
         {
             foreach (var operationModel in OperationImports)
@@ -214,12 +254,18 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
+        /// <summary>
+        /// Empties a list of operation imports.
+        /// </summary>
         public void EmptyList()
         {
             OperationImports = Enumerable.Empty<OperationImportModel>();
             _operationImportsCount = 0;
         }
 
+        /// <summary>
+        /// Selects all operation imports.
+        /// </summary>
         public void SelectAll()
         {
             foreach (var operation in OperationImports)
@@ -228,6 +274,9 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
+        /// <summary>
+        /// Deselect all operation imports.
+        /// </summary>
         public void UnselectAll()
         {
             foreach (var operation in OperationImports)
@@ -236,6 +285,9 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
+        /// <summary>
+        /// Save the selected operation imports to user settings.
+        /// </summary>
         private void SaveToUserSettings()
         {
             if (this.UserSettings != null)
@@ -246,6 +298,9 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
+        /// <summary>
+        /// Loads operation import configurations from user settings.
+        /// </summary>
         public void LoadFromUserSettings()
         {
             if (UserSettings != null)

--- a/src/ViewModels/SchemaTypesViewModel.cs
+++ b/src/ViewModels/SchemaTypesViewModel.cs
@@ -27,6 +27,29 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
         public IEnumerable<SchemaTypeModel> SchemaTypes { get; set; }
 
+        private string _searchText;
+        public string SearchText
+        {
+            get { return _searchText; }
+            set
+            {
+                _searchText = value;
+
+                this.OnPropertyChanged(nameof(SearchText));
+                this.OnPropertyChanged(nameof(FilteredSchemaTypes));
+            }
+        }
+
+        public IEnumerable<SchemaTypeModel> FilteredSchemaTypes
+        {
+            get
+            {
+                return SearchText == null
+                    ? SchemaTypes
+                    : SchemaTypes.Where(x => x.ShortName.StartsWith(SearchText, StringComparison.InvariantCultureIgnoreCase));
+            }
+        }
+
         private long _schemaTypesCount = 0;
         public long SchemaTypesCount => this._schemaTypesCount;
 

--- a/src/Views/OperationImports.xaml
+++ b/src/Views/OperationImports.xaml
@@ -42,11 +42,20 @@
                 <TextBlock Text="{Binding OperationImportsCount}" />
             </DockPanel>
         </StackPanel>
+        <StackPanel Margin="0,5,0,5" Orientation="Horizontal">
+            <TextBlock Margin="0,5,0,5" Text="Search operations:" />
+            <TextBox
+                Width="250"
+                Height="20"
+                Margin="5,5,10,5"
+                HorizontalAlignment="Left"
+                Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+        </StackPanel>
         <ListBox
             x:Name="OperationImportsList"
             MinHeight="150"
             MaxHeight="150"
-            ItemsSource="{Binding OperationImports}"
+            ItemsSource="{Binding FilteredOperationImports}"
             ScrollViewer.HorizontalScrollBarVisibility="Auto"
             ScrollViewer.VerticalScrollBarVisibility="Auto"
             Visibility="Visible">

--- a/src/Views/SchemaTypes.xaml
+++ b/src/Views/SchemaTypes.xaml
@@ -64,11 +64,20 @@
                 <TextBlock Text="{Binding BoundOperationsCount}" />
             </DockPanel>
         </StackPanel>
+        <StackPanel Margin="0,5,0,5" Orientation="Horizontal">
+            <TextBlock Margin="0,5,0,5" Text="Search schemas:" />
+            <TextBox
+                Width="250"
+                Height="20"
+                Margin="5,5,10,5"
+                HorizontalAlignment="Left"
+                Text="{Binding SearchText, UpdateSourceTrigger=PropertyChanged}" />
+        </StackPanel>
         <TreeView
             x:Name="SchemaTypesTreeView"
             MinHeight="150"
-            MaxHeight="270"
-            ItemsSource="{Binding SchemaTypes}"
+            MaxHeight="230"
+            ItemsSource="{Binding FilteredSchemaTypes}"
             ScrollViewer.HorizontalScrollBarVisibility="Auto"
             ScrollViewer.VerticalScrollBarVisibility="Auto"
             Visibility="Visible">

--- a/test/ODataConnectedService.Tests/ViewModels/OperationImportsViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/OperationImportsViewModelTests.cs
@@ -174,5 +174,44 @@ namespace ODataConnectedService.Tests.ViewModels
                 });
             }
         }
+
+        [TestMethod]
+        public void FillingSearchText_ShouldFilterOperationImports()
+        {
+            using (var objectSelection = new OperationImportsViewModel
+            {
+                OperationImports = new List<OperationImportModel>
+                {
+                    new OperationImportModel { Name = "Func1", IsSelected = true },
+                    new OperationImportModel { Name = "AnotherFunc2", IsSelected = true }
+                }
+            })
+            {
+                objectSelection.FilteredOperationImports.ShouldBeEquivalentTo(new List<OperationImportModel>
+                {
+                    new OperationImportModel { Name = "Func1", IsSelected = true },
+                    new OperationImportModel { Name = "AnotherFunc2", IsSelected = true }
+                });
+
+                objectSelection.SearchText = "fun";
+
+                objectSelection.FilteredOperationImports.ShouldBeEquivalentTo(new List<OperationImportModel>
+                {
+                    new OperationImportModel { Name = "Func1", IsSelected = true }
+                });
+
+                objectSelection.SearchText = "wrong";
+
+                objectSelection.FilteredOperationImports.ShouldBeEquivalentTo(new List<OperationImportModel>());
+
+                objectSelection.SearchText = string.Empty;
+
+                objectSelection.FilteredOperationImports.ShouldBeEquivalentTo(new List<OperationImportModel>
+                {
+                    new OperationImportModel { Name = "Func1", IsSelected = true },
+                    new OperationImportModel { Name = "AnotherFunc2", IsSelected = true }
+                });
+            }
+        }
     }
 }

--- a/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
@@ -834,25 +834,67 @@ namespace ODataConnectedService.Tests.ViewModels
                 SchemaTypes = new List<SchemaTypeModel>()
             })
             {
+                var entityTypeWithBoundOperation = new EdmEntityType("Test", "WithBoundOperationEntityType");
+                var boundOperation = new EdmAction("Test", "Enter",
+                    new EdmPrimitiveTypeReference(new EdmPrimitiveType(EdmPrimitiveTypeKind.Boolean), false), true,
+                    new EdmPathExpression(string.Empty));
+
                 var listToLoad = new List<IEdmSchemaType>
                 {
                     new EdmEntityType("Test", "EntityType", new EdmEntityType("Test", "BaseEntityType")),
-                    new EdmEntityType("Test", "BaseEntityType")
+                    new EdmEntityType("Test", "BaseEntityType"),
+                    entityTypeWithBoundOperation
                 };
 
-                objectSelection.LoadSchemaTypes(listToLoad, new Dictionary<IEdmType, List<IEdmOperation>>());
+                objectSelection.LoadSchemaTypes(listToLoad, new Dictionary<IEdmType, List<IEdmOperation>> 
+                {
+                    {
+                        entityTypeWithBoundOperation, new List<IEdmOperation>
+                        {
+                            boundOperation
+                        }
+                    }
+                });
 
                 objectSelection.FilteredSchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
                 {
                     new SchemaTypeModel { ShortName = "BaseEntityType", Name = "Test.BaseEntityType", IsSelected = true },
-                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true }
+                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true },
+                    new SchemaTypeModel
+                    {
+                        ShortName = "WithBoundOperationEntityType",
+                        Name = "Test.WithBoundOperationEntityType",
+                        IsSelected = true,
+                        BoundOperations = new List<BoundOperationModel> {
+                            new BoundOperationModel
+                            {
+                                Name = "Enter(Test.WithBoundOperationEntityType)",
+                                ShortName = "Enter",
+                                IsSelected = true
+                            }
+                        }
+                    }
                 });
 
                 objectSelection.SearchText = "e";
 
                 objectSelection.FilteredSchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
                 {
-                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true }
+                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true },
+                    new SchemaTypeModel
+                    {
+                        ShortName = "WithBoundOperationEntityType",
+                        Name = "Test.WithBoundOperationEntityType",
+                        IsSelected = true,
+                        BoundOperations = new List<BoundOperationModel> {
+                            new BoundOperationModel
+                            {
+                                Name = "Enter(Test.WithBoundOperationEntityType)",
+                                ShortName = "Enter",
+                                IsSelected = true
+                            }
+                        }
+                    }
                 });
 
                 objectSelection.SearchText = "wrong";
@@ -864,7 +906,21 @@ namespace ODataConnectedService.Tests.ViewModels
                 objectSelection.FilteredSchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
                 {
                     new SchemaTypeModel { ShortName = "BaseEntityType", Name = "Test.BaseEntityType", IsSelected = true },
-                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true }
+                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true },
+                    new SchemaTypeModel
+                    {
+                        ShortName = "WithBoundOperationEntityType",
+                        Name = "Test.WithBoundOperationEntityType",
+                        IsSelected = true,
+                        BoundOperations = new List<BoundOperationModel> {
+                            new BoundOperationModel
+                            {
+                                Name = "Enter(Test.WithBoundOperationEntityType)",
+                                ShortName = "Enter",
+                                IsSelected = true
+                            }
+                        }
+                    }
                 });
             }
         }

--- a/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
@@ -825,5 +825,48 @@ namespace ODataConnectedService.Tests.ViewModels
                 });
             }
         }
+
+        [TestMethod]
+        public void FillingSearchText_ShouldFilterSchemaTypes()
+        {
+            using (var objectSelection = new SchemaTypesViewModel
+            {
+                SchemaTypes = new List<SchemaTypeModel>()
+            })
+            {
+                var listToLoad = new List<IEdmSchemaType>
+                {
+                    new EdmEntityType("Test", "EntityType", new EdmEntityType("Test", "BaseEntityType")),
+                    new EdmEntityType("Test", "BaseEntityType")
+                };
+
+                objectSelection.LoadSchemaTypes(listToLoad, new Dictionary<IEdmType, List<IEdmOperation>>());
+
+                objectSelection.FilteredSchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel { ShortName = "BaseEntityType", Name = "Test.BaseEntityType", IsSelected = true },
+                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true }
+                });
+
+                objectSelection.SearchText = "e";
+
+                objectSelection.FilteredSchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true }
+                });
+
+                objectSelection.SearchText = "wrong";
+
+                objectSelection.FilteredSchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>());
+
+                objectSelection.SearchText = string.Empty;
+
+                objectSelection.FilteredSchemaTypes.ShouldBeEquivalentTo(new List<SchemaTypeModel>
+                {
+                    new SchemaTypeModel { ShortName = "BaseEntityType", Name = "Test.BaseEntityType", IsSelected = true },
+                    new SchemaTypeModel { ShortName = "EntityType", Name = "Test.EntityType", IsSelected = true }
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix #158 :

![search_text_box](https://user-images.githubusercontent.com/29679226/88340226-2165a080-cd44-11ea-9b3d-e442214c0d8f.gif)

Added the tests below:

To **SchemaTypesViewModelTests:**

- [x] `FillingSearchText_ShouldFilterSchemaTypes`.

To **OperationImportsViewModelTests:**

- [x] `FillingSearchText_ShouldFilterOperationImports`.