### PR TITLE
Excluding SAP common vocabulary namespaces

### DIFF
--- a/src/Templates/ODataT4CodeGenerator.cs
+++ b/src/Templates/ODataT4CodeGenerator.cs
@@ -1490,7 +1490,8 @@ public class CodeGenerationContext
                 tmp.FindDeclaredTerm(AlternateKeysVocabularyConstants.AlternateKeys) != null ||
                 tmp.FindDeclaredTerm("Org.OData.Authorization.V1.Authorizations") != null ||
                 tmp.FindDeclaredTerm("Org.OData.Validation.V1.DerivedTypeConstraint") != null ||
-                tmp.FindDeclaredTerm("Org.OData.Community.V1.UrlEscapeFunction") != null)
+                tmp.FindDeclaredTerm("Org.OData.Community.V1.UrlEscapeFunction") != null ||
+                tmp.DeclaredNamespaces.Any(n => n.StartsWith("com.sap.vocabularies")))
             {
                 continue;
             }

--- a/src/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Templates/ODataT4CodeGenerator.ttinclude
@@ -1344,7 +1344,8 @@ public class CodeGenerationContext
                 tmp.FindDeclaredTerm(AlternateKeysVocabularyConstants.AlternateKeys) != null ||
                 tmp.FindDeclaredTerm("Org.OData.Authorization.V1.Authorizations") != null ||
                 tmp.FindDeclaredTerm("Org.OData.Validation.V1.DerivedTypeConstraint") != null ||
-                tmp.FindDeclaredTerm("Org.OData.Community.V1.UrlEscapeFunction") != null)
+                tmp.FindDeclaredTerm("Org.OData.Community.V1.UrlEscapeFunction") != null ||
+                tmp.DeclaredNamespaces.Any(n => n.StartsWith("com.sap.vocabularies")))
             {
                 continue;
             }


### PR DESCRIPTION
Similar to the [Org.Odata namespace of vocabularies](https://github.com/oasis-tcs/odata-vocabularies/tree/master/vocabularies) the following should also all be excluded:
https://github.com/SAP/odata-vocabularies/tree/master/vocabularies

Fixes: #184

A better fix might be to add a new screen to the wizard which allows users to exclude specific namespaces from the codegen.