### PR TITLE
Allow users to store custom Http headers and proxy credentials

### DIFF
--- a/src/Models/ServiceConfiguration.cs
+++ b/src/Models/ServiceConfiguration.cs
@@ -26,11 +26,13 @@ namespace Microsoft.OData.ConnectedService.Models
         public bool IncludeWebProxy { get; set; }
         public string WebProxyHost { get; set; }
         public bool IncludeWebProxyNetworkCredentials { get; set; }
+        public bool StoreWebProxyNetworkCredentials { get; set; }
         public string WebProxyNetworkCredentialsUsername { get; set; }
         public string WebProxyNetworkCredentialsPassword { get; set; }
         public string WebProxyNetworkCredentialsDomain { get; set; }
         public bool IncludeCustomHeaders { get; set; }
-        public List<string> ExcludedSchemaTypes { get; set; }
+        public bool StoreCustomHttpHeaders { get; set; }
+        public List<string> ExcludedSchemaTypes { get; set; }        
 
     }
 

--- a/src/Models/UserSettings.cs
+++ b/src/Models/UserSettings.cs
@@ -58,6 +58,8 @@ namespace Microsoft.OData.ConnectedService.Models
 
         private string customHttpHeaders;
 
+        private bool storeCustomHttpHeaders;
+
         private bool enableNamingAlias;
 
         private bool ignoreUnexpectedElementsAndAttributes;
@@ -69,6 +71,8 @@ namespace Microsoft.OData.ConnectedService.Models
         private string webProxyHost;
 
         private bool includeWebProxyNetworkCredentials;
+
+        private bool storeWebProxyNetworkCredentials;
 
         private string webProxyNetworkCredentialsUsername;
 
@@ -254,6 +258,17 @@ namespace Microsoft.OData.ConnectedService.Models
         }
 
         [DataMember]
+        public bool StoreCustomHttpHeaders
+        {
+            get { return storeCustomHttpHeaders; }
+            set
+            {
+                storeCustomHttpHeaders = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
         public string WebProxyHost
         {
             get { return webProxyHost; }
@@ -271,6 +286,17 @@ namespace Microsoft.OData.ConnectedService.Models
             set
             {
                 includeWebProxyNetworkCredentials = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool StoreWebProxyNetworkCredentials
+        {
+            get { return storeWebProxyNetworkCredentials; }
+            set
+            {
+                storeWebProxyNetworkCredentials = value;
                 OnPropertyChanged();
             }
         }

--- a/src/ODataConnectedServiceHandler.cs
+++ b/src/ODataConnectedServiceHandler.cs
@@ -48,11 +48,17 @@ namespace Microsoft.OData.ConnectedService
             Project project = ProjectHelper.GetProjectFromHierarchy(context.ProjectHierarchy);
             var serviceInstance = (ODataConnectedServiceInstance)context.ServiceInstance;
 
-            var codeGenDescriptor = await GenerateCodeAsync(serviceInstance.ServiceConfig.Endpoint, serviceInstance.ServiceConfig.EdmxVersion, context, project).ConfigureAwait(false);
-            // We don't save headers and proxy details to designer data
-            serviceInstance.ServiceConfig.CustomHttpHeaders = null;
-            serviceInstance.ServiceConfig.WebProxyNetworkCredentialsUsername = null;
-            serviceInstance.ServiceConfig.WebProxyNetworkCredentialsPassword = null;
+            var codeGenDescriptor = await GenerateCodeAsync(serviceInstance.ServiceConfig.Endpoint, serviceInstance.ServiceConfig.EdmxVersion, context, project).ConfigureAwait(false);            
+            if (!serviceInstance.ServiceConfig.StoreCustomHttpHeaders)
+            {
+                serviceInstance.ServiceConfig.CustomHttpHeaders = null;
+            }
+            if (!serviceInstance.ServiceConfig.StoreWebProxyNetworkCredentials)
+            {
+                serviceInstance.ServiceConfig.WebProxyNetworkCredentialsUsername = null;
+                serviceInstance.ServiceConfig.WebProxyNetworkCredentialsPassword = null;
+                serviceInstance.ServiceConfig.WebProxyNetworkCredentialsDomain = null;
+            }
 
             context.SetExtendedDesignerData(serviceInstance.ServiceConfig);
             return codeGenDescriptor;

--- a/src/Views/ConfigODataEndpoint.xaml
+++ b/src/Views/ConfigODataEndpoint.xaml
@@ -119,6 +119,14 @@
                     </ToolTip>
                 </TextBox.ToolTip>
             </TextBox>
+            <CheckBox
+                x:Name="StoreCustomHttpHeaders"
+                Margin="0,15"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Content="Save custom http headers in ConnectedService.json"
+                FontWeight="Medium"
+                IsChecked="{Binding Path=UserSettings.StoreCustomHttpHeaders, Mode=TwoWay}" />
         </StackPanel>
 
         <CheckBox
@@ -197,6 +205,14 @@
                     HorizontalAlignment="Left"
                     Text="{Binding Path=UserSettings.WebProxyNetworkCredentialsDomain, Mode=TwoWay}"
                     TextWrapping="Wrap" />
+                <CheckBox
+                    x:Name="StoreWebProxyNetworkCredentials"
+                    Margin="0,10"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Content="Save web proxy credentials in ConnectedService.json"
+                    FontWeight="Medium"
+                    IsChecked="{Binding Path=UserSettings.StoreWebProxyNetworkCredentials, Mode=TwoWay}" />
 
             </StackPanel>
         </StackPanel>

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -54,10 +54,12 @@ namespace ODataConnectedService.Tests
                 EdmxVersion = Constants.EdmxVersion4,
                 ServiceName = "MyService",
                 IncludeCustomHeaders = true,
+                StoreCustomHttpHeaders = true,
                 CustomHttpHeaders = "Key1:Val1\nKey2:Val2",
                 IncludeWebProxy = true,
                 WebProxyHost = "http://localhost:8080",
                 IncludeWebProxyNetworkCredentials = true,
+                StoreWebProxyNetworkCredentials = true,
                 WebProxyNetworkCredentialsDomain = "domain",
                 WebProxyNetworkCredentialsUsername = "username",
                 WebProxyNetworkCredentialsPassword = "password",
@@ -124,10 +126,12 @@ namespace ODataConnectedService.Tests
                 Assert.Null(endpointPage.UserSettings.Endpoint);
                 Assert.Null(endpointPage.EdmxVersion);
                 Assert.False(endpointPage.UserSettings.IncludeCustomHeaders);
+                Assert.False(endpointPage.UserSettings.StoreCustomHttpHeaders);
                 Assert.Null(endpointPage.UserSettings.CustomHttpHeaders);
                 Assert.False(endpointPage.UserSettings.IncludeWebProxy);
                 Assert.Null(endpointPage.UserSettings.WebProxyHost);
                 Assert.False(endpointPage.UserSettings.IncludeWebProxyNetworkCredentials);
+                Assert.False(endpointPage.UserSettings.StoreWebProxyNetworkCredentials);
                 Assert.Null(endpointPage.UserSettings.WebProxyNetworkCredentialsDomain);
                 Assert.Null(endpointPage.UserSettings.WebProxyNetworkCredentialsUsername);
                 Assert.Null(endpointPage.UserSettings.WebProxyNetworkCredentialsPassword);
@@ -276,11 +280,13 @@ namespace ODataConnectedService.Tests
                 Assert.Equal("https://service/$metadata", endpointPage.UserSettings.Endpoint);
                 Assert.Equal("MyService", endpointPage.UserSettings.ServiceName);
                 Assert.True(endpointPage.UserSettings.IncludeCustomHeaders);
+                Assert.True(endpointPage.UserSettings.StoreCustomHttpHeaders);
                 Assert.Equal("Key1:Val1\nKey2:Val2", endpointPage.UserSettings.CustomHttpHeaders);
                 Assert.True(endpointPage.UserSettings.IncludeWebProxy);
                 Assert.Equal("http://localhost:8080", endpointPage.UserSettings.WebProxyHost);
                 Assert.True(endpointPage.UserSettings.IncludeWebProxyNetworkCredentials);
-                Assert.Equal("domain", endpointPage.UserSettings.WebProxyNetworkCredentialsDomain);
+                Assert.True(endpointPage.UserSettings.StoreWebProxyNetworkCredentials);
+                Assert.Equal("domain", endpointPage.UserSettings.WebProxyNetworkCredentialsDomain);                                
                 // username and password are not restored from the config
                 Assert.Equal("username", endpointPage.UserSettings.WebProxyNetworkCredentialsUsername);
                 Assert.Equal("password", endpointPage.UserSettings.WebProxyNetworkCredentialsPassword);
@@ -464,10 +470,12 @@ namespace ODataConnectedService.Tests
                 endpointPage.UserSettings.Endpoint = MetadataPath;
                 endpointPage.EdmxVersion = Constants.EdmxVersion4;
                 endpointPage.UserSettings.IncludeCustomHeaders = true;
+                endpointPage.UserSettings.StoreCustomHttpHeaders = true;
                 endpointPage.UserSettings.CustomHttpHeaders = "Key:val";
-                endpointPage.UserSettings.IncludeWebProxy = true;
+                endpointPage.UserSettings.IncludeWebProxy = true;                
                 endpointPage.UserSettings.WebProxyHost = "http://localhost:8080";
                 endpointPage.UserSettings.IncludeWebProxyNetworkCredentials = true;
+                endpointPage.UserSettings.StoreWebProxyNetworkCredentials = true;
                 endpointPage.UserSettings.WebProxyNetworkCredentialsDomain = "domain";
                 endpointPage.UserSettings.WebProxyNetworkCredentialsUsername = "user";
                 endpointPage.UserSettings.WebProxyNetworkCredentialsPassword = "pass";
@@ -538,10 +546,12 @@ namespace ODataConnectedService.Tests
                 Assert.Equal(MetadataPath, settings.MruEndpoints.First());
                 Assert.Equal(1, settings.MruEndpoints.Count(e => e == MetadataPath));
                 Assert.True(settings.IncludeCustomHeaders);
+                Assert.True(settings.StoreCustomHttpHeaders);
                 Assert.Null(settings.CustomHttpHeaders); // Custom HTTP headers may contain sensitive details like auth tokens
                 Assert.True(settings.IncludeWebProxy);
                 Assert.Equal("http://localhost:8080", settings.WebProxyHost);
                 Assert.True(settings.IncludeWebProxyNetworkCredentials);
+                Assert.True(settings.StoreWebProxyNetworkCredentials);
                 Assert.Equal("domain", settings.WebProxyNetworkCredentialsDomain);
                 // We don't persist web proxy network credentials
                 Assert.Null(settings.WebProxyNetworkCredentialsUsername);
@@ -574,10 +584,12 @@ namespace ODataConnectedService.Tests
                 Assert.Equal(MetadataPath, config.Endpoint);
                 Assert.Equal(Constants.EdmxVersion4, config.EdmxVersion);
                 Assert.True(config.IncludeCustomHeaders);
+                Assert.True(config.StoreCustomHttpHeaders);
                 Assert.Equal("Key:val", config.CustomHttpHeaders);
                 Assert.True(config.IncludeWebProxy);
                 Assert.Equal("http://localhost:8080", config.WebProxyHost);
                 Assert.True(config.IncludeWebProxyNetworkCredentials);
+                Assert.True(config.StoreCustomHttpHeaders);
                 Assert.Equal("domain", config.WebProxyNetworkCredentialsDomain);
                 Assert.Equal("user", config.WebProxyNetworkCredentialsUsername);
                 Assert.Equal("pass", config.WebProxyNetworkCredentialsPassword);
@@ -625,10 +637,12 @@ namespace ODataConnectedService.Tests
                 Assert.Equal(MetadataPath, config.Endpoint);
                 Assert.Equal(Constants.EdmxVersion4, config.EdmxVersion);
                 Assert.True(config.IncludeCustomHeaders);
+                Assert.True(config.StoreCustomHttpHeaders);
                 Assert.Equal("Key1:Val1\nKey2:Val2", config.CustomHttpHeaders);
                 Assert.True(config.IncludeWebProxy);
                 Assert.Equal("http://localhost:8080", config.WebProxyHost);
                 Assert.True(config.IncludeWebProxyNetworkCredentials);
+                Assert.True(config.StoreWebProxyNetworkCredentials);
                 Assert.Equal("domain", config.WebProxyNetworkCredentialsDomain);
                 Assert.Equal("username", config.WebProxyNetworkCredentialsUsername);
                 Assert.Equal("password", config.WebProxyNetworkCredentialsPassword);
@@ -713,6 +727,8 @@ namespace ODataConnectedService.Tests
                 Assert.Equal(MetadataPath, endpointPage.UserSettings.Endpoint);
                 endpointPage.UserSettings.ServiceName = "Service";
                 endpointPage.UserSettings.IncludeCustomHeaders = true;
+                endpointPage.UserSettings.StoreCustomHttpHeaders = true;
+                endpointPage.UserSettings.StoreWebProxyNetworkCredentials = true;
                 endpointPage.UserSettings.CustomHttpHeaders = "A:b";
                 endpointPage.OnPageLeavingAsync(null).Wait();
 
@@ -751,6 +767,8 @@ namespace ODataConnectedService.Tests
                 Assert.Equal("Service", config.ServiceName);
                 Assert.Equal(MetadataPath, config.Endpoint);
                 Assert.True(config.IncludeCustomHeaders);
+                Assert.True(config.StoreCustomHttpHeaders);
+                Assert.True(config.StoreWebProxyNetworkCredentials);
                 Assert.Equal("A:b", config.CustomHttpHeaders);
                 Assert.True(config.GenerateMultipleFiles);
                 Assert.True(config.MakeTypesInternal);
@@ -852,6 +870,8 @@ namespace ODataConnectedService.Tests
                 Assert.Equal(savedConfig.ServiceName, config.ServiceName);
                 Assert.Equal(savedConfig.Endpoint, config.Endpoint);
                 Assert.True(config.IncludeCustomHeaders);
+                Assert.True(config.StoreCustomHttpHeaders);
+                Assert.True(config.StoreWebProxyNetworkCredentials);
                 Assert.Equal("A:b", config.CustomHttpHeaders);
                 Assert.True(config.GenerateMultipleFiles);
                 Assert.True(config.MakeTypesInternal);


### PR DESCRIPTION
Allow users to store custom Http headers and proxy credentials in `ConnectedService.json`.

Adds a checkbox to "Include Custom Http Headers" and "Include Proxy Network Credentials" allowing the user to store these in `ConnectedService.json` if so desired.