### PR TITLE
Set the most logical config defaults for the wizard

### DIFF
--- a/src/Common/ExtensionMethods.cs
+++ b/src/Common/ExtensionMethods.cs
@@ -1,0 +1,46 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ExtensionMethods.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//----------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.OData.ConnectedService.Common
+{
+    internal static class ExtensionMethods
+    {
+        /// <summary>
+        /// Copies public properties with matching name and type from one object to the other.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <param name="source">The source.</param>
+        public static void CopyPropertiesFrom(this object target, object source)
+        {
+            if (source == null)
+            {
+                return;
+            }
+
+            var fromProperties = source.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(d => d.GetGetMethod() != null);
+            var toProperties = target.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(d => d.GetSetMethod() != null);
+
+            foreach(var toProperty in toProperties)
+            {
+                var fromProperty = fromProperties.SingleOrDefault(d => 
+                    d.Name.Equals(toProperty.Name, StringComparison.Ordinal) 
+                    && toProperty.PropertyType.IsAssignableFrom(d.PropertyType));
+
+                if (fromProperty != null)
+                {
+                    toProperty.SetValue(target, fromProperty.GetValue(source));
+                }
+            }
+        }
+    }
+}

--- a/src/Common/UserSettingsPersistenceHelper.cs
+++ b/src/Common/UserSettingsPersistenceHelper.cs
@@ -36,7 +36,8 @@ namespace Microsoft.OData.ConnectedService.Common
                         {
                             // note: this overwrites existing settings file if it exists
                             stream = file.OpenFile(fileName, FileMode.Create);
-                            using (var writer = XmlWriter.Create(stream))
+
+                            using (var writer = XmlWriter.Create(stream, new XmlWriterSettings { Indent = true }))
                             {
                                 var dcs = new DataContractSerializer(userSettings.GetType());
                                 dcs.WriteObject(writer, userSettings);
@@ -112,7 +113,7 @@ namespace Microsoft.OData.ConnectedService.Common
 
         private static string GetStorageFileName(string providerId, string name)
         {
-            return providerId + "_" + name + ".xml";
+            return providerId + "." + name + ".xml";
         }
 
         private static IsolatedStorageFile GetIsolatedStorageFile()

--- a/src/Models/ServiceConfiguration.cs
+++ b/src/Models/ServiceConfiguration.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OData.ConnectedService.Models
         public bool EnableNamingAlias { get; set; }
         public bool IgnoreUnexpectedElementsAndAttributes { get; set; }
         public bool IncludeT4File { get; set; }
-        public List<string> ExcludedOperationImports;
-        public List<string> ExcludedBoundOperations;
+        public List<string> ExcludedOperationImports { get; set; }
+        public List<string> ExcludedBoundOperations { get; set; }
     }
 }

--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -5,147 +5,466 @@
 // </copyright>
 //----------------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Microsoft.OData.ConnectedService.Common;
 using Microsoft.VisualStudio.ConnectedServices;
+using Newtonsoft.Json;
 
 namespace Microsoft.OData.ConnectedService.Models
 {
     [DataContract]
-    internal class UserSettings
+    internal class UserSettings : INotifyPropertyChanged
     {
-        private const string Name = "Settings";
+        #region Const Members
+
         private const int MaxMruEntries = 10;
 
-        private ConnectedServiceLogger logger;
+        #endregion Const Members
+
+        #region Readonly Members
+
+        private readonly ConnectedServiceLogger logger;
+
+        private readonly string configName;
+
+        #endregion Readonly Members
+
+        #region Private Members
+
+        private ObservableCollection<string> mruEndpoints;
+
+        private string serviceName;
+
+        private string endpoint;
+
+        private string generatedFileNamePrefix;
+
+        private bool useNamespacePrefix;
+
+        private string namespacePrefix;
+
+        private bool useDataServiceCollection;
+
+        private bool makeTypesInternal;
+
+        private bool openGeneratedFilesInIDE;
+
+        private bool generateMultipleFiles;
+
+        private string customHttpHeaders;
+
+        private bool enableNamingAlias;
+
+        private bool ignoreUnexpectedElementsAndAttributes;
+
+        private bool includeT4File;
+
+        private bool includeWebProxy;
+
+        private string webProxyHost;
+
+        private bool includeWebProxyNetworkCredentials;
+
+        private string webProxyNetworkCredentialsUsername;
+
+        private string webProxyNetworkCredentialsPassword;
+
+        private string webProxyNetworkCredentialsDomain;
+
+        private bool includeCustomHeaders;
+
+        private List<string> excludedOperationImports;
+
+        private List<string> excludedBoundOperations;
+
+        private List<string> excludedSchemaTypes;
+
+        #endregion Private Members
+
+        public event PropertyChangedEventHandler PropertyChanged;
 
         [DataMember]
-        public ObservableCollection<string> MruEndpoints { get; set; }
-
-        [DataMember]
-        public string ServiceName { get; set; }
-
-        [DataMember]
-        public string Endpoint { get; set; }
-
-        [DataMember]
-        public string GeneratedFileNamePrefix { get; set; }
-
-        [DataMember]
-        public bool UseNamespacePrefix { get; set; }
-
-        [DataMember]
-        public string NamespacePrefix { get; set; }
-
-        [DataMember]
-        public bool UseDataServiceCollection { get; set; }
-
-        [DataMember]
-        public bool MakeTypesInternal { get; set; }
-
-        [DataMember]
-        public bool OpenGeneratedFilesInIDE { get; set; }
-
-        [DataMember]
-        public bool GenerateMultipleFiles { get; set; }
-
-        [DataMember]
-        public string CustomHttpHeaders { get; set; }
-
-        [DataMember]
-        public bool EnableNamingAlias { get; set; }
-
-        [DataMember]
-        public bool IgnoreUnexpectedElementsAndAttributes { get; set; }
-
-        [DataMember]
-        public bool IncludeT4File { get; set; }
-
-        [DataMember]
-        public bool IncludeWebProxy { get; set; }
-
-        [DataMember]
-        public string WebProxyHost { get; set; }
-
-        [DataMember]
-        public bool IncludeWebProxyNetworkCredentials { get; set; }
-
-        [DataMember]
-        public string WebProxyNetworkCredentialsUsername { get; set; }
-
-        [DataMember]
-        public string WebProxyNetworkCredentialsPassword { get; set; }
-
-        [DataMember]
-        public string WebProxyNetworkCredentialsDomain { get; set; }
-
-        [DataMember]
-        public bool IncludeCustomHeaders { get; set; }
-
-        [DataMember]
-        public List<string> ExcludedOperationImports { get; set; }
-
-        [DataMember]
-        public List<string> ExcludedBoundOperations { get; set; }
-
-        [DataMember]
-        public List<string> ExcludedSchemaTypes { get; set; }
-
-        public UserSettings()
+        public ObservableCollection<string> MruEndpoints
         {
-            this.MruEndpoints = new ObservableCollection<string>();
+            get { return mruEndpoints; }
+            set
+            {
+                mruEndpoints = value;
+                OnPropertyChanged();
+            }
         }
 
+        [DataMember]
+        public string ServiceName
+        {
+            get { return serviceName; }
+            set
+            {
+                serviceName = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public string Endpoint
+        {
+            get { return endpoint; }
+            set
+            {
+                endpoint = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public string GeneratedFileNamePrefix
+        {
+            get { return generatedFileNamePrefix; }
+            set
+            {
+                generatedFileNamePrefix = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool UseNamespacePrefix
+        {
+            get { return useNamespacePrefix; }
+            set
+            {
+                useNamespacePrefix = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public string NamespacePrefix
+        {
+            get { return namespacePrefix; }
+            set
+            {
+                namespacePrefix = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool UseDataServiceCollection
+        {
+            get { return useDataServiceCollection; }
+            set
+            {
+                useDataServiceCollection = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool MakeTypesInternal
+        {
+            get { return makeTypesInternal; }
+            set
+            {
+                makeTypesInternal = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool OpenGeneratedFilesInIDE
+        {
+            get { return openGeneratedFilesInIDE; }
+            set
+            {
+                openGeneratedFilesInIDE = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool GenerateMultipleFiles
+        {
+            get { return generateMultipleFiles; }
+            set
+            {
+                generateMultipleFiles = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [IgnoreDataMember] // Do not serialize - may contain authentication tokens
+        public string CustomHttpHeaders
+        {
+            get { return customHttpHeaders; }
+            set
+            {
+                customHttpHeaders = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool EnableNamingAlias
+        {
+            get { return enableNamingAlias; }
+            set
+            {
+                enableNamingAlias = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool IgnoreUnexpectedElementsAndAttributes
+        {
+            get { return ignoreUnexpectedElementsAndAttributes; }
+            set
+            {
+                ignoreUnexpectedElementsAndAttributes = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool IncludeT4File
+        {
+            get { return includeT4File; }
+            set
+            {
+                includeT4File = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool IncludeWebProxy
+        {
+            get { return includeWebProxy; }
+            set
+            {
+                includeWebProxy = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public string WebProxyHost
+        {
+            get { return webProxyHost; }
+            set
+            {
+                webProxyHost = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool IncludeWebProxyNetworkCredentials
+        {
+            get { return includeWebProxyNetworkCredentials; }
+            set
+            {
+                includeWebProxyNetworkCredentials = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [IgnoreDataMember] // Do not serialize - security consideration
+        public string WebProxyNetworkCredentialsUsername
+        {
+            get { return webProxyNetworkCredentialsUsername; }
+            set
+            {
+                webProxyNetworkCredentialsUsername = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [IgnoreDataMember] // Do not serialize - security consideration
+        public string WebProxyNetworkCredentialsPassword
+        {
+            get { return webProxyNetworkCredentialsPassword; }
+            set
+            {
+                webProxyNetworkCredentialsPassword = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public string WebProxyNetworkCredentialsDomain
+        {
+            get { return webProxyNetworkCredentialsDomain; }
+            set
+            {
+                webProxyNetworkCredentialsDomain = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool IncludeCustomHeaders
+        {
+            get { return includeCustomHeaders; }
+            set
+            {
+                includeCustomHeaders = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public List<string> ExcludedOperationImports
+        {
+            get { return excludedOperationImports; }
+            set
+            {
+                excludedOperationImports = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public List<string> ExcludedBoundOperations
+        {
+            get { return excludedBoundOperations; }
+            set
+            {
+                excludedBoundOperations = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public List<string> ExcludedSchemaTypes
+        {
+            get { return excludedSchemaTypes; }
+            set
+            {
+                excludedSchemaTypes = value;
+                OnPropertyChanged();
+            }
+        }
+
+        protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserSettings"/> class.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="configName">The name to use for the config file.</param>
+        public UserSettings(ConnectedServiceLogger logger, string configName = "Settings")
+        {
+            this.configName = configName;
+            this.logger = logger;
+            // Desired defaults
+            GeneratedFileNamePrefix = Constants.DefaultReferenceFileName;
+            NamespacePrefix = Constants.DefaultReferenceFileName;
+            ServiceName = Constants.DefaultServiceName;
+            UseDataServiceCollection = true; // To support entity and property tracking
+            EnableNamingAlias = true; // To force upper camel case in the event that entities are named in lower camel case
+            IgnoreUnexpectedElementsAndAttributes = true; // Ignore unexpected elements and attributes in the metadata document
+            ExcludedBoundOperations = new List<string>();
+            ExcludedOperationImports = new List<string>();
+            ExcludedSchemaTypes = new List<string>();
+            MruEndpoints = new ObservableCollection<string>();
+            UserSettingsPersistenceHelper.Load<UserSettings>(
+                providerId: Constants.ProviderId,
+                name: configName,
+                onLoaded: (userSettings) =>
+                {
+                    // onLoaded action is currently triggered only if settings are loaded from config file
+                    // Do this defensively all the same...
+                    if (userSettings != null)
+                    {
+                        foreach (var mruEndpoint in userSettings.MruEndpoints)
+                        {
+                            this.MruEndpoints.Add(mruEndpoint);
+                        }
+                    }
+                },
+                logger: logger);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserSettings"/> class.
+        /// </summary>
+        /// <param name="configName">The name to use for the config file.</param>
+        [JsonConstructor] // Constructor should be used to create a class during deserialization
+        public UserSettings(string configName = "Settings")
+            : this(null, configName)
+        {
+        }
+
+        /// <summary>
+        /// Saves user settings to config file.
+        /// </summary>
         public void Save()
         {
-            UserSettingsPersistenceHelper.Save(this, Constants.ProviderId, UserSettings.Name, null, this.logger);
+            UserSettingsPersistenceHelper.Save(this, Constants.ProviderId, configName, null, logger);
         }
 
-        public static UserSettings Load(ConnectedServiceLogger logger)
+        /// <summary>
+        /// Loads user settings from config file.
+        /// </summary>
+        public void Load()
         {
             var userSettings = UserSettingsPersistenceHelper.Load<UserSettings>(
-                Constants.ProviderId, UserSettings.Name, null, logger) ?? new UserSettings();
-            userSettings.logger = logger;
+                Constants.ProviderId, configName, null, logger);
 
-            return userSettings;
+            if (userSettings != null)
+            {
+                this.CopyPropertiesFrom(userSettings);
+            }
         }
 
-        public static void AddToTopOfMruList<T>(ObservableCollection<T> mruList, T item)
+        /// <summary>
+        /// Adds endpoint to the most recently used endpoints collection.
+        /// </summary>
+        /// <param name="endpoint">Endpoint</param>
+        public void AddMruEndpoint(string mruEndpoint)
         {
-            if (mruList == null)
+            if (string.IsNullOrWhiteSpace(mruEndpoint))
             {
                 return;
             }
 
-            var index = mruList.IndexOf(item);
+            var index = this.MruEndpoints.IndexOf(mruEndpoint);
+
             if (index >= 0)
             {
-                // Ensure there aren't any duplicates in the list.
-                for (var i = mruList.Count - 1; i > index; i--)
+                // Remove possible duplicates
+                for (var i = this.MruEndpoints.Count - 1; index > 0 && i > index; i--)
                 {
-                    if (EqualityComparer<T>.Default.Equals(mruList[i], item))
+                    if (this.MruEndpoints[i].Equals(mruEndpoint, StringComparison.Ordinal))
                     {
-                        mruList.RemoveAt(i);
+                        this.MruEndpoints.RemoveAt(i);
                     }
                 }
 
+                // Endpoint not at index 0
                 if (index > 0)
                 {
-                    // The item is in the MRU list but it is not at the top.
-                    mruList.Move(index, 0);
+                    this.MruEndpoints.Move(index, 0);
                 }
             }
             else
             {
-                // The item is not in the MRU list, make room for it by clearing out the oldest item.
-                while (mruList.Count >= UserSettings.MaxMruEntries)
+                while (this.MruEndpoints.Count >= MaxMruEntries)
                 {
-                    mruList.RemoveAt(mruList.Count - 1);
+                    this.MruEndpoints.RemoveAt(this.MruEndpoints.Count - 1);
                 }
 
-                mruList.Insert(0, item);
+                this.MruEndpoints.Insert(0, mruEndpoint);
             }
         }
     }

--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -388,7 +388,7 @@ namespace Microsoft.OData.ConnectedService.Models
                     {
                         foreach (var mruEndpoint in userSettings.MruEndpoints)
                         {
-                            this.MruEndpoints.Add(mruEndpoint);
+                            MruEndpoints.Add(mruEndpoint);
                         }
                     }
                 },
@@ -438,33 +438,33 @@ namespace Microsoft.OData.ConnectedService.Models
                 return;
             }
 
-            var index = this.MruEndpoints.IndexOf(mruEndpoint);
+            var index = MruEndpoints.IndexOf(mruEndpoint);
 
             if (index >= 0)
             {
                 // Remove possible duplicates
-                for (var i = this.MruEndpoints.Count - 1; index > 0 && i > index; i--)
+                for (var i = MruEndpoints.Count - 1; index > 0 && i > index; i--)
                 {
-                    if (this.MruEndpoints[i].Equals(mruEndpoint, StringComparison.Ordinal))
+                    if (MruEndpoints[i].Equals(mruEndpoint, StringComparison.Ordinal))
                     {
-                        this.MruEndpoints.RemoveAt(i);
+                        MruEndpoints.RemoveAt(i);
                     }
                 }
 
                 // Endpoint not at index 0
                 if (index > 0)
                 {
-                    this.MruEndpoints.Move(index, 0);
+                    MruEndpoints.Move(index, 0);
                 }
             }
             else
             {
-                while (this.MruEndpoints.Count >= MaxMruEntries)
+                while (MruEndpoints.Count >= MaxMruEntries)
                 {
-                    this.MruEndpoints.RemoveAt(this.MruEndpoints.Count - 1);
+                    MruEndpoints.RemoveAt(MruEndpoints.Count - 1);
                 }
 
-                this.MruEndpoints.Insert(0, mruEndpoint);
+                MruEndpoints.Insert(0, mruEndpoint);
             }
         }
     }

--- a/src/ODataConnectedService.csproj
+++ b/src/ODataConnectedService.csproj
@@ -190,6 +190,7 @@
     <Compile Include="CodeGeneration\V4CodeGenDescriptor.cs" />
     <Compile Include="Common\Constants.cs" />
     <Compile Include="Common\EdmHelper.cs" />
+    <Compile Include="Common\ExtensionMethods.cs" />
     <Compile Include="Common\ExtensionsHelper.cs" />
     <Compile Include="Common\ProjectHelper.cs" />
     <Compile Include="Common\UserSettingsPersistenceHelper.cs" />

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -39,8 +39,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.2.0")]
-[assembly: AssemblyFileVersion("0.11.2.0")]
+[assembly: AssemblyVersion("0.11.1.0")]
+[assembly: AssemblyFileVersion("0.11.1.0")]
 [assembly: NeutralResourcesLanguageAttribute("en")]
 
 [assembly: InternalsVisibleTo("ODataConnectedService.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001003d2fbcc3c5595b4212227a5ca0fb1c45cb9c942096831420563dc169dd847a8a5fe068170bd10802dea50bc4d8342c1f8aa2ab9f27e3ceccdb21ce8c1415c3ea33eb7bc09059ca50b3e8607fa34bb9925466525ceffc3edac84ac1863afc28ef935c8db7a6430771fa41aa3de8a8d399990b02cae85e834e5d29d2cc0109b8cb")]

--- a/src/ViewModels/AdvancedSettingsViewModel.cs
+++ b/src/ViewModels/AdvancedSettingsViewModel.cs
@@ -15,27 +15,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 {
     internal class AdvancedSettingsViewModel : ConnectedServiceWizardPage
     {
-        public bool UseDataServiceCollection { get; set; }
-
-        public bool UseNamespacePrefix { get; set; }
-
-        public string NamespacePrefix { get; set; }
-
-        public bool EnableNamingAlias { get; set; }
-
-        public bool IgnoreUnexpectedElementsAndAttributes { get; set; }
-
-        public string GeneratedFileNamePrefix { get; set; }
-
-        public bool IncludeT4File { get; set; }
-
-        public bool MakeTypesInternal { get; set; }
-
-        public bool OpenGeneratedFilesInIDE { get; set; }
-
-        public bool GenerateMultipleFiles { get; set; }
-
-        public UserSettings UserSettings { get; set; }
+        public UserSettings UserSettings { get; internal set; }
 
         internal bool IsEntered;
 
@@ -45,8 +25,6 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             this.Description = "Advanced settings for generating client proxy";
             this.Legend = "Settings";
             this.UserSettings = userSettings;
-            this.GeneratedFileNamePrefix = Common.Constants.DefaultReferenceFileName;
-            this.NamespacePrefix = Common.Constants.DefaultReferenceFileName;
         }
 
         public event EventHandler<EventArgs> PageEntering;
@@ -61,42 +39,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
         public override Task<PageNavigationResult> OnPageLeavingAsync(WizardLeavingArgs args)
         {
-            SaveToUserSettings();
             return base.OnPageLeavingAsync(args);
-        }
-
-        private void SaveToUserSettings()
-        {
-            if (this.UserSettings != null)
-            {
-                UserSettings.GeneratedFileNamePrefix = this.GeneratedFileNamePrefix;
-                UserSettings.OpenGeneratedFilesInIDE = this.OpenGeneratedFilesInIDE;
-                UserSettings.UseNamespacePrefix = this.UseNamespacePrefix;
-                UserSettings.NamespacePrefix = this.NamespacePrefix;
-                UserSettings.UseDataServiceCollection = this.UseDataServiceCollection;
-                UserSettings.MakeTypesInternal = this.MakeTypesInternal;
-                UserSettings.IncludeT4File = this.IncludeT4File;
-                UserSettings.IgnoreUnexpectedElementsAndAttributes = this.IgnoreUnexpectedElementsAndAttributes;
-                UserSettings.EnableNamingAlias = this.EnableNamingAlias;
-                UserSettings.GenerateMultipleFiles = this.GenerateMultipleFiles;
-            }
-        }
-
-        public void LoadFromUserSettings()
-        {
-            if (UserSettings != null)
-            {
-                this.GeneratedFileNamePrefix = UserSettings.GeneratedFileNamePrefix ?? Common.Constants.DefaultReferenceFileName;
-                this.OpenGeneratedFilesInIDE = UserSettings.OpenGeneratedFilesInIDE;
-                this.UseNamespacePrefix = UserSettings.UseNamespacePrefix;
-                this.NamespacePrefix = UserSettings.NamespacePrefix ?? Common.Constants.DefaultReferenceFileName;
-                this.UseDataServiceCollection = UserSettings.UseDataServiceCollection;
-                this.MakeTypesInternal = UserSettings.MakeTypesInternal;
-                this.IncludeT4File = UserSettings.IncludeT4File;
-                this.IgnoreUnexpectedElementsAndAttributes = UserSettings.IgnoreUnexpectedElementsAndAttributes;
-                this.EnableNamingAlias = UserSettings.EnableNamingAlias;
-                this.GenerateMultipleFiles = UserSettings.GenerateMultipleFiles;
-            }
         }
     }
 }

--- a/src/ViewModels/OperationImportsViewModel.cs
+++ b/src/ViewModels/OperationImportsViewModel.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         /// <remarks>
         /// <see cref="Models.UserSettings"/>
         /// </remarks>
-        public UserSettings UserSettings { get; set; }
+        public UserSettings UserSettings { get; internal set; }
 
         private long _operationImportsCount = 0;
 

--- a/src/Views/AdvancedSettings.xaml
+++ b/src/Views/AdvancedSettings.xaml
@@ -15,7 +15,7 @@
 
             <TextBlock x:Name="ReferenceFileNameLabel" Text="Enter the file name (without extension):"
                            HorizontalAlignment="Left" Margin="0, 5, 0, 0"/>
-            <TextBox x:Name="ReferenceFileName" Text="{Binding GeneratedFileNamePrefix}"
+            <TextBox x:Name="ReferenceFileName" Text="{Binding UserSettings.GeneratedFileNamePrefix, Mode=TwoWay}"
                          HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Bottom" Width="250" Margin="20, 5, 0, 0"/>
             <StackPanel x:Name="AdvancedSettingsHyperLinkPanel">
                 <TextBlock x:Name="Label" TextWrapping="WrapWithOverflow" Margin="0, 20, 40, 0">
@@ -28,33 +28,33 @@
         </StackPanel>
         <StackPanel x:Name="AdvancedSettingsPanel">
             <StackPanel HorizontalAlignment="Left" Margin="10, 0, 0, 0" VerticalAlignment="Top">
-                <CheckBox x:Name="UseNamespacePrefix" IsChecked="{Binding UseNamespacePrefix}"
+                <CheckBox x:Name="UseNamespacePrefix" IsChecked="{Binding UserSettings.UseNamespacePrefix, Mode=TwoWay}"
                           HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="0,5">
                     <TextBlock TextWrapping="Wrap" Margin="0, 0, 40, 0">
                         Use a custom namespace (It will replace the original namespace in the metadata document, unless the model has several namespaces.)
                     </TextBlock>
                 </CheckBox>
-                <TextBox x:Name="NamespacePrefix" Text="{Binding NamespacePrefix}"
+                <TextBox x:Name="NamespacePrefix" Text="{Binding Path=UserSettings.NamespacePrefix, Mode=TwoWay}"
                          HorizontalAlignment="Left" TextWrapping="Wrap" VerticalAlignment="Center" Width="250" Margin="20, 0, 0, 5"/>
-                <CheckBox x:Name="UseDSC" Content="Enable entity and property tracking" IsChecked="{Binding UseDataServiceCollection}"
+                <CheckBox x:Name="UseDSC" Content="Enable entity and property tracking" IsChecked="{Binding Path=UserSettings.UseDataServiceCollection, Mode=TwoWay}"
                           HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5, 0, 0" />
             </StackPanel>
             <StackPanel x:Name="AdvancedSettingsForv4" HorizontalAlignment="Left" Margin="10, 5, 0, 0" VerticalAlignment="Top">
-                <CheckBox x:Name="EnableCamelCase" Content="Use c# casing style" IsChecked="{Binding EnableNamingAlias}"
+                <CheckBox x:Name="EnableCamelCase" Content="Use c# casing style" IsChecked="{Binding Path=UserSettings.EnableNamingAlias, Mode=TwoWay}"
             		HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5"/>
-                <CheckBox x:Name="IgnoreUnknownAttributeOrElement" IsChecked="{Binding IgnoreUnexpectedElementsAndAttributes}"
+                <CheckBox x:Name="IgnoreUnknownAttributeOrElement" IsChecked="{Binding Path=UserSettings.IgnoreUnexpectedElementsAndAttributes, Mode=TwoWay}"
             		HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5">
                     <TextBlock TextWrapping="Wrap" Margin="0, 0, 40, 0">Ignore unknown elements (Whether to ignore unexpected elements and attributes in the metadata document and generate the client code if any.)</TextBlock>
                 </CheckBox>
-                <CheckBox x:Name="MakeTypesInternal" IsChecked="{Binding MakeTypesInternal}"
+                <CheckBox x:Name="MakeTypesInternal" IsChecked="{Binding Path=UserSettings.MakeTypesInternal, Mode=TwoWay}"
                     HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5">
                     <TextBlock TextWrapping="Wrap" Margin="0, 0, 40, 0">Make generated types internal (Enable this if you don't want to expose the generated types outside of your assembly.)</TextBlock>
                 </CheckBox>
-                <CheckBox x:Name="IncludeT4File" Content="Add code templates (Whether to include the T4 files into this project.)" IsChecked="{Binding IncludeT4File}"
+                <CheckBox x:Name="IncludeT4File" Content="Add code templates (Whether to include the T4 files into this project.)" IsChecked="{Binding Path=UserSettings.IncludeT4File, Mode=TwoWay}"
             		HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 15" FontWeight="Medium"/>
-                <CheckBox x:Name="OpenGeneratedFilesInIDE" Content="Open generated files in the IDE when generation completes." IsChecked="{Binding OpenGeneratedFilesInIDE}"
+                <CheckBox x:Name="OpenGeneratedFilesInIDE" Content="Open generated files in the IDE when generation completes." IsChecked="{Binding Path=UserSettings.OpenGeneratedFilesInIDE, Mode=TwoWay}"
                     HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5"/>
-                <CheckBox x:Name="GenerateMultipleFiles" Content="Generate multiple files." IsChecked="{Binding GenerateMultipleFiles}"
+                <CheckBox x:Name="GenerateMultipleFiles" Content="Generate multiple files." IsChecked="{Binding Path=UserSettings.GenerateMultipleFiles, Mode=TwoWay}"
                     HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5"/>
             </StackPanel>
         </StackPanel>

--- a/src/Views/ConfigODataEndpoint.xaml
+++ b/src/Views/ConfigODataEndpoint.xaml
@@ -38,7 +38,7 @@
                 Height="20"
                 Margin="0,5,10,5"
                 HorizontalAlignment="Left"
-                Text="{Binding Path=ServiceName, Mode=TwoWay}" />
+                Text="{Binding Path=UserSettings.ServiceName, Mode=TwoWay}" />
             <Button
                 x:Name="OpenConnectedServiceJsonFileButton"
                 Grid.Column="1"
@@ -71,7 +71,7 @@
                 HorizontalAlignment="Stretch"
                 IsEditable="True"
                 ItemsSource="{Binding Path=UserSettings.MruEndpoints}"
-                Text="{Binding Path=Endpoint, Mode=TwoWay, TargetNullValue='Enter your endpoint...'}" />
+                Text="{Binding Path=UserSettings.Endpoint, Mode=TwoWay, TargetNullValue='Enter your endpoint...'}" />
             <Button
                 x:Name="OpenEndpointFileButton"
                 Grid.Column="1"
@@ -91,7 +91,7 @@
             VerticalAlignment="Top"
             Content="Include Custom Http Headers"
             FontWeight="Medium"
-            IsChecked="{Binding IncludeCustomHeaders, Mode=TwoWay}" />
+            IsChecked="{Binding Path=UserSettings.IncludeCustomHeaders, Mode=TwoWay}" />
 
         <StackPanel Margin="20,0,0,0" Visibility="{Binding Path=IsChecked, ElementName=IncludeHttpHeadersElement, Converter={StaticResource BooleanToVisibilityConverter}}">
 
@@ -106,7 +106,7 @@
                 Margin="20,5,10,5"
                 HorizontalAlignment="Left"
                 AcceptsReturn="True"
-                Text="{Binding Path=CustomHttpHeaders, Mode=TwoWay}"
+                Text="{Binding Path=UserSettings.CustomHttpHeaders, Mode=TwoWay}"
                 TextWrapping="Wrap"
                 VerticalScrollBarVisibility="Visible">
                 <TextBox.ToolTip>
@@ -128,7 +128,7 @@
             VerticalAlignment="Top"
             Content="Include WebProxy"
             FontWeight="Medium"
-            IsChecked="{Binding IncludeWebProxy, Mode=TwoWay}" />
+            IsChecked="{Binding Path=UserSettings.IncludeWebProxy, Mode=TwoWay}" />
 
         <StackPanel Margin="20,0,0,0" Visibility="{Binding Path=IsChecked, ElementName=IncludeWebProxyElement, Converter={StaticResource BooleanToVisibilityConverter}}">
 
@@ -143,7 +143,7 @@
                     Width="300"
                     Margin="0,0,0,0"
                     HorizontalAlignment="Left"
-                    Text="{Binding WebProxyHost}"
+                    Text="{Binding Path=UserSettings.WebProxyHost, Mode=TwoWay}"
                     TextWrapping="Wrap" />
             </StackPanel>
             <CheckBox
@@ -153,7 +153,7 @@
                 VerticalAlignment="Top"
                 Content="Include Proxy Network credentials"
                 FontWeight="Medium"
-                IsChecked="{Binding IncludeWebProxyNetworkCredentials, Mode=TwoWay}" />
+                IsChecked="{Binding Path=UserSettings.IncludeWebProxyNetworkCredentials, Mode=TwoWay}" />
             <StackPanel
                 Margin="20,0,0,0"
                 Orientation="Vertical"
@@ -169,7 +169,7 @@
                     Width="300"
                     Margin="0,5,0,0"
                     HorizontalAlignment="Left"
-                    Text="{Binding WebProxyNetworkCredentialsUsername, Mode=TwoWay}"
+                    Text="{Binding Path=UserSettings.WebProxyNetworkCredentialsUsername, Mode=TwoWay}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
@@ -182,7 +182,7 @@
                     Width="300"
                     Margin="0,5,0,0"
                     HorizontalAlignment="Left"
-                    Text="{Binding WebProxyNetworkCredentialsPassword, Mode=TwoWay}"
+                    Text="{Binding Path=UserSettings.WebProxyNetworkCredentialsPassword, Mode=TwoWay}"
                     TextWrapping="Wrap" />
 
                 <TextBlock
@@ -195,7 +195,7 @@
                     Width="300"
                     Margin="0,5,0,0"
                     HorizontalAlignment="Left"
-                    Text="{Binding WebProxyNetworkCredentialsDomain, Mode=TwoWay}"
+                    Text="{Binding Path=UserSettings.WebProxyNetworkCredentialsDomain, Mode=TwoWay}"
                     TextWrapping="Wrap" />
 
             </StackPanel>

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.11.2" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="0.11.1" Language="en-US" Publisher="Microsoft" />
         <Author>Microsoft</Author>
         <DisplayName>OData Connected Service</DisplayName>
         <Description xml:space="preserve">OData Connected Service for V1-V4</Description>

--- a/test/ODataConnectedService.Tests/Common/ExtensionMethodsTests.cs
+++ b/test/ODataConnectedService.Tests/Common/ExtensionMethodsTests.cs
@@ -1,0 +1,149 @@
+﻿//-----------------------------------------------------------------------------------
+// <copyright file="ExtensionMethodsTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OData.ConnectedService.Common;
+using Microsoft.OData.ConnectedService.Models;
+using Xunit;
+
+namespace ODataConnectedService.Tests
+{
+    public class ExtensionMethodsTests
+    {
+        private static UserSettings CreateUserSettings()
+        {
+            var userSettings = new UserSettings(configName: "TestSettings");
+
+            userSettings.CustomHttpHeaders = "Key:Test";
+            userSettings.EnableNamingAlias = true;
+            userSettings.Endpoint = "http://test";
+            userSettings.ExcludedBoundOperations = new List<string> { "TestBoundOperation" };
+            userSettings.ExcludedOperationImports = new List<string> { "TestOperationImport" };
+            userSettings.ExcludedSchemaTypes = new List<string> { "TestSchemaType" };
+            userSettings.GeneratedFileNamePrefix = "Test";
+            userSettings.GenerateMultipleFiles = true;
+            userSettings.IgnoreUnexpectedElementsAndAttributes = true;
+            userSettings.IncludeCustomHeaders = true;
+            userSettings.IncludeT4File = true;
+            userSettings.IncludeWebProxy = true;
+            userSettings.IncludeWebProxyNetworkCredentials = true;
+            userSettings.MakeTypesInternal = true;
+            userSettings.NamespacePrefix = "Test";
+            userSettings.OpenGeneratedFilesInIDE = true;
+            userSettings.ServiceName = "Test";
+            userSettings.UseDataServiceCollection = true;
+            userSettings.UseNamespacePrefix = true;
+            userSettings.WebProxyHost = "Test";
+            userSettings.WebProxyNetworkCredentialsDomain = "Test";
+            userSettings.WebProxyNetworkCredentialsPassword = "Test";
+            userSettings.WebProxyNetworkCredentialsUsername = "Test";
+            userSettings.AddMruEndpoint("http://test");
+
+            return userSettings;
+        }
+
+        private static ServiceConfigurationV4 CreateServiceConfiguration()
+        {
+            var serviceConfig = new ServiceConfigurationV4();
+            serviceConfig.CustomHttpHeaders = "Key:Test";
+            serviceConfig.EdmxVersion = new Version(4, 0, 0, 0);
+            serviceConfig.EnableNamingAlias = true;
+            serviceConfig.Endpoint = "http://test";
+            serviceConfig.ExcludedBoundOperations = new List<string> { "TestBoundOperation" };
+            serviceConfig.ExcludedOperationImports = new List<string> { "TestOperationImport" };
+            serviceConfig.ExcludedSchemaTypes = new List<string> { "TestSchemaType" };
+            serviceConfig.GeneratedFileNamePrefix = "Test";
+            serviceConfig.GenerateMultipleFiles = true;
+            serviceConfig.IgnoreUnexpectedElementsAndAttributes = true;
+            serviceConfig.IncludeCustomHeaders = true;
+            serviceConfig.IncludeT4File = true;
+            serviceConfig.IncludeWebProxy = true;
+            serviceConfig.IncludeWebProxyNetworkCredentials = true;
+            serviceConfig.MakeTypesInternal = true;
+            serviceConfig.NamespacePrefix = "Test";
+            serviceConfig.OpenGeneratedFilesInIDE = true;
+            serviceConfig.ServiceName = "Test";
+            serviceConfig.UseDataServiceCollection = true;
+            serviceConfig.UseNamespacePrefix = true;
+            serviceConfig.WebProxyHost = "Test";
+            serviceConfig.WebProxyNetworkCredentialsDomain = "Test";
+            serviceConfig.WebProxyNetworkCredentialsPassword = "Test";
+            serviceConfig.WebProxyNetworkCredentialsUsername = "Test";
+
+            return serviceConfig;
+        }
+
+        [Fact]
+        public void TestCopyPropertiesFromUserSettingsToServiceConfiguration()
+        {
+            var userSettings = CreateUserSettings();
+
+            var serviceConfig = new ServiceConfigurationV4();
+
+            serviceConfig.CopyPropertiesFrom(userSettings);
+
+            Assert.Equal("Key:Test", serviceConfig.CustomHttpHeaders);
+            Assert.True(serviceConfig.EnableNamingAlias);
+            Assert.Equal("http://test", serviceConfig.Endpoint);
+            Assert.Single(serviceConfig.ExcludedBoundOperations, "TestBoundOperation");
+            Assert.Single(serviceConfig.ExcludedOperationImports, "TestOperationImport");
+            Assert.Single(serviceConfig.ExcludedSchemaTypes, "TestSchemaType");
+            Assert.Equal("Test", serviceConfig.GeneratedFileNamePrefix);
+            Assert.True(serviceConfig.GenerateMultipleFiles);
+            Assert.True(serviceConfig.IgnoreUnexpectedElementsAndAttributes);
+            Assert.True(serviceConfig.IncludeCustomHeaders);
+            Assert.True(serviceConfig.IncludeT4File);
+            Assert.True(serviceConfig.IncludeWebProxy);
+            Assert.True(serviceConfig.IncludeWebProxyNetworkCredentials);
+            Assert.True(serviceConfig.MakeTypesInternal);
+            Assert.Equal("Test", serviceConfig.NamespacePrefix);
+            Assert.True(serviceConfig.OpenGeneratedFilesInIDE);
+            Assert.Equal("Test", serviceConfig.ServiceName);
+            Assert.True(serviceConfig.UseDataServiceCollection);
+            Assert.True(serviceConfig.UseNamespacePrefix);
+            Assert.Equal("Test", serviceConfig.WebProxyHost);
+            Assert.Equal("Test", serviceConfig.WebProxyNetworkCredentialsDomain);
+            Assert.Equal("Test", serviceConfig.WebProxyNetworkCredentialsPassword);
+            Assert.Equal("Test", serviceConfig.WebProxyNetworkCredentialsUsername);
+        }
+
+        [Fact]
+        public void TestCopyPropertiesFromServiceConfigurationToUserSettings()
+        {
+            var serviceConfig = CreateServiceConfiguration();
+
+            var userSettings = new UserSettings(configName: "TestUserSettings");
+
+            userSettings.CopyPropertiesFrom(serviceConfig);
+
+            Assert.Equal("Key:Test", userSettings.CustomHttpHeaders);
+            Assert.True(userSettings.EnableNamingAlias);
+            Assert.Equal("http://test", userSettings.Endpoint);
+            Assert.Single(userSettings.ExcludedBoundOperations, "TestBoundOperation");
+            Assert.Single(userSettings.ExcludedOperationImports, "TestOperationImport");
+            Assert.Single(userSettings.ExcludedSchemaTypes, "TestSchemaType");
+            Assert.Equal("Test", userSettings.GeneratedFileNamePrefix);
+            Assert.True(userSettings.GenerateMultipleFiles);
+            Assert.True(userSettings.IgnoreUnexpectedElementsAndAttributes);
+            Assert.True(userSettings.IncludeCustomHeaders);
+            Assert.True(userSettings.IncludeT4File);
+            Assert.True(userSettings.IncludeWebProxy);
+            Assert.True(userSettings.IncludeWebProxyNetworkCredentials);
+            Assert.True(userSettings.MakeTypesInternal);
+            Assert.Equal("Test", userSettings.NamespacePrefix);
+            Assert.True(userSettings.OpenGeneratedFilesInIDE);
+            Assert.Equal("Test", userSettings.ServiceName);
+            Assert.True(userSettings.UseDataServiceCollection);
+            Assert.True(userSettings.UseNamespacePrefix);
+            Assert.Equal("Test", userSettings.WebProxyHost);
+            Assert.Equal("Test", userSettings.WebProxyNetworkCredentialsDomain);
+            Assert.Equal("Test", userSettings.WebProxyNetworkCredentialsPassword);
+            Assert.Equal("Test", userSettings.WebProxyNetworkCredentialsUsername);
+        }
+    }
+}

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -63,6 +63,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\ExtensionMethodsTests.cs" />
     <Compile Include="Common\EdmHelperTests.cs" />
     <Compile Include="Converters\BoolToVisibilityConverterTests.cs" />
     <Compile Include="Converters\SchemaTypeModelToVisibilityConverterTests.cs" />

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.OData.ConnectedService;
 using Microsoft.OData.ConnectedService.Common;
 using Microsoft.OData.ConnectedService.Models;
-using Microsoft.OData.ConnectedService.Tests.Templates;
 using Microsoft.OData.ConnectedService.ViewModels;
 using Microsoft.VisualStudio.ConnectedServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -31,7 +30,8 @@ namespace ODataConnectedService.Tests.ViewModels
         {
             userSettings = new UserSettings();
             serviceWizard = new ODataConnectedServiceWizard(null);
-            configOdataEndPointViewModel = new ConfigODataEndpointViewModel(userSettings, serviceWizard);
+            configOdataEndPointViewModel = new ConfigODataEndpointViewModel(userSettings);
+            serviceWizard.Pages.Add(configOdataEndPointViewModel);
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
         }
 
@@ -55,11 +55,11 @@ namespace ODataConnectedService.Tests.ViewModels
             Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
 
             //Provide a url without $metadata
-            configOdataEndPointViewModel.Endpoint = "http://mysite/ODataService";
+            configOdataEndPointViewModel.UserSettings.Endpoint = "http://mysite/ODataService";
             pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
             //Check if $metadata is apended if the url does not have it added at the end
-            Assert.AreEqual(configOdataEndPointViewModel.Endpoint, "http://mysite/ODataService/$metadata");
+            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://mysite/ODataService/$metadata");
 
             //Check if an exception is thrown for an invalid url and the user is notified
             pageNavigationResult = pageNavigationResultTask?.Result;
@@ -69,7 +69,7 @@ namespace ODataConnectedService.Tests.ViewModels
             Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
 
 
-            configOdataEndPointViewModel.Endpoint = Path.Combine(Directory.GetCurrentDirectory(),"EdmxFile.xml");
+            configOdataEndPointViewModel.UserSettings.Endpoint = Path.Combine(Directory.GetCurrentDirectory(),"EdmxFile.xml");
             pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
             //Check if any errors were reported


### PR DESCRIPTION
This pull request fixes #181 

Set the most logical config defaults for the wizard. Below is a detailed explanation of the changes:

1. Restore OCS wizard default settings that were inadvertently dropped with the introduction of the settings persistence feature, i.e.
   - GeneratedFileNamePrefix => `Reference`
   - NamespacePrefix => `Reference`
   - UseDataServiceCollection => `true`
   - EnableNamingAlias => `true`
   - IgnoreUnexpectedElementsAndAttributes => `true`
   - ServiceName => `OData Service` 

2. ~Fix handling of **most recently used** (MRU) endpoints. Presently, the `UserSettings` class exposes MRU endpoints as an `ObservableCollection` that one is able to manipulate directly (add/remove/etc) and violate the whole idea of "most recently used". This is fixed by changing `MruEndpoints` property type to `ReadOnlyObservableCollection` and providing a public method `AddMruEndpoint` through which the MRU endpoints collection can be manipulated~

3. Fix binding of user settings to the wizard pages. There was a lot of unnecessary duplication of code to support binding with lots of copying logic in multiple places. This is fixed by having all the wizard pages bind directly to the properties in a `UserSettings` instance.

4. Tests would change the settings file that is used when creating Connected Services from Visual Studio. This is fixed by making it possible to create a "named" user settings config file in test scenarios

5. Refactor to make the code leaner and cleaner