### PR TITLE
Fix #48 by improving handling of Uris with/without "$metadata" suffix.

### DIFF
--- a/src/ODataConnectedService/Common/ExtensionMethods.cs
+++ b/src/ODataConnectedService/Common/ExtensionMethods.cs
@@ -42,5 +42,40 @@ namespace Microsoft.OData.ConnectedService.Common
                 }
             }
         }
+
+
+        /// <summary>
+        /// Ensures that the Uri conforms to the expected "$metadata" format
+        /// </summary>
+        /// <param name="uri">Uri to clean</param>
+        /// <returns>Cleaned uri</returns>
+        public static Uri CleanMetadataUri(this Uri uri)
+        {
+            if (uri.Scheme == "http" || uri.Scheme == "https")
+            {
+                UriBuilder uriBuilder;
+                bool preserveQueryAndFragment = true;
+                if (uri.Segments.Last().StartsWith("$metadata", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
+                    var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
+                    uriBuilder = new UriBuilder(absolutePathUri);
+                }
+                else
+                {
+                    var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
+                    uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
+                }
+                if (preserveQueryAndFragment)
+                {
+                    uriBuilder.Query = uri.Query.TrimStart('?');
+                    uriBuilder.Fragment = uri.Fragment.TrimStart('#');
+                }
+                uriBuilder.UserName = uri.UserInfo;
+
+                return new Uri(uriBuilder.Uri.AbsoluteUri);
+            }
+            return new Uri(uri.AbsoluteUri);
+        }
     }
 }

--- a/src/ODataConnectedService/Templates/ODataT4CodeGenerator.cs
+++ b/src/ODataConnectedService/Templates/ODataT4CodeGenerator.cs
@@ -30,7 +30,8 @@ namespace Microsoft.OData.ConnectedService.Templates
     using Microsoft.VisualStudio.TextTemplating;
     using Microsoft.VisualStudio.ConnectedServices;
     using EnvDTE;
-    
+    using Microsoft.OData.ConnectedService.Common;
+
     /// <summary>
     /// Class to produce the template output
     /// </summary>
@@ -303,15 +304,9 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        if (uri.Scheme == "http" || uri.Scheme == "https")
-        {
-            value = uri.Scheme + "://" + uri.Authority + uri.AbsolutePath;
-            value = value.TrimEnd('/');
-            if (!value.EndsWith("$metadata"))
-            {
-                value += "/$metadata";
-            }
-        }
+        uri = uri.CleanMetadataUri();
+
+        value = uri.AbsoluteUri;
 
         this.metadataDocumentUri = value;
     }

--- a/src/ODataConnectedService/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/ODataConnectedService/Templates/ODataT4CodeGenerator.ttinclude
@@ -159,12 +159,27 @@ public string MetadataDocumentUri
 
         if (uri.Scheme == "http" || uri.Scheme == "https")
         {
-            value = uri.Scheme + "://" + uri.Authority + uri.AbsolutePath;
-            value = value.TrimEnd('/');
-            if (!value.EndsWith("$metadata"))
+            UriBuilder uriBuilder;
+            bool preserveQueryAndFragment = true;
+            if (uri.Segments.Last().StartsWith("$metadata", StringComparison.InvariantCultureIgnoreCase))
             {
-                value += "/$metadata";
+                preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
+                var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
+                uriBuilder = new UriBuilder(absolutePathUri);
             }
+            else
+            {
+                var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
+                uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
+            }
+            if (preserveQueryAndFragment)
+            {
+                uriBuilder.Query = uri.Query.TrimStart('?');
+                uriBuilder.Fragment = uri.Fragment.TrimStart('#');
+            }
+            uriBuilder.UserName = uri.UserInfo;
+
+            value = uriBuilder.Uri.AbsoluteUri;
         }
 
         this.metadataDocumentUri = value;

--- a/src/ODataConnectedService/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ODataConnectedService/ViewModels/ConfigODataEndpointViewModel.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Xml;
@@ -77,10 +78,14 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             if (UserSettings.Endpoint.StartsWith("https:", StringComparison.Ordinal)
                 || UserSettings.Endpoint.StartsWith("http", StringComparison.Ordinal))
             {
-                if (!UserSettings.Endpoint.EndsWith("$metadata", StringComparison.Ordinal))
+                if (!Uri.TryCreate(UserSettings.Endpoint, UriKind.Absolute, out var uri))
                 {
-                    UserSettings.Endpoint = UserSettings.Endpoint.TrimEnd('/') + "/$metadata";
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", UserSettings.Endpoint));
                 }
+
+                uri = uri.CleanMetadataUri();
+
+                UserSettings.Endpoint = uri.AbsoluteUri;
             }
 
             Stream metadataStream;

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorUnitTest.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorUnitTest.cs
@@ -98,28 +98,28 @@ namespace ODataConnectedService.Tests
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldAddSlashAndMetadataSurfix()
+        public void GetMetadataDocumentUriShouldAddSlashAndMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldAddMetadataSurfix()
+        public void GetMetadataDocumentUriShouldAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldNotAddMetadataSurfix()
+        public void GetMetadataDocumentUriShouldNotAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/$metadata";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriWithSlashShouldNotAddMetadataSurfix()
+        public void GetMetadataDocumentUriWithSlashShouldNotAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/$metadata/";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
@@ -136,14 +136,14 @@ namespace ODataConnectedService.Tests
         public void GetMetadataDocumentUriWithLocalhostShouldContainPortNumber()
         {
             codeGenerator.MetadataDocumentUri = "http://localhost:8080/Aruba.svc/?query=0";
-            codeGenerator.MetadataDocumentUri.Should().Be("http://localhost:8080/Aruba.svc/$metadata");
+            codeGenerator.MetadataDocumentUri.Should().Be("http://localhost:8080/Aruba.svc/$metadata?query=0");
         }
         
         [TestMethod]
-        public void GetMetadataDocumentUriShouldNotAddMetadataSurfixForFilePath()
+        public void GetMetadataDocumentUriShouldNotAddMetadataSuffixForFilePath()
         {
-            codeGenerator.MetadataDocumentUri = "File://C://Odata//edmx";
-            codeGenerator.MetadataDocumentUri.Should().Be("File://C://Odata//edmx");
+            codeGenerator.MetadataDocumentUri = "file:///C://Odata//edmx";
+            codeGenerator.MetadataDocumentUri.Should().Be("file:///C://Odata//edmx");
         }
     }
 }

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -54,12 +54,19 @@ namespace ODataConnectedService.Tests.ViewModels
             Assert.IsFalse(pageNavigationResult.IsSuccess);
             Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
 
+            //Provide a url with "$metadata" as the last segment in the url
+            configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment";
+            _ = configOdataEndPointViewModel.OnPageLeavingAsync(null);
+
+            //Check if the url is detected as valid and is unmodified
+            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment");
+
             //Provide a url without $metadata
-            configOdataEndPointViewModel.UserSettings.Endpoint = "http://mysite/ODataService";
+            configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService?$schemaversion=2.0#fragment";
             pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
-            //Check if $metadata is apended if the url does not have it added at the end
-            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://mysite/ODataService/$metadata");
+            //Check if $metadata is apended as the last segment if it was not the last segment of the url
+            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment");
 
             //Check if an exception is thrown for an invalid url and the user is notified
             pageNavigationResult = pageNavigationResultTask?.Result;


### PR DESCRIPTION
Query and fragment parts of the Uri were always clobbered, these are now
preserved, except in the special case where the last segment of the Uri is
"$metadata/".

Please note, that some of the code is perhaps slightly unwieldy, to handle
the "$metadata/" edge-case. This is done to satisfy the specific test-case:
"GetMetadataDocumentUriWithSlashShouldIgnoreQueries".

I am not sure I understand the reasoning behind this test-case, but as
mentioned, the code is made to satisfy this test.

If there is no reason to satisfy this test, that is, if it is OK to always preserve
query parameters, the whole "preserveQueryAndFragment" part of this patch
can be eliminated.