### PR TITLE
Improve uri handling

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,10 +101,10 @@ stages:
         publishLocation: 'Container'
 
     - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact - VSIX2022plus'
+      displayName: 'Publish Artifact - VSIX2022Plus'
       inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)\VSIX2022plus'
-        ArtifactName: 'VSIX2022plus'
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\VSIX2022Plus'
+        ArtifactName: 'VSIX2022Plus'
         publishLocation: 'Container'
 
     - publish: configs

--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -138,7 +138,7 @@ namespace Microsoft.OData.Cli
                 (
                     GenerateOptions options,
                     IConsole console
-                ) 
+                )
                 => HandleGenerateCommand(options, console));
         }
 
@@ -185,10 +185,10 @@ namespace Microsoft.OData.Cli
             catch (Exception ex)
             {
                 console.Error.Write(ex.Message);
-                return 0;
+                return 1;
             }
 
-            return 1;
+            return 0;
         }
 
         private Version GetMetadataVersion(GenerateOptions generateOptions)
@@ -203,7 +203,7 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsUsername = generateOptions.WebProxyNetworkCredentialsUsername;
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
-            
+
             version = MetadataReader.GetMetadataVersion(serviceConfiguration);
             return version;
         }
@@ -232,7 +232,7 @@ namespace Microsoft.OData.Cli
 
             Project project = ProjectHelper.CreateProjectInstance(generateOptions.OutputDir);
             BaseCodeGenDescriptor codeGenDescriptor = new CodeGenDescriptorFactory().Create(
-                Constants.EdmxVersion4, 
+                Constants.EdmxVersion4,
                 new ODataCliFileHandler(new ODataCliMessageLogger(console), project),
                 new ODataCliMessageLogger(console),
                 new ODataCliPackageInstaller(project, new ODataCliMessageLogger(console)));

--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -172,7 +172,8 @@ namespace Microsoft.OData.Cli
                     }
                 }
 
-                Version version = GetMetadataVersion(options);
+                ServiceConfiguration config = GetServiceConfiguration(options);
+                MetadataReader.GetMetadataVersion(config, out Version version);
                 if (version == Constants.EdmxVersion4)
                 {
                     await GenerateCodeForV4Clients(options, console).ConfigureAwait(false);
@@ -191,10 +192,9 @@ namespace Microsoft.OData.Cli
             return 0;
         }
 
-        private Version GetMetadataVersion(GenerateOptions generateOptions)
+        private ServiceConfiguration GetServiceConfiguration(GenerateOptions generateOptions)
         {
-            Version version = null;
-            var serviceConfiguration = new ServiceConfiguration();
+            ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
             serviceConfiguration.Endpoint = generateOptions.MetadataUri;
             serviceConfiguration.CustomHttpHeaders = generateOptions.CustomHeaders;
             serviceConfiguration.WebProxyHost = generateOptions.WebProxyHost;
@@ -204,8 +204,7 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
 
-            version = MetadataReader.GetMetadataVersion(serviceConfiguration);
-            return version;
+            return serviceConfiguration;
         }
 
         private async Task GenerateCodeForV4Clients(GenerateOptions generateOptions, IConsole console)

--- a/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
+++ b/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
@@ -36,10 +36,15 @@ namespace Microsoft.OData.CodeGen.Common
             if (serviceConfiguration.Endpoint.StartsWith("https:", StringComparison.Ordinal)
                 || serviceConfiguration.Endpoint.StartsWith("http", StringComparison.Ordinal))
             {
-                if (!serviceConfiguration.Endpoint.EndsWith("$metadata", StringComparison.Ordinal))
+                if (!Uri.TryCreate(serviceConfiguration.Endpoint, UriKind.Absolute, out var uri))
+
                 {
-                    serviceConfiguration.Endpoint = serviceConfiguration.Endpoint.TrimEnd('/') + "/$metadata";
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", serviceConfiguration.Endpoint));
                 }
+
+                uri = CleanMetadataUri(uri);
+
+                serviceConfiguration.Endpoint = uri.AbsoluteUri;
             }
 
             Stream metadataStream;
@@ -119,6 +124,44 @@ namespace Microsoft.OData.CodeGen.Common
             {
                 metadataStream?.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Ensures that the Uri conforms to the expected "$metadata" format
+        /// </summary>
+        /// <param name="uri">Uri to clean</param>
+        /// <returns>Cleaned uri</returns>
+        public static Uri CleanMetadataUri(this Uri uri)
+        {
+            if (uri.Scheme == "http" || uri.Scheme == "https")
+            {
+                UriBuilder uriBuilder;
+
+                /// Evaluates to true if Query and Fragment properties are present in the Uri 
+                bool preserveQueryAndFragment = true;
+
+                if (uri.Segments.Last().StartsWith("$metadata", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
+                    Uri absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
+                    uriBuilder = new UriBuilder(absolutePathUri);
+                }
+                else
+                {
+                    var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
+                    uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
+                }
+
+                if (preserveQueryAndFragment)
+                {
+                    uriBuilder.Query = uri.Query.TrimStart('?');
+                    uriBuilder.Fragment = uri.Fragment.TrimStart('#');
+                }
+                uriBuilder.UserName = uri.UserInfo;
+
+                return new Uri(uriBuilder.Uri.AbsoluteUri);
+            }
+            return new Uri(uri.AbsoluteUri);
         }
     }
 }

--- a/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
+++ b/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
@@ -157,6 +157,7 @@ namespace Microsoft.OData.CodeGen.Common
                     uriBuilder.Query = uri.Query.TrimStart('?');
                     uriBuilder.Fragment = uri.Fragment.TrimStart('#');
                 }
+
                 uriBuilder.UserName = uri.UserInfo;
 
                 return new Uri(uriBuilder.Uri.AbsoluteUri);

--- a/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
+++ b/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
@@ -7,7 +7,9 @@
 
 
 using System;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Xml;
 using Microsoft.OData.CodeGen.Models;
@@ -24,13 +26,12 @@ namespace Microsoft.OData.CodeGen.Common
         /// </summary>
         /// <param name="serviceConfiguration">The <see cref="ServiceConfiguration"/> of the metadata provided.</param>
         /// <returns>The <see cref="Version"/> of the metadata</returns>
-        public static Version GetMetadataVersion(ServiceConfiguration serviceConfiguration)
+        public static string GetMetadataVersion(ServiceConfiguration serviceConfiguration, out Version edmxVersion)
         {
             if (string.IsNullOrEmpty(serviceConfiguration.Endpoint))
-                throw new ArgumentNullException("OData Service Endpoint", "Input the metadata document resource");
-
-            if (File.Exists(serviceConfiguration.Endpoint))
-                serviceConfiguration.Endpoint = new FileInfo(serviceConfiguration.Endpoint).FullName;
+            {
+                throw new ArgumentNullException("OData Service Endpoint", string.Format(CultureInfo.InvariantCulture, Constants.InputServiceEndpointMsg));
+            }
 
             if (serviceConfiguration.Endpoint.StartsWith("https:", StringComparison.Ordinal)
                 || serviceConfiguration.Endpoint.StartsWith("http", StringComparison.Ordinal))
@@ -41,19 +42,26 @@ namespace Microsoft.OData.CodeGen.Common
                 }
             }
 
-            
-
             Stream metadataStream;
-            Uri metadataUri = new Uri(serviceConfiguration.Endpoint);
+            var metadataUri = new Uri(serviceConfiguration.Endpoint);
 
             if (!metadataUri.IsFile)
             {
                 var webRequest = (HttpWebRequest)WebRequest.Create(metadataUri);
+                if (serviceConfiguration.CustomHttpHeaders != null)
+                {
+                    var headerElements = serviceConfiguration.CustomHttpHeaders.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                    foreach (var headerElement in headerElements)
+                    {
+                        // Trim header for empty spaces
+                        var header = headerElement.Trim();
+                        webRequest.Headers.Add(header);
+                    }
+                }
 
                 if (serviceConfiguration.IncludeWebProxy)
                 {
                     var proxy = new WebProxy(serviceConfiguration.WebProxyHost);
-
                     if (serviceConfiguration.IncludeWebProxyNetworkCredentials)
                     {
                         proxy.Credentials = new NetworkCredential(
@@ -79,30 +87,36 @@ namespace Microsoft.OData.CodeGen.Common
                 metadataStream = (Stream)xmlUrlResolver.GetEntity(metadataUri, null, typeof(Stream));
             }
 
+            var workFile = Path.GetTempFileName();
+
             try
             {
                 using (XmlReader reader = XmlReader.Create(metadataStream))
                 {
-                    while (reader.NodeType != XmlNodeType.Element)
+                    using (var writer = XmlWriter.Create(workFile))
                     {
-                        reader.Read();
-                    }
+                        while (reader.NodeType != XmlNodeType.Element)
+                        {
+                            reader.Read();
+                        }
 
-                    if (reader.EOF)
-                    {
-                        throw new InvalidOperationException("The metadata is an empty file");
-                    }
+                        if (reader.EOF)
+                        {
+                            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "The metadata is an empty file"));
+                        }
 
-                    Constants.SupportedEdmxNamespaces.TryGetValue(reader.NamespaceURI, out var edmxVersion);
-                    return edmxVersion;
+                        Constants.SupportedEdmxNamespaces.TryGetValue(reader.NamespaceURI, out edmxVersion);
+                        writer.WriteNode(reader, false);
+                    }
                 }
+                return workFile;
             }
             catch (WebException e)
             {
-                throw new InvalidOperationException(string.Format("The metadata cannot be accessed"), e);
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Cannot access {0}", serviceConfiguration.Endpoint), e);
             }
             finally
-            { 
+            {
                 metadataStream?.Dispose();
             }
         }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -27,13 +27,9 @@ namespace Microsoft.OData.CodeGen.Templates
     using Microsoft.OData.CodeGen.Logging;
     using System.Text;
     using System.Net;
-    using System.Reflection;
-    using Microsoft.OData.ConnectedService.Common;
     using System.Security;
-    using Microsoft.VisualStudio.TextTemplating;
-    using Microsoft.VisualStudio.ConnectedServices;
-    using EnvDTE;
-    
+    using Microsoft.OData.CodeGen.Common;
+
     /// <summary>
     /// Class to produce the template output
     /// </summary>
@@ -306,7 +302,7 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        value = uri.CleanMetadataUri().ToString();
+        value = MetadataReader.CleanMetadataUri(uri).ToString();
         this.metadataDocumentUri = value;
     }
 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -28,7 +28,11 @@ namespace Microsoft.OData.CodeGen.Templates
     using System.Text;
     using System.Net;
     using System.Security;
-    
+    using Microsoft.VisualStudio.TextTemplating;
+    using Microsoft.VisualStudio.ConnectedServices;
+    using EnvDTE;
+    using Microsoft.OData.ConnectedService.Common;
+
     /// <summary>
     /// Class to produce the template output
     /// </summary>
@@ -301,15 +305,9 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        if (uri.Scheme == "http" || uri.Scheme == "https")
-        {
-            value = uri.Scheme + "://" + uri.Authority + uri.AbsolutePath;
-            value = value.TrimEnd('/');
-            if (!value.EndsWith("$metadata"))
-            {
-                value += "/$metadata";
-            }
-        }
+        uri = uri.CleanMetadataUri();
+
+        value = uri.AbsoluteUri;
 
         this.metadataDocumentUri = value;
     }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -27,12 +27,12 @@ namespace Microsoft.OData.CodeGen.Templates
     using Microsoft.OData.CodeGen.Logging;
     using System.Text;
     using System.Net;
+    using System.Reflection;
     using System.Security;
     using Microsoft.VisualStudio.TextTemplating;
     using Microsoft.VisualStudio.ConnectedServices;
     using EnvDTE;
-    using Microsoft.OData.ConnectedService.Common;
-
+    
     /// <summary>
     /// Class to produce the template output
     /// </summary>
@@ -305,10 +305,7 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        uri = uri.CleanMetadataUri();
-
-        value = uri.AbsoluteUri;
-
+        value = uri.CleanMetadataUri().ToString();
         this.metadataDocumentUri = value;
     }
 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -160,12 +160,27 @@ public string MetadataDocumentUri
 
         if (uri.Scheme == "http" || uri.Scheme == "https")
         {
-            value = uri.Scheme + "://" + uri.Authority + uri.AbsolutePath;
-            value = value.TrimEnd('/');
-            if (!value.EndsWith("$metadata"))
+            UriBuilder uriBuilder;
+            bool preserveQueryAndFragment = true;
+            if (uri.Segments.Last().StartsWith("$metadata", StringComparison.InvariantCultureIgnoreCase))
             {
-                value += "/$metadata";
+                preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
+                var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
+                uriBuilder = new UriBuilder(absolutePathUri);
             }
+            else
+            {
+                var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
+                uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
+            }
+            if (preserveQueryAndFragment)
+            {
+                uriBuilder.Query = uri.Query.TrimStart('?');
+                uriBuilder.Fragment = uri.Fragment.TrimStart('#');
+            }
+            uriBuilder.UserName = uri.UserInfo;
+
+            value = uriBuilder.Uri.AbsoluteUri;
         }
 
         this.metadataDocumentUri = value;

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -35,6 +35,8 @@
 <#@ Import Namespace="Microsoft.OData.CodeGen.Logging" #>
 <#@ Import Namespace="System.Text"#>
 <#@ Import Namespace="System.Net"#>
+<#@ Import Namespace="System.Reflection"#>
+<#@ Import Namespace= "Microsoft.OData.ConnectedService.Common"#>
 <#@include file="ODataT4CodeGenFilesManager.ttinclude"
 #><#
     CodeGenerationContext context;
@@ -158,31 +160,7 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        if (uri.Scheme == "http" || uri.Scheme == "https")
-        {
-            UriBuilder uriBuilder;
-            bool preserveQueryAndFragment = true;
-            if (uri.Segments.Last().StartsWith("$metadata", StringComparison.InvariantCultureIgnoreCase))
-            {
-                preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
-                var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
-                uriBuilder = new UriBuilder(absolutePathUri);
-            }
-            else
-            {
-                var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
-                uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
-            }
-            if (preserveQueryAndFragment)
-            {
-                uriBuilder.Query = uri.Query.TrimStart('?');
-                uriBuilder.Fragment = uri.Fragment.TrimStart('#');
-            }
-            uriBuilder.UserName = uri.UserInfo;
-
-            value = uriBuilder.Uri.AbsoluteUri;
-        }
-
+        value = uri.CleanMetadataUri().ToString();
         this.metadataDocumentUri = value;
     }
 }

--- a/src/ODataConnectedService.Shared/Common/ExtensionMethods.cs
+++ b/src/ODataConnectedService.Shared/Common/ExtensionMethods.cs
@@ -42,44 +42,5 @@ namespace Microsoft.OData.ConnectedService.Common
                 }
             }
         }
-
-
-        /// <summary>
-        /// Ensures that the Uri conforms to the expected "$metadata" format
-        /// </summary>
-        /// <param name="uri">Uri to clean</param>
-        /// <returns>Cleaned uri</returns>
-        public static Uri CleanMetadataUri(this Uri uri)
-        {
-            if (uri.Scheme == "http" || uri.Scheme == "https")
-            {
-                UriBuilder uriBuilder;
-
-                /// Evaluates to true if Query and Fragment properties are present in the Uri 
-                bool preserveQueryAndFragment = true;
-
-                if (uri.Segments.Last().StartsWith("$metadata", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
-                    Uri absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
-                    uriBuilder = new UriBuilder(absolutePathUri);
-                }
-                else
-                {
-                    var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
-                    uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
-                }
-
-                if (preserveQueryAndFragment)
-                {
-                    uriBuilder.Query = uri.Query.TrimStart('?');
-                    uriBuilder.Fragment = uri.Fragment.TrimStart('#');
-                }
-                uriBuilder.UserName = uri.UserInfo;
-
-                return new Uri(uriBuilder.Uri.AbsoluteUri);
-            }
-            return new Uri(uri.AbsoluteUri);
-        }
     }
 }

--- a/src/ODataConnectedService.Shared/Common/ExtensionMethods.cs
+++ b/src/ODataConnectedService.Shared/Common/ExtensionMethods.cs
@@ -42,5 +42,40 @@ namespace Microsoft.OData.ConnectedService.Common
                 }
             }
         }
+
+
+        /// <summary>
+        /// Ensures that the Uri conforms to the expected "$metadata" format
+        /// </summary>
+        /// <param name="uri">Uri to clean</param>
+        /// <returns>Cleaned uri</returns>
+        public static Uri CleanMetadataUri(this Uri uri)
+        {
+            if (uri.Scheme == "http" || uri.Scheme == "https")
+            {
+                UriBuilder uriBuilder;
+                bool preserveQueryAndFragment = true;
+                if (uri.Segments.Last().StartsWith("$metadata", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
+                    var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
+                    uriBuilder = new UriBuilder(absolutePathUri);
+                }
+                else
+                {
+                    var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
+                    uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
+                }
+                if (preserveQueryAndFragment)
+                {
+                    uriBuilder.Query = uri.Query.TrimStart('?');
+                    uriBuilder.Fragment = uri.Fragment.TrimStart('#');
+                }
+                uriBuilder.UserName = uri.UserInfo;
+
+                return new Uri(uriBuilder.Uri.AbsoluteUri);
+            }
+            return new Uri(uri.AbsoluteUri);
+        }
     }
 }

--- a/src/ODataConnectedService.Shared/Common/ExtensionMethods.cs
+++ b/src/ODataConnectedService.Shared/Common/ExtensionMethods.cs
@@ -54,11 +54,14 @@ namespace Microsoft.OData.ConnectedService.Common
             if (uri.Scheme == "http" || uri.Scheme == "https")
             {
                 UriBuilder uriBuilder;
+
+                /// Evaluates to true if Query and Fragment properties are present in the Uri 
                 bool preserveQueryAndFragment = true;
+
                 if (uri.Segments.Last().StartsWith("$metadata", StringComparison.InvariantCultureIgnoreCase))
                 {
                     preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
-                    var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
+                    Uri absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
                     uriBuilder = new UriBuilder(absolutePathUri);
                 }
                 else
@@ -66,6 +69,7 @@ namespace Microsoft.OData.ConnectedService.Common
                     var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
                     uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
                 }
+
                 if (preserveQueryAndFragment)
                 {
                     uriBuilder.Query = uri.Query.TrimStart('?');

--- a/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
@@ -23,6 +23,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
         public UserSettings UserSettings { get; internal set; }
 
+        public ServiceConfiguration ServiceConfiguration { get; set; }
+
         public event EventHandler<EventArgs> PageEntering;
 
         public ConfigODataEndpointViewModel(UserSettings userSettings) : base()
@@ -45,9 +47,10 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         {
             try
             {
-                var serviceConfiguration = GetServiceConfiguration();
-                this.MetadataTempPath = CodeGen.Common.MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
+                ServiceConfiguration = GetServiceConfiguration();
+                this.MetadataTempPath = CodeGen.Common.MetadataReader.GetMetadataVersion(ServiceConfiguration, out var version);
                 // Makes sense to add MRU endpoint at this point since GetMetadata manipulates UserSettings.Endpoint
+                UserSettings.Endpoint = ServiceConfiguration.Endpoint;
                 UserSettings.AddMruEndpoint(UserSettings.Endpoint);
                 this.EdmxVersion = version;
                 PageLeaving?.Invoke(this, EventArgs.Empty);

--- a/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             try
             {
                 var serviceConfiguration = GetServiceConfiguration();
-                this.MetadataTempPath = Microsoft.OData.CodeGen.Common.MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
+                this.MetadataTempPath = MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
                 // Makes sense to add MRU endpoint at this point since GetMetadata manipulates UserSettings.Endpoint
                 UserSettings.AddMruEndpoint(UserSettings.Endpoint);
                 this.EdmxVersion = version;

--- a/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Xml;
@@ -77,10 +78,14 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             if (UserSettings.Endpoint.StartsWith("https:", StringComparison.Ordinal)
                 || UserSettings.Endpoint.StartsWith("http", StringComparison.Ordinal))
             {
-                if (!UserSettings.Endpoint.EndsWith("$metadata", StringComparison.Ordinal))
+                if (!Uri.TryCreate(UserSettings.Endpoint, UriKind.Absolute, out var uri))
                 {
-                    UserSettings.Endpoint = UserSettings.Endpoint.TrimEnd('/') + "/$metadata";
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", UserSettings.Endpoint));
                 }
+
+                uri = uri.CleanMetadataUri();
+
+                UserSettings.Endpoint = uri.AbsoluteUri;
             }
 
             Stream metadataStream;

--- a/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             try
             {
                 var serviceConfiguration = GetServiceConfiguration();
-                this.MetadataTempPath = MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
+                this.MetadataTempPath = CodeGen.Common.MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
                 // Makes sense to add MRU endpoint at this point since GetMetadata manipulates UserSettings.Endpoint
                 UserSettings.AddMruEndpoint(UserSettings.Endpoint);
                 this.EdmxVersion = version;

--- a/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
@@ -120,7 +120,7 @@ namespace Microsoft.OData.ConnectedService.Views
             try
             {
                 var serviceConfiguration = GetServiceConfiguration();
-                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
+                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = CodeGen.Common.MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
                 connectedServiceWizard.ConfigODataEndpointViewModel.EdmxVersion = version;
                 if (version == Constants.EdmxVersion4)
                 {

--- a/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
@@ -119,7 +119,8 @@ namespace Microsoft.OData.ConnectedService.Views
             // get Operation Imports and bound operations from metadata for excluding ExcludedOperationImports and ExcludedBoundOperations
             try
             {
-                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = connectedServiceWizard.ConfigODataEndpointViewModel.GetMetadata(out var version);
+                var serviceConfiguration = GetServiceConfiguration();
+                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
                 connectedServiceWizard.ConfigODataEndpointViewModel.EdmxVersion = version;
                 if (version == Constants.EdmxVersion4)
                 {
@@ -146,6 +147,21 @@ namespace Microsoft.OData.ConnectedService.Views
         private ODataConnectedServiceWizard GetODataConnectedServiceWizard()
         {
             return (ODataConnectedServiceWizard)((ConfigODataEndpointViewModel)this.DataContext).Wizard;
+        }
+
+        private ServiceConfiguration GetServiceConfiguration()
+        {
+            ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+            serviceConfiguration.Endpoint = this.UserSettings.Endpoint;
+            serviceConfiguration.CustomHttpHeaders = this.UserSettings.CustomHttpHeaders;
+            serviceConfiguration.WebProxyHost = this.UserSettings.WebProxyHost;
+            serviceConfiguration.IncludeWebProxy = this.UserSettings.IncludeWebProxy;
+            serviceConfiguration.IncludeWebProxyNetworkCredentials = this.UserSettings.IncludeWebProxyNetworkCredentials;
+            serviceConfiguration.WebProxyNetworkCredentialsUsername = this.UserSettings.WebProxyNetworkCredentialsUsername;
+            serviceConfiguration.WebProxyNetworkCredentialsPassword = this.UserSettings.WebProxyNetworkCredentialsPassword;
+            serviceConfiguration.WebProxyNetworkCredentialsDomain = this.UserSettings.WebProxyNetworkCredentialsDomain;
+
+            return serviceConfiguration;
         }
     }
 }

--- a/src/ODataConnectedService_VS2022Plus/source.extension.vsixmanifest
+++ b/src/ODataConnectedService_VS2022Plus/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ODataConnectedService2022plus.5b4f5787-7c18-4eb4-bf4a-5d2fcd66278a" Version="1.0.0" Language="en-US" Publisher="Company" />
+        <Identity Id="ODataConnectedService2022plus.5b4f5787-7c18-4eb4-bf4a-5d2fcd66278a" Version="1.0.0" Language="en-US" Publisher="Microsoft" />
         <DisplayName>OData Connected Service 2022+</DisplayName>
         <Description xml:space="preserve">OData Connected Service for V1-V4</Description>
         <MoreInfo>https://github.com/odata/ODataConnectedService</MoreInfo>

--- a/src/ODataConnectedService_VS2022Plus/source.extension.vsixmanifest
+++ b/src/ODataConnectedService_VS2022Plus/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ODataConnectedService2022plus.5b4f5787-7c18-4eb4-bf4a-5d2fcd66278a" Version="1.0.0" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="ODataConnectedService2022plus.5b4f5787-7c18-4eb4-bf4a-5d2fcd66278a" Version="1.0.0" Language="en-US" Publisher="marketplace" />
         <DisplayName>OData Connected Service 2022+</DisplayName>
         <Description xml:space="preserve">OData Connected Service for V1-V4</Description>
         <MoreInfo>https://github.com/odata/ODataConnectedService</MoreInfo>

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorUnitTest.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorUnitTest.cs
@@ -98,28 +98,28 @@ namespace ODataConnectedService.Tests
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldAddSlashAndMetadataSurfix()
+        public void GetMetadataDocumentUriShouldAddSlashAndMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldAddMetadataSurfix()
+        public void GetMetadataDocumentUriShouldAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldNotAddMetadataSurfix()
+        public void GetMetadataDocumentUriShouldNotAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/$metadata";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriWithSlashShouldNotAddMetadataSurfix()
+        public void GetMetadataDocumentUriWithSlashShouldNotAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/$metadata/";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
@@ -136,14 +136,14 @@ namespace ODataConnectedService.Tests
         public void GetMetadataDocumentUriWithLocalhostShouldContainPortNumber()
         {
             codeGenerator.MetadataDocumentUri = "http://localhost:8080/Aruba.svc/?query=0";
-            codeGenerator.MetadataDocumentUri.Should().Be("http://localhost:8080/Aruba.svc/$metadata");
+            codeGenerator.MetadataDocumentUri.Should().Be("http://localhost:8080/Aruba.svc/$metadata?query=0");
         }
         
         [TestMethod]
-        public void GetMetadataDocumentUriShouldNotAddMetadataSurfixForFilePath()
+        public void GetMetadataDocumentUriShouldNotAddMetadataSuffixForFilePath()
         {
-            codeGenerator.MetadataDocumentUri = "File://C://Odata//edmx";
-            codeGenerator.MetadataDocumentUri.Should().Be("File://C://Odata//edmx");
+            codeGenerator.MetadataDocumentUri = "file:///C://Odata//edmx";
+            codeGenerator.MetadataDocumentUri.Should().Be("file:///C://Odata//edmx");
         }
     }
 }

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -59,14 +59,14 @@ namespace ODataConnectedService.Tests.ViewModels
             _ = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
             //Check if the url is detected as valid and is unmodified
-            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment");
+            Assert.AreEqual("http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment", configOdataEndPointViewModel.ServiceConfiguration.Endpoint);
 
             //Provide a url without $metadata
             configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService?$schemaversion=2.0#fragment";
             pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
             //Check if $metadata is appended as the last segment if it was not the last segment of the url
-            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment");
+            Assert.AreEqual("http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment", configOdataEndPointViewModel.ServiceConfiguration.Endpoint);
 
             //Check if an exception is thrown for an invalid url and the user is notified
             pageNavigationResult = pageNavigationResultTask?.Result;

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -54,12 +54,19 @@ namespace ODataConnectedService.Tests.ViewModels
             Assert.IsFalse(pageNavigationResult.IsSuccess);
             Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
 
+            //Provide a url with "$metadata" as the last segment in the url
+            configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment";
+            _ = configOdataEndPointViewModel.OnPageLeavingAsync(null);
+
+            //Check if the url is detected as valid and is unmodified
+            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment");
+
             //Provide a url without $metadata
-            configOdataEndPointViewModel.UserSettings.Endpoint = "http://mysite/ODataService";
+            configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService?$schemaversion=2.0#fragment";
             pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
-            //Check if $metadata is apended if the url does not have it added at the end
-            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://mysite/ODataService/$metadata");
+            //Check if $metadata is apended as the last segment if it was not the last segment of the url
+            Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment");
 
             //Check if an exception is thrown for an invalid url and the user is notified
             pageNavigationResult = pageNavigationResultTask?.Result;

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -65,7 +65,7 @@ namespace ODataConnectedService.Tests.ViewModels
             configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService?$schemaversion=2.0#fragment";
             pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
-            //Check if $metadata is apended as the last segment if it was not the last segment of the url
+            //Check if $metadata is appended as the last segment if it was not the last segment of the url
             Assert.AreEqual(configOdataEndPointViewModel.UserSettings.Endpoint, "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment");
 
             //Check if an exception is thrown for an invalid url and the user is notified

--- a/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/ConfigOdataEndPointViewModelTests.cs
@@ -54,6 +54,13 @@ namespace ODataConnectedService.Tests.ViewModels
             Assert.IsFalse(pageNavigationResult.IsSuccess);
             Assert.IsTrue(pageNavigationResult.ShowMessageBoxOnFailure);
 
+            //Provide a url without $metadata
+            configOdataEndPointViewModel.UserSettings.Endpoint = "http://mysite/ODataService/$metadata";
+            pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
+
+            //Check if $metadata is appended as the last segment if it was not the last segment of the url
+            Assert.AreEqual("http://mysite/ODataService/$metadata", configOdataEndPointViewModel.ServiceConfiguration.Endpoint);
+
             //Provide a url with "$metadata" as the last segment in the url
             configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment";
             _ = configOdataEndPointViewModel.OnPageLeavingAsync(null);
@@ -61,12 +68,19 @@ namespace ODataConnectedService.Tests.ViewModels
             //Check if the url is detected as valid and is unmodified
             Assert.AreEqual("http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment", configOdataEndPointViewModel.ServiceConfiguration.Endpoint);
 
-            //Provide a url without $metadata
+            //Provide a url with query and fragment segments without $metadata
             configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService?$schemaversion=2.0#fragment";
             pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
 
             //Check if $metadata is appended as the last segment if it was not the last segment of the url
             Assert.AreEqual("http://user:password@mysite/ODataService/$metadata?$schemaversion=2.0#fragment", configOdataEndPointViewModel.ServiceConfiguration.Endpoint);
+
+            //Provide a url with a fragment segment without $metadata
+            configOdataEndPointViewModel.UserSettings.Endpoint = "http://user:password@mysite/ODataService#fragment";
+            pageNavigationResultTask = configOdataEndPointViewModel.OnPageLeavingAsync(null);
+
+            //Check if $metadata is appended as the last segment if it was not the last segment of the url
+            Assert.AreEqual("http://user:password@mysite/ODataService/$metadata#fragment", configOdataEndPointViewModel.ServiceConfiguration.Endpoint);
 
             //Check if an exception is thrown for an invalid url and the user is notified
             pageNavigationResult = pageNavigationResultTask?.Result;


### PR DESCRIPTION
This PR fixes the issue [Metadata URL with values in Query String · Issue #48 · OData/ODataConnectedService (github.com)](https://github.com/OData/ODataConnectedService/issues/48)
and is an add on to a contributor's (https://github.com/dr-consit) PR [Fix #48 by improving handling of Uris with/without "$metadata" suffix. by dr-consit · Pull Request #237 · OData/ODataConnectedService (github.com)](https://github.com/OData/ODataConnectedService/pull/237)

It ensures the OData Endpoint URI does not get distorted when the URI includes query and fragment segments. 
### Before fix 
A URI like 'http://localhost:5000/odata/$metadata?api-version=1.0' would have $metadata appended to the end of the URI which would make the OData service inaccessible.
### After fix
$metadata, query and fragment segments maintain the correct position and order.