### PR TITLE
Make ODataT4CodeGenerator public

### DIFF
--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -8,7 +8,7 @@
 //---------------------------------------------------------------------------------
 */
 #>
-<#@ template debug="true" hostSpecific="true" visibility="internal" linePragmas="false"#>
+<#@ template debug="true" hostSpecific="true" visibility="public" linePragmas="false"#>
 <#@ output extension=".cs" #>
 <#@ Assembly Name="System.Core.dll" #>
 <#@ Assembly Name="System.Runtime.dll" #>


### PR DESCRIPTION
Currently, if we run custom tool on the tt template, we get a diff that changes the `ODataT4CodeGenerator` modifier from `public` to `interna`l. This is because the `.cs` file was modified but the `tt` file wasn't. This PR fixes that issue.