### PR TITLE
Improve metadata uri handling

### DIFF
--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -173,7 +173,7 @@ namespace Microsoft.OData.Cli
                 }
 
                 ServiceConfiguration config = GetServiceConfiguration(options);
-                MetadataReader.GetMetadataVersion(config, out Version version);
+                MetadataReader.ProcessServiceMetadata(config, out Version version);
                 if (version == Constants.EdmxVersion4)
                 {
                     await GenerateCodeForV4Clients(options, console).ConfigureAwait(false);

--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -172,7 +172,8 @@ namespace Microsoft.OData.Cli
                     }
                 }
 
-                Version version = GetMetadataVersion(options);
+                ServiceConfiguration config = GetServiceConfiguration(options);
+                MetadataReader.GetMetadataVersion(config, out Version version);
                 if (version == Constants.EdmxVersion4)
                 {
                     await GenerateCodeForV4Clients(options, console).ConfigureAwait(false);
@@ -191,10 +192,9 @@ namespace Microsoft.OData.Cli
             return 0;
         }
 
-        private Version GetMetadataVersion(GenerateOptions generateOptions)
+        private ServiceConfiguration GetServiceConfiguration(GenerateOptions generateOptions)
         {
-            Version version = null;
-            var serviceConfiguration = new ServiceConfiguration();
+            ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
             serviceConfiguration.Endpoint = generateOptions.MetadataUri;
             serviceConfiguration.CustomHttpHeaders = generateOptions.CustomHeaders;
             serviceConfiguration.WebProxyHost = generateOptions.WebProxyHost;
@@ -204,8 +204,7 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
 
-            version = MetadataReader.GetMetadataVersion(serviceConfiguration);
-            return version;
+            return serviceConfiguration;
         }
 
         private async Task GenerateCodeForV4Clients(GenerateOptions generateOptions, IConsole console)

--- a/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
+++ b/src/Microsoft.OData.CodeGen/Common/MetadataReader.cs
@@ -7,7 +7,9 @@
 
 
 using System;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Xml;
 using Microsoft.OData.CodeGen.Models;
@@ -23,25 +25,27 @@ namespace Microsoft.OData.CodeGen.Common
         /// Reads the metadata version from the metadata url prvided.
         /// </summary>
         /// <param name="serviceConfiguration">The <see cref="ServiceConfiguration"/> of the metadata provided.</param>
-        /// <returns>The <see cref="Version"/> of the metadata</returns>
-        public static Version GetMetadataVersion(ServiceConfiguration serviceConfiguration)
+        /// <param name="edmxVersion">of the metadata</param>
+        /// <returns>The <see cref="String"/> of the metadata</returns>
+        public static string GetMetadataVersion(ServiceConfiguration serviceConfiguration, out Version edmxVersion)
         {
             if (string.IsNullOrEmpty(serviceConfiguration.Endpoint))
-                throw new ArgumentNullException("OData Service Endpoint", "Input the metadata document resource");
-
-            if (File.Exists(serviceConfiguration.Endpoint))
-                serviceConfiguration.Endpoint = new FileInfo(serviceConfiguration.Endpoint).FullName;
+            {
+                throw new ArgumentNullException("OData Service Endpoint", string.Format(CultureInfo.InvariantCulture, Constants.InputServiceEndpointMsg));
+            }
 
             if (serviceConfiguration.Endpoint.StartsWith("https:", StringComparison.Ordinal)
                 || serviceConfiguration.Endpoint.StartsWith("http", StringComparison.Ordinal))
             {
-                if (!serviceConfiguration.Endpoint.EndsWith("$metadata", StringComparison.Ordinal))
+                if (!Uri.TryCreate(serviceConfiguration.Endpoint, UriKind.Absolute, out var uri))
                 {
-                    serviceConfiguration.Endpoint = serviceConfiguration.Endpoint.TrimEnd('/') + "/$metadata";
+                    throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", serviceConfiguration.Endpoint));
                 }
-            }
 
-            
+                uri = CleanMetadataUri(uri);
+
+                serviceConfiguration.Endpoint = uri.AbsoluteUri;
+            }
 
             Stream metadataStream;
             Uri metadataUri = new Uri(serviceConfiguration.Endpoint);
@@ -49,6 +53,18 @@ namespace Microsoft.OData.CodeGen.Common
             if (!metadataUri.IsFile)
             {
                 var webRequest = (HttpWebRequest)WebRequest.Create(metadataUri);
+
+                if (serviceConfiguration.CustomHttpHeaders != null)
+                {
+                    var headerElements = serviceConfiguration.CustomHttpHeaders.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                    
+                    foreach (var headerElement in headerElements)
+                    {
+                        // Trim header for empty spaces
+                        var header = headerElement.Trim();
+                        webRequest.Headers.Add(header);
+                    }
+                }
 
                 if (serviceConfiguration.IncludeWebProxy)
                 {
@@ -79,32 +95,80 @@ namespace Microsoft.OData.CodeGen.Common
                 metadataStream = (Stream)xmlUrlResolver.GetEntity(metadataUri, null, typeof(Stream));
             }
 
+            var workFile = Path.GetTempFileName();
+
             try
             {
                 using (XmlReader reader = XmlReader.Create(metadataStream))
                 {
-                    while (reader.NodeType != XmlNodeType.Element)
+                    using (var writer = XmlWriter.Create(workFile))
                     {
-                        reader.Read();
-                    }
+                        while (reader.NodeType != XmlNodeType.Element)
+                        {
+                            reader.Read();
+                        }
 
-                    if (reader.EOF)
-                    {
-                        throw new InvalidOperationException("The metadata is an empty file");
-                    }
+                        if (reader.EOF)
+                        {
+                            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "The metadata is an empty file"));
+                        }
 
-                    Constants.SupportedEdmxNamespaces.TryGetValue(reader.NamespaceURI, out var edmxVersion);
-                    return edmxVersion;
+                        Constants.SupportedEdmxNamespaces.TryGetValue(reader.NamespaceURI, out edmxVersion);
+                        writer.WriteNode(reader, false);
+                    }
                 }
+
+                return workFile;
             }
             catch (WebException e)
             {
-                throw new InvalidOperationException(string.Format("The metadata cannot be accessed"), e);
+                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Cannot access {0}", serviceConfiguration.Endpoint), e);
+
             }
             finally
             { 
                 metadataStream?.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Ensures that the Uri conforms to the expected "$metadata" format
+        /// </summary>
+        /// <param name="uri">Uri to clean</param>
+        /// <returns>Cleaned uri</returns>
+        public static Uri CleanMetadataUri(this Uri uri)
+        {
+            if (uri.Scheme == "http" || uri.Scheme == "https")
+            {
+                UriBuilder uriBuilder;
+
+                /// Evaluates to true if Query and Fragment properties are present in the Uri 
+                bool preserveQueryAndFragment = true;
+
+                if (uri.Segments.Last().Equals("$metadata", StringComparison.InvariantCultureIgnoreCase) | uri.Segments.Last().Equals("$metadata/", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    preserveQueryAndFragment = !uri.AbsolutePath.EndsWith("/", StringComparison.Ordinal);
+                    Uri absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/')).Uri;
+                    uriBuilder = new UriBuilder(absolutePathUri);
+                }
+                else
+                {
+                    var absolutePathUri = new UriBuilder(uri.Scheme, uri.Host, uri.Port, uri.AbsolutePath.TrimEnd('/') + "/").Uri;
+                    uriBuilder = new UriBuilder(new Uri(absolutePathUri, "$metadata"));
+                }
+
+                if (preserveQueryAndFragment)
+                {
+                    uriBuilder.Query = uri.Query.TrimStart('?');
+                    uriBuilder.Fragment = uri.Fragment.TrimStart('#');
+                }
+
+                uriBuilder.UserName = uri.UserInfo;
+
+                return new Uri(uriBuilder.Uri.AbsoluteUri);
+            }
+
+            return new Uri(uri.AbsoluteUri);
         }
     }
 }

--- a/src/Microsoft.OData.CodeGen/Microsoft.OData.CodeGen.csproj
+++ b/src/Microsoft.OData.CodeGen/Microsoft.OData.CodeGen.csproj
@@ -53,7 +53,7 @@
     <Reference Include="Microsoft.Data.Services.Design">
       <HintPath>..\..\external\Binaries\V3\Microsoft.Data.Services.Design.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TextTemplating.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.TextTemplating.15.0, Version=16.0.28727, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -302,7 +302,7 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        value = uri.CleanMetadataUri().ToString();
+        value = uri.CleanMetadataUri().AbsoluteUri;
         this.metadataDocumentUri = value;
     }
 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -10,13 +10,16 @@
 namespace Microsoft.OData.CodeGen.Templates
 {
     using System;
-    using System.IO;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
+    using System.IO;
     using System.Linq;
+    using System.Net;
+    using System.Security;
+    using System.Text;
     using System.Xml;
     using System.Xml.Linq;
-    using System.Collections.Generic;
     using Microsoft.OData.Edm.Csdl;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Edm.Validation;
@@ -25,9 +28,7 @@ namespace Microsoft.OData.CodeGen.Templates
     using Microsoft.OData.Edm.Vocabularies.Community.V1;
     using Microsoft.OData.CodeGen.FileHandling;
     using Microsoft.OData.CodeGen.Logging;
-    using System.Text;
-    using System.Net;
-    using System.Security;
+    using Microsoft.OData.CodeGen.Common;
     
     /// <summary>
     /// Class to produce the template output
@@ -301,16 +302,7 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        if (uri.Scheme == "http" || uri.Scheme == "https")
-        {
-            value = uri.Scheme + "://" + uri.Authority + uri.AbsolutePath;
-            value = value.TrimEnd('/');
-            if (!value.EndsWith("$metadata"))
-            {
-                value += "/$metadata";
-            }
-        }
-
+        value = uri.CleanMetadataUri().ToString();
         this.metadataDocumentUri = value;
     }
 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -160,7 +160,7 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        value = uri.CleanMetadataUri().ToString();
+        value = uri.CleanMetadataUri().AbsoluteUri;
         this.metadataDocumentUri = value;
     }
 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -18,13 +18,16 @@
 <#@ Assembly Name="System.Windows.Forms.dll" #>
 <#@ Assembly Name="Microsoft.OData.Edm.dll" #>
 <#@ Import Namespace="System" #>
-<#@ Import Namespace="System.IO" #>
+<#@ Import Namespace="System.Collections.Generic" #>
 <#@ Import Namespace="System.Diagnostics" #>
 <#@ Import Namespace="System.Globalization" #>
+<#@ Import Namespace="System.IO" #>
 <#@ Import Namespace="System.Linq" #>
+<#@ Import Namespace="System.Net"#>
+<#@ Import Namespace="System.Security"#>
+<#@ Import Namespace="System.Text"#>
 <#@ Import Namespace="System.Xml"#>
 <#@ Import Namespace="System.Xml.Linq" #>
-<#@ Import Namespace="System.Collections.Generic" #>
 <#@ Import Namespace="Microsoft.OData.Edm.Csdl" #>
 <#@ Import Namespace="Microsoft.OData.Edm" #>
 <#@ Import Namespace="Microsoft.OData.Edm.Validation" #>
@@ -33,8 +36,7 @@
 <#@ Import Namespace="Microsoft.OData.Edm.Vocabularies.Community.V1" #>
 <#@ Import Namespace="Microsoft.OData.CodeGen.FileHandling" #>
 <#@ Import Namespace="Microsoft.OData.CodeGen.Logging" #>
-<#@ Import Namespace="System.Text"#>
-<#@ Import Namespace="System.Net"#>
+<#@ Import Namespace= "Microsoft.OData.CodeGen.Common"#>
 <#@include file="ODataT4CodeGenFilesManager.ttinclude"
 #><#
     CodeGenerationContext context;
@@ -158,16 +160,7 @@ public string MetadataDocumentUri
             throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "The value \"{0}\" is not a valid MetadataDocumentUri because is it not a valid absolute Uri. The MetadataDocumentUri must be set to an absolute Uri referencing the $metadata endpoint of an OData service.", value));
         }
 
-        if (uri.Scheme == "http" || uri.Scheme == "https")
-        {
-            value = uri.Scheme + "://" + uri.Authority + uri.AbsolutePath;
-            value = value.TrimEnd('/');
-            if (!value.EndsWith("$metadata"))
-            {
-                value += "/$metadata";
-            }
-        }
-
+        value = uri.CleanMetadataUri().ToString();
         this.metadataDocumentUri = value;
     }
 }

--- a/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
@@ -26,6 +26,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
 
         public UserSettings UserSettings { get; internal set; }
 
+        public ServiceConfiguration ServiceConfiguration { get; set; }
+
         public event EventHandler<EventArgs> PageEntering;
 
         public ConfigODataEndpointViewModel(UserSettings userSettings) : base()
@@ -48,8 +50,10 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         {
             try
             {
-                this.MetadataTempPath = GetMetadata(out var version);
+                ServiceConfiguration = GetServiceConfiguration();
+                this.MetadataTempPath = CodeGen.Common.MetadataReader.GetMetadataVersion(ServiceConfiguration, out var version);
                 // Makes sense to add MRU endpoint at this point since GetMetadata manipulates UserSettings.Endpoint
+                UserSettings.Endpoint = ServiceConfiguration.Endpoint;
                 UserSettings.AddMruEndpoint(UserSettings.Endpoint);
                 this.EdmxVersion = version;
                 PageLeaving?.Invoke(this, EventArgs.Empty);
@@ -67,107 +71,19 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             }
         }
 
-        internal string GetMetadata(out Version edmxVersion)
+        private ServiceConfiguration GetServiceConfiguration()
         {
-            if (string.IsNullOrEmpty(UserSettings.Endpoint))
-            {
-                throw new ArgumentNullException("OData Service Endpoint", string.Format(CultureInfo.InvariantCulture, Constants.InputServiceEndpointMsg));
-            }
+            ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+            serviceConfiguration.Endpoint = this.UserSettings.Endpoint;
+            serviceConfiguration.CustomHttpHeaders = this.UserSettings.CustomHttpHeaders;
+            serviceConfiguration.WebProxyHost = this.UserSettings.WebProxyHost;
+            serviceConfiguration.IncludeWebProxy = this.UserSettings.IncludeWebProxy;
+            serviceConfiguration.IncludeWebProxyNetworkCredentials = this.UserSettings.IncludeWebProxyNetworkCredentials;
+            serviceConfiguration.WebProxyNetworkCredentialsUsername = this.UserSettings.WebProxyNetworkCredentialsUsername;
+            serviceConfiguration.WebProxyNetworkCredentialsPassword = this.UserSettings.WebProxyNetworkCredentialsPassword;
+            serviceConfiguration.WebProxyNetworkCredentialsDomain = this.UserSettings.WebProxyNetworkCredentialsDomain;
 
-            if (UserSettings.Endpoint.StartsWith("https:", StringComparison.Ordinal)
-                || UserSettings.Endpoint.StartsWith("http", StringComparison.Ordinal))
-            {
-                if (!UserSettings.Endpoint.EndsWith("$metadata", StringComparison.Ordinal))
-                {
-                    UserSettings.Endpoint = UserSettings.Endpoint.TrimEnd('/') + "/$metadata";
-                }
-            }
-
-            Stream metadataStream;
-            var metadataUri = new Uri(UserSettings.Endpoint);
-            if (!metadataUri.IsFile)
-            {
-                var webRequest = (HttpWebRequest)WebRequest.Create(metadataUri);
-                if (!string.IsNullOrEmpty(UserSettings.CustomHttpHeaders))
-                {
-                    var headerElements = UserSettings.CustomHttpHeaders.Split(new [] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-                    foreach (var headerElement in headerElements)
-                    {
-                        // Trim header for empty spaces
-                        var header = headerElement.Trim();
-                        webRequest.Headers.Add(header);
-                    }
-                }
-
-                if (UserSettings.IncludeWebProxy)
-                {
-                    if (!string.IsNullOrEmpty(UserSettings.WebProxyHost))
-                    {
-                        var proxy = new WebProxy(UserSettings.WebProxyHost);
-                        if (UserSettings.IncludeWebProxyNetworkCredentials)
-                        {
-                            proxy.Credentials = new NetworkCredential(
-                                UserSettings.WebProxyNetworkCredentialsUsername,
-                                UserSettings.WebProxyNetworkCredentialsPassword,
-                                UserSettings.WebProxyNetworkCredentialsDomain);
-                        }
-
-                        webRequest.Proxy = proxy;
-                    }
-                    
-                }
-
-                WebResponse webResponse = webRequest.GetResponse();
-                metadataStream = webResponse.GetResponseStream();
-            }
-            else
-            {
-                // Set up XML secure resolver
-                var xmlUrlResolver = new XmlUrlResolver
-                {
-                    Credentials = CredentialCache.DefaultNetworkCredentials
-                };
-
-                metadataStream = (Stream)xmlUrlResolver.GetEntity(metadataUri, null, typeof(Stream));
-            }
-
-            var workFile = Path.GetTempFileName();
-
-            try
-            {
-                using (XmlReader reader = XmlReader.Create(metadataStream))
-                {
-                    using (var writer = XmlWriter.Create(workFile))
-                    {
-                        while (reader.NodeType != XmlNodeType.Element)
-                        {
-                            reader.Read();
-                        }
-
-                        if (reader.EOF)
-                        {
-                            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "The metadata is an empty file"));
-                        }
-
-                        Constants.SupportedEdmxNamespaces.TryGetValue(reader.NamespaceURI, out edmxVersion);
-                        writer.WriteNode(reader, false);
-                    }
-                }
-                return workFile;
-            }
-            catch (WebException e)
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, "Cannot access {0}", UserSettings.Endpoint), e);
-            }
-            finally
-            {
-                this.DisposeStream(metadataStream);
-            }
-        }
-
-        private void DisposeStream(Stream stream)
-        {
-            stream?.Dispose();
+            return serviceConfiguration;
         }
     }
 }

--- a/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
+++ b/src/ODataConnectedService.Shared/ViewModels/ConfigODataEndpointViewModel.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             try
             {
                 ServiceConfiguration = GetServiceConfiguration();
-                this.MetadataTempPath = CodeGen.Common.MetadataReader.GetMetadataVersion(ServiceConfiguration, out var version);
+                this.MetadataTempPath = CodeGen.Common.MetadataReader.ProcessServiceMetadata(ServiceConfiguration, out var version);
                 // Makes sense to add MRU endpoint at this point since GetMetadata manipulates UserSettings.Endpoint
                 UserSettings.Endpoint = ServiceConfiguration.Endpoint;
                 UserSettings.AddMruEndpoint(UserSettings.Endpoint);

--- a/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
@@ -120,7 +120,7 @@ namespace Microsoft.OData.ConnectedService.Views
             try
             {
                 var serviceConfiguration = GetServiceConfiguration();
-                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = CodeGen.Common.MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
+                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = CodeGen.Common.MetadataReader.ProcessServiceMetadata(serviceConfiguration, out var version);
                 connectedServiceWizard.ConfigODataEndpointViewModel.EdmxVersion = version;
                 if (version == Constants.EdmxVersion4)
                 {

--- a/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
@@ -119,7 +119,8 @@ namespace Microsoft.OData.ConnectedService.Views
             // get Operation Imports and bound operations from metadata for excluding ExcludedOperationImports and ExcludedBoundOperations
             try
             {
-                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = connectedServiceWizard.ConfigODataEndpointViewModel.GetMetadata(out var version);
+                var serviceConfiguration = GetServiceConfiguration();
+                connectedServiceWizard.ConfigODataEndpointViewModel.MetadataTempPath = CodeGen.Common.MetadataReader.GetMetadataVersion(serviceConfiguration, out var version);
                 connectedServiceWizard.ConfigODataEndpointViewModel.EdmxVersion = version;
                 if (version == Constants.EdmxVersion4)
                 {
@@ -146,6 +147,21 @@ namespace Microsoft.OData.ConnectedService.Views
         private ODataConnectedServiceWizard GetODataConnectedServiceWizard()
         {
             return (ODataConnectedServiceWizard)((ConfigODataEndpointViewModel)this.DataContext).Wizard;
+        }
+
+        private ServiceConfiguration GetServiceConfiguration()
+        {
+            ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+            serviceConfiguration.Endpoint = this.UserSettings.Endpoint;
+            serviceConfiguration.CustomHttpHeaders = this.UserSettings.CustomHttpHeaders;
+            serviceConfiguration.WebProxyHost = this.UserSettings.WebProxyHost;
+            serviceConfiguration.IncludeWebProxy = this.UserSettings.IncludeWebProxy;
+            serviceConfiguration.IncludeWebProxyNetworkCredentials = this.UserSettings.IncludeWebProxyNetworkCredentials;
+            serviceConfiguration.WebProxyNetworkCredentialsUsername = this.UserSettings.WebProxyNetworkCredentialsUsername;
+            serviceConfiguration.WebProxyNetworkCredentialsPassword = this.UserSettings.WebProxyNetworkCredentialsPassword;
+            serviceConfiguration.WebProxyNetworkCredentialsDomain = this.UserSettings.WebProxyNetworkCredentialsDomain;
+
+            return serviceConfiguration;
         }
     }
 }

--- a/src/ODataConnectedService_VS2022Plus/ODataConnectedService_VS2022Plus.csproj
+++ b/src/ODataConnectedService_VS2022Plus/ODataConnectedService_VS2022Plus.csproj
@@ -88,6 +88,13 @@
     <PackageReference Include="Microsoft.OData.Edm">
       <Version>7.6.3</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.2.32505.173" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ConnectedServices">
       <Version>16.2.45</Version>
     </PackageReference>

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorUnitTest.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorUnitTest.cs
@@ -98,28 +98,28 @@ namespace ODataConnectedService.Tests
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldAddSlashAndMetadataSurfix()
+        public void GetMetadataDocumentUriShouldAddSlashAndMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldAddMetadataSurfix()
+        public void GetMetadataDocumentUriShouldAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriShouldNotAddMetadataSurfix()
+        public void GetMetadataDocumentUriShouldNotAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/$metadata";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
         }
 
         [TestMethod]
-        public void GetMetadataDocumentUriWithSlashShouldNotAddMetadataSurfix()
+        public void GetMetadataDocumentUriWithSlashShouldNotAddMetadataSuffix()
         {
             codeGenerator.MetadataDocumentUri = "http://services.odata.org/Experimental/OData/OData.svc/$metadata/";
             codeGenerator.MetadataDocumentUri.Should().Be(MetadataUri);
@@ -136,14 +136,14 @@ namespace ODataConnectedService.Tests
         public void GetMetadataDocumentUriWithLocalhostShouldContainPortNumber()
         {
             codeGenerator.MetadataDocumentUri = "http://localhost:8080/Aruba.svc/?query=0";
-            codeGenerator.MetadataDocumentUri.Should().Be("http://localhost:8080/Aruba.svc/$metadata");
+            codeGenerator.MetadataDocumentUri.Should().Be("http://localhost:8080/Aruba.svc/$metadata?query=0");
         }
-        
+
         [TestMethod]
-        public void GetMetadataDocumentUriShouldNotAddMetadataSurfixForFilePath()
+        public void GetMetadataDocumentUriShouldNotAddMetadataSuffixForFilePath()
         {
-            codeGenerator.MetadataDocumentUri = "File://C://Odata//edmx";
-            codeGenerator.MetadataDocumentUri.Should().Be("File://C://Odata//edmx");
+            codeGenerator.MetadataDocumentUri = "file:///C://Odata//edmx";
+            codeGenerator.MetadataDocumentUri.Should().Be("file:///C://Odata//edmx");
         }
     }
 }


### PR DESCRIPTION
This PR fixes the issue https://github.com/OData/ODataConnectedService/issues/48
and is an add on to a contributor's (https://github.com/dr-consit) PR https://github.com/OData/ODataConnectedService/pull/237

It ensures the OData Endpoint URI does not get distorted when the URI includes query and fragment segments.

Before fix
A URI like 'http://localhost:5000/odata/$metadata?api-version=1.0' would have $metadata appended to the end of the URI which would make the OData service inaccessible.

After fix
$metadata, query and fragment segments maintain the correct position and order.