### PR TITLE
Restore default for client proxy to namespace in the metadata document

### DIFF
--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -368,7 +368,6 @@ namespace Microsoft.OData.ConnectedService.Models
             this.logger = logger;
             // Desired defaults
             GeneratedFileNamePrefix = Constants.DefaultReferenceFileName;
-            NamespacePrefix = Constants.DefaultReferenceFileName;
             ServiceName = Constants.DefaultServiceName;
             UseDataServiceCollection = true; // To support entity and property tracking
             EnableNamingAlias = true; // To force upper camel case in the event that entities are named in lower camel case

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -250,7 +250,7 @@ namespace ODataConnectedService.Tests
                 advancedPage.OnPageEnteringAsync(new WizardEnteringArgs(typesPage)).Wait();
                 Assert.Equal(Constants.DefaultReferenceFileName, advancedPage.UserSettings.GeneratedFileNamePrefix);
                 Assert.False(advancedPage.UserSettings.UseNamespacePrefix);
-                Assert.Equal(Constants.DefaultReferenceFileName, advancedPage.UserSettings.NamespacePrefix);
+                Assert.Null(advancedPage.UserSettings.NamespacePrefix);
                 Assert.True(advancedPage.UserSettings.UseDataServiceCollection);
                 Assert.True(advancedPage.UserSettings.EnableNamingAlias);
                 Assert.False(advancedPage.UserSettings.OpenGeneratedFilesInIDE);


### PR DESCRIPTION
Fixes #208 