### PR TITLE
Fixes Custom Header being ignored

### DIFF
--- a/OData.CLI.sln
+++ b/OData.CLI.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31729.503
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OData.Cli", "src\OData.Cli\OData.Cli.csproj", "{8C2FC194-F76E-4831-BE0F-4A52C222D9D8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.Cli", "src\Microsoft.OData.Cli\Microsoft.OData.Cli.csproj", "{887BCE02-9AAF-4A80-B62D-D9249B875349}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.CodeGen", "src\Microsoft.OData.CodeGen\Microsoft.OData.CodeGen.csproj", "{86FAAAEC-3BBD-479C-8A44-D2715A6BD4C1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{8C2FC194-F76E-4831-BE0F-4A52C222D9D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8C2FC194-F76E-4831-BE0F-4A52C222D9D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8C2FC194-F76E-4831-BE0F-4A52C222D9D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8C2FC194-F76E-4831-BE0F-4A52C222D9D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{887BCE02-9AAF-4A80-B62D-D9249B875349}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{887BCE02-9AAF-4A80-B62D-D9249B875349}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{887BCE02-9AAF-4A80-B62D-D9249B875349}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{887BCE02-9AAF-4A80-B62D-D9249B875349}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86FAAAEC-3BBD-479C-8A44-D2715A6BD4C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86FAAAEC-3BBD-479C-8A44-D2715A6BD4C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86FAAAEC-3BBD-479C-8A44-D2715A6BD4C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86FAAAEC-3BBD-479C-8A44-D2715A6BD4C1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -72,7 +72,7 @@ namespace Microsoft.OData.Cli
             Option upperCamelCase = new Option<bool>(new[] { "--upper-camel-case", "-ucc" })
             {
                 Name = "upper-camel-case",
-                Description = "Disables upper camel casing."
+                Description = "Enables upper camel casing."
             };
 
             this.AddOption(upperCamelCase);

--- a/src/Microsoft.OData.Cli/Microsoft.OData.Cli.csproj
+++ b/src/Microsoft.OData.Cli/Microsoft.OData.Cli.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta3.22114.1" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.OData.CodeGen\Microsoft.OData.CodeGen.csproj" />
   </ItemGroup>

--- a/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
+++ b/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
@@ -120,11 +120,15 @@ namespace Microsoft.OData.CodeGen.Common
                 var headerKeyValuePair = customHeader.Split(':');
 
                 if (headerKeyValuePair.Length > 1)
+                {
                     webRequest.Headers.Add(headerKeyValuePair[0], headerKeyValuePair[1]);
+                }
                 else
+                {
                     Console.WriteLine(headerKeyValuePair.Length > 0
                         ? $"Header '{headerKeyValuePair[0]}' is missing its value and thus will be ignored."
-                        : "Neither an header name or value was found, header ignored.");
+                        : "Neither a header name or value was found, header ignored.");
+                }
             }
         }
     }

--- a/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
+++ b/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
@@ -49,6 +49,8 @@ namespace Microsoft.OData.CodeGen.Common
             if (!metadataUri.IsFile)
             {
                 var webRequest = (HttpWebRequest)WebRequest.Create(metadataUri);
+                
+                AddCustomHeaders(serviceConfiguration, webRequest);
 
                 if (serviceConfiguration.IncludeWebProxy)
                 {
@@ -104,6 +106,25 @@ namespace Microsoft.OData.CodeGen.Common
             finally
             { 
                 metadataStream?.Dispose();
+            }
+        }
+
+        private static void AddCustomHeaders(ServiceConfiguration serviceConfiguration, WebRequest webRequest)
+        {
+            if (string.IsNullOrWhiteSpace(serviceConfiguration.CustomHttpHeaders)) 
+                return;
+            
+            var customHeaders = serviceConfiguration.CustomHttpHeaders.Split(',');
+            foreach (var customHeader in customHeaders)
+            {
+                var headerKeyValuePair = customHeader.Split(':');
+
+                if (headerKeyValuePair.Length > 1)
+                    webRequest.Headers.Add(headerKeyValuePair[0], headerKeyValuePair[1]);
+                else
+                    Console.WriteLine(headerKeyValuePair.Length > 0
+                        ? $"Header '{headerKeyValuePair[0]}' is missing its value and thus will be ignored."
+                        : "Neither an header name or value was found, header ignored.");
             }
         }
     }


### PR DESCRIPTION
The OData Cli is ignoring the custom headers at the first step when obtaining the metadata information. This pull request fixes this issue. Also, I've taken care of fixing a misleading command line argument comment. 

This fixes #272 