### PR TITLE
Fix warnings as a result of an empty metadata file generated when user opts to include T4 file

### DIFF
--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -89,7 +89,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
 
             // When the T4 file is added to the target project, the proxy and metadata files 
             // are not automatically generated. To avoid ending up with an empty metadata file with 
-            // warnings, we pre-populate the it with the root element. The content will later be overwritten.
+            // warnings, we pre-populate it with the root element. The content will later be overwritten with the actual metadata when T4 template is run by the user.
             using (StreamWriter writer = File.CreateText(tempFile))
             {
                 await writer.WriteLineAsync("<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">").ConfigureAwait(true);

--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -63,13 +63,13 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
         {
             await Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "Adding T4 files for OData V4...").ConfigureAwait(true);
 
-            var tempFile = Path.GetTempFileName();
+            var t4IncludeTempFile = Path.GetTempFileName();
             var t4Folder = Path.Combine(this.CurrentAssemblyPath, "Templates");
 
             var referenceFolder = this.GetReferenceFileFolder();
 
             // generate .ttinclude
-            using (StreamWriter writer = File.CreateText(tempFile))
+            using (StreamWriter writer = File.CreateText(t4IncludeTempFile))
             {
                 var ttIncludeText = File.ReadAllText(Path.Combine(t4Folder, "ODataT4CodeGenerator.ttinclude"));
                 if (this.TargetProjectLanguage == LanguageOption.GenerateVBCode)
@@ -78,10 +78,10 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 await writer.FlushAsync().ConfigureAwait(true);
             }
 
-            await Context.HandlerHelper.AddFileAsync(tempFile, Path.Combine(referenceFolder, GeneratedFileNamePrefix + ".ttinclude")).ConfigureAwait(true);
+            await Context.HandlerHelper.AddFileAsync(t4IncludeTempFile, Path.Combine(referenceFolder, GeneratedFileNamePrefix + ".ttinclude")).ConfigureAwait(true);
             await Context.HandlerHelper.AddFileAsync(Path.Combine(t4Folder, "ODataT4CodeGenFilesManager.ttinclude"), Path.Combine(referenceFolder, "ODataT4CodeGenFilesManager.ttinclude")).ConfigureAwait(true);
 
-            tempFile = Path.GetTempFileName();
+            var csdlTempFile = Path.GetTempFileName();
 
             // Csdl file name is this format [ServiceName]Csdl.xml
             var csdlFileName = string.Concat(ServiceConfiguration.ServiceName, Common.Constants.CsdlFileNameSuffix);
@@ -90,13 +90,13 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             // When the T4 file is added to the target project, the proxy and metadata files 
             // are not automatically generated. To avoid ending up with an empty metadata file with 
             // warnings, we pre-populate it with the root element. The content will later be overwritten with the actual metadata when T4 template is run by the user.
-            using (StreamWriter writer = File.CreateText(tempFile))
+            using (StreamWriter writer = File.CreateText(csdlTempFile))
             {
                 await writer.WriteLineAsync("<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">").ConfigureAwait(true);
                 await writer.WriteLineAsync("</edmx:Edmx>").ConfigureAwait(true);
             }
 
-            await Context.HandlerHelper.AddFileAsync(tempFile, metadataFile, new AddFileOptions() { SuppressOverwritePrompt = true }).ConfigureAwait(true);
+            await Context.HandlerHelper.AddFileAsync(csdlTempFile, metadataFile, new AddFileOptions() { SuppressOverwritePrompt = true }).ConfigureAwait(true);
 
             // Hack!
             // Tests were failing since the test project cannot access ProjectItems
@@ -108,9 +108,9 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 projectItem.Properties.Item("BuildAction").Value = prjBuildAction.prjBuildActionEmbeddedResource;
             }
 
-            tempFile = Path.GetTempFileName();
+            var t4TempFile = Path.GetTempFileName();
 
-            using (StreamWriter writer = File.CreateText(tempFile))
+            using (StreamWriter writer = File.CreateText(t4TempFile))
             {
                 var text = File.ReadAllText(Path.Combine(t4Folder, "ODataT4CodeGenerator.tt"));
 
@@ -152,7 +152,7 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
                 await writer.FlushAsync().ConfigureAwait(true);
             }
 
-            await Context.HandlerHelper.AddFileAsync(tempFile, Path.Combine(referenceFolder, GeneratedFileNamePrefix + ".tt")).ConfigureAwait(true);
+            await Context.HandlerHelper.AddFileAsync(t4TempFile, Path.Combine(referenceFolder, GeneratedFileNamePrefix + ".tt")).ConfigureAwait(true);
 
             await Context.Logger.WriteMessageAsync(LoggerMessageCategory.Information, "T4 files for OData V4 were added.").ConfigureAwait(true);
         }

--- a/src/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/CodeGeneration/V4CodeGenDescriptor.cs
@@ -87,18 +87,6 @@ namespace Microsoft.OData.ConnectedService.CodeGeneration
             var csdlFileName = string.Concat(ServiceConfiguration.ServiceName, Common.Constants.CsdlFileNameSuffix);
             var metadataFile = Path.Combine(referenceFolder, csdlFileName);
 
-            await Context.HandlerHelper.AddFileAsync(tempFile, metadataFile, new AddFileOptions() { SuppressOverwritePrompt = true }).ConfigureAwait(true);
-
-            // Hack!
-            // Tests were failing since the test project cannot access ProjectItems
-            // dte == null when running test cases
-            var dte = VisualStudio.Shell.Package.GetGlobalService(typeof(DTE)) as DTE;
-            if (dte != null)
-            {
-                var projectItem = this.GetCsdlFileProjectItem(csdlFileName);
-                projectItem.Properties.Item("BuildAction").Value = prjBuildAction.prjBuildActionEmbeddedResource;
-            }
-
             using (StreamWriter writer = File.CreateText(tempFile))
             {
                 var text = File.ReadAllText(Path.Combine(t4Folder, "ODataT4CodeGenerator.tt"));


### PR DESCRIPTION
This pull request fixes #195

Fix warnings as a result of an empty metadata file generated when user opts to include T4 file.
By pre-populating the file with the root element to suppress the warnings. That content is later overwritten when the metadata is written to the file [here](https://github.com/OData/ODataConnectedService/blob/ef08797cbbf2e8b6809d88dd9142f95de61c8710/src/Templates/ODataT4CodeGenerator.cs#L4492) - `append: false` to overwrite the file