### PR TITLE
move getmetadata version to core class

### DIFF
--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -172,7 +172,8 @@ namespace Microsoft.OData.Cli
                     }
                 }
 
-                Version version = GetMetadataVersion(options);
+                ServiceConfiguration config = GetServiceConfiguration(options);
+                MetadataReader.GetMetadataVersion(config, out Version version);
                 if (version == Constants.EdmxVersion4)
                 {
                     await GenerateCodeForV4Clients(options, console).ConfigureAwait(false);
@@ -191,10 +192,9 @@ namespace Microsoft.OData.Cli
             return 1;
         }
 
-        private Version GetMetadataVersion(GenerateOptions generateOptions)
+        private ServiceConfiguration GetServiceConfiguration(GenerateOptions generateOptions)
         {
-            Version version = null;
-            var serviceConfiguration = new ServiceConfiguration();
+            ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
             serviceConfiguration.Endpoint = generateOptions.MetadataUri;
             serviceConfiguration.CustomHttpHeaders = generateOptions.CustomHeaders;
             serviceConfiguration.WebProxyHost = generateOptions.WebProxyHost;
@@ -203,9 +203,8 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsUsername = generateOptions.WebProxyNetworkCredentialsUsername;
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
-            
-            version = MetadataReader.GetMetadataVersion(serviceConfiguration);
-            return version;
+
+            return serviceConfiguration;
         }
 
         private async Task GenerateCodeForV4Clients(GenerateOptions generateOptions, IConsole console)

--- a/src/ODataConnectedService/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ODataConnectedService/ViewModels/ConfigODataEndpointViewModel.cs
@@ -76,14 +76,14 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         private ServiceConfiguration GetServiceConfiguration()
         {
             ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
-            serviceConfiguration.Endpoint = UserSettings.Endpoint;
-            serviceConfiguration.CustomHttpHeaders = UserSettings.CustomHttpHeaders;
-            serviceConfiguration.WebProxyHost = UserSettings.WebProxyHost;
-            serviceConfiguration.IncludeWebProxy = UserSettings.IncludeWebProxy;
-            serviceConfiguration.IncludeWebProxyNetworkCredentials = UserSettings.IncludeWebProxyNetworkCredentials;
-            serviceConfiguration.WebProxyNetworkCredentialsUsername = UserSettings.WebProxyNetworkCredentialsUsername;
-            serviceConfiguration.WebProxyNetworkCredentialsPassword = UserSettings.WebProxyNetworkCredentialsPassword;
-            serviceConfiguration.WebProxyNetworkCredentialsDomain = UserSettings.WebProxyNetworkCredentialsDomain;
+            serviceConfiguration.Endpoint = this.UserSettings.Endpoint;
+            serviceConfiguration.CustomHttpHeaders = this.UserSettings.CustomHttpHeaders;
+            serviceConfiguration.WebProxyHost = this.UserSettings.WebProxyHost;
+            serviceConfiguration.IncludeWebProxy = this.UserSettings.IncludeWebProxy;
+            serviceConfiguration.IncludeWebProxyNetworkCredentials = this.UserSettings.IncludeWebProxyNetworkCredentials;
+            serviceConfiguration.WebProxyNetworkCredentialsUsername = this.UserSettings.WebProxyNetworkCredentialsUsername;
+            serviceConfiguration.WebProxyNetworkCredentialsPassword = this.UserSettings.WebProxyNetworkCredentialsPassword;
+            serviceConfiguration.WebProxyNetworkCredentialsDomain = this.UserSettings.WebProxyNetworkCredentialsDomain;
             
             return serviceConfiguration;
         }

--- a/src/ODataConnectedService/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/ODataConnectedService/Views/ConfigODataEndpoint.xaml.cs
@@ -152,14 +152,14 @@ namespace Microsoft.OData.ConnectedService.Views
         private ServiceConfiguration GetServiceConfiguration()
         {
             ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
-            serviceConfiguration.Endpoint = UserSettings.Endpoint;
-            serviceConfiguration.CustomHttpHeaders = UserSettings.CustomHttpHeaders;
-            serviceConfiguration.WebProxyHost = UserSettings.WebProxyHost;
-            serviceConfiguration.IncludeWebProxy = UserSettings.IncludeWebProxy;
-            serviceConfiguration.IncludeWebProxyNetworkCredentials = UserSettings.IncludeWebProxyNetworkCredentials;
-            serviceConfiguration.WebProxyNetworkCredentialsUsername = UserSettings.WebProxyNetworkCredentialsUsername;
-            serviceConfiguration.WebProxyNetworkCredentialsPassword = UserSettings.WebProxyNetworkCredentialsPassword;
-            serviceConfiguration.WebProxyNetworkCredentialsDomain = UserSettings.WebProxyNetworkCredentialsDomain;
+            serviceConfiguration.Endpoint = this.UserSettings.Endpoint;
+            serviceConfiguration.CustomHttpHeaders = this.UserSettings.CustomHttpHeaders;
+            serviceConfiguration.WebProxyHost = this.UserSettings.WebProxyHost;
+            serviceConfiguration.IncludeWebProxy = this.UserSettings.IncludeWebProxy;
+            serviceConfiguration.IncludeWebProxyNetworkCredentials = this.UserSettings.IncludeWebProxyNetworkCredentials;
+            serviceConfiguration.WebProxyNetworkCredentialsUsername = this.UserSettings.WebProxyNetworkCredentialsUsername;
+            serviceConfiguration.WebProxyNetworkCredentialsPassword = this.UserSettings.WebProxyNetworkCredentialsPassword;
+            serviceConfiguration.WebProxyNetworkCredentialsDomain = this.UserSettings.WebProxyNetworkCredentialsDomain;
 
             return serviceConfiguration;
         }

--- a/src/ODataConnectedService/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/ODataConnectedService/Views/ConfigODataEndpoint.xaml.cs
@@ -119,7 +119,8 @@ namespace Microsoft.OData.ConnectedService.Views
             // get Operation Imports and bound operations from metadata for excluding ExcludedOperationImports and ExcludedBoundOperations
             try
             {
-                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = connectedServiceWizard.ConfigODataEndpointViewModel.GetMetadata(out var version);
+                var serviceConfiguration = GetServiceConfiguration();
+                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
                 connectedServiceWizard.ConfigODataEndpointViewModel.EdmxVersion = version;
                 if (version == Constants.EdmxVersion4)
                 {
@@ -146,6 +147,21 @@ namespace Microsoft.OData.ConnectedService.Views
         private ODataConnectedServiceWizard GetODataConnectedServiceWizard()
         {
             return (ODataConnectedServiceWizard)((ConfigODataEndpointViewModel)this.DataContext).Wizard;
+        }
+
+        private ServiceConfiguration GetServiceConfiguration()
+        {
+            ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+            serviceConfiguration.Endpoint = UserSettings.Endpoint;
+            serviceConfiguration.CustomHttpHeaders = UserSettings.CustomHttpHeaders;
+            serviceConfiguration.WebProxyHost = UserSettings.WebProxyHost;
+            serviceConfiguration.IncludeWebProxy = UserSettings.IncludeWebProxy;
+            serviceConfiguration.IncludeWebProxyNetworkCredentials = UserSettings.IncludeWebProxyNetworkCredentials;
+            serviceConfiguration.WebProxyNetworkCredentialsUsername = UserSettings.WebProxyNetworkCredentialsUsername;
+            serviceConfiguration.WebProxyNetworkCredentialsPassword = UserSettings.WebProxyNetworkCredentialsPassword;
+            serviceConfiguration.WebProxyNetworkCredentialsDomain = UserSettings.WebProxyNetworkCredentialsDomain;
+
+            return serviceConfiguration;
         }
     }
 }


### PR DESCRIPTION
There was a method for getting the metadata version but it was in the <code>OData Connected Service </code> project. While working on <code>odata-cli</code>I had created a method for getting the metadata version in the core project library. I have replaced the method that I had created in the core project with the method that was in the <code>OData Connected Service</code> project as it takes care of Custom HttpHeaders and Web Proxies. 

It fixes this issue https://github.com/OData/ODataConnectedService/issues/272