### PR TITLE
Implement "No tracking" option for odata-cli

### DIFF
--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // <copyright file="GenerateCommand.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
 //      See License.txt in the project root for license information.
@@ -68,6 +68,15 @@ namespace Microsoft.OData.Cli
             };
 
             this.AddOption(ns);
+
+            Option noTracking = new Option<bool>(new[] { "--no-tracking", "-n" })
+            {
+                Name = "notracking",
+                Description = "Disables entity and property tracking."
+            };
+            noTracking.SetDefaultValue(false);
+
+            this.AddOption(noTracking);
 
             Option upperCamelCase = new Option<bool>(new[] { "--upper-camel-case", "-ucc" })
             {
@@ -203,6 +212,7 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsUsername = generateOptions.WebProxyNetworkCredentialsUsername;
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
+            serviceConfiguration.UseDataServiceCollection = !generateOptions.NoTracking;
 
             return serviceConfiguration;
         }
@@ -228,6 +238,7 @@ namespace Microsoft.OData.Cli
             serviceConfigurationV4.ExcludedOperationImports = generateOptions.ExcludedOperationImports;
             serviceConfigurationV4.IgnoreUnexpectedElementsAndAttributes = generateOptions.IgnoreUnexpectedElements;
             serviceConfigurationV4.EnableNamingAlias = generateOptions.UpperCamelCase;
+            serviceConfigurationV4.UseDataServiceCollection = !generateOptions.NoTracking;
 
             Project project = ProjectHelper.CreateProjectInstance(generateOptions.OutputDir);
             BaseCodeGenDescriptor codeGenDescriptor = new CodeGenDescriptorFactory().Create(
@@ -253,6 +264,7 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
             serviceConfiguration.NamespacePrefix = generateOptions.NamespacePrefix;
+            serviceConfiguration.UseDataServiceCollection = !generateOptions.NoTracking;
 
             Project project = ProjectHelper.CreateProjectInstance(generateOptions.OutputDir);
             BaseCodeGenDescriptor codeGenDescriptor = new CodeGenDescriptorFactory().Create(

--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -1,6 +1,6 @@
-//-----------------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------------
 // <copyright file="GenerateCommand.cs" company=".NET Foundation">
-//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //----------------------------------------------------------------------------
@@ -69,14 +69,14 @@ namespace Microsoft.OData.Cli
 
             this.AddOption(ns);
 
-            Option noTracking = new Option<bool>(new[] { "--no-tracking", "-n" })
+            Option enableTracking = new Option<bool>(new[] { "--enable-tracking", "-et" })
             {
-                Name = "notracking",
-                Description = "Disables entity and property tracking."
+                Name = "enable-tracking",
+                Description = "Enable entity and property tracking."
             };
-            noTracking.SetDefaultValue(false);
+            enableTracking.SetDefaultValue(false);
 
-            this.AddOption(noTracking);
+            this.AddOption(enableTracking);
 
             Option upperCamelCase = new Option<bool>(new[] { "--upper-camel-case", "-ucc" })
             {
@@ -212,7 +212,7 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsUsername = generateOptions.WebProxyNetworkCredentialsUsername;
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
-            serviceConfiguration.UseDataServiceCollection = !generateOptions.NoTracking;
+            serviceConfiguration.UseDataServiceCollection = generateOptions.EnableTracking;
 
             return serviceConfiguration;
         }
@@ -238,7 +238,7 @@ namespace Microsoft.OData.Cli
             serviceConfigurationV4.ExcludedOperationImports = generateOptions.ExcludedOperationImports;
             serviceConfigurationV4.IgnoreUnexpectedElementsAndAttributes = generateOptions.IgnoreUnexpectedElements;
             serviceConfigurationV4.EnableNamingAlias = generateOptions.UpperCamelCase;
-            serviceConfigurationV4.UseDataServiceCollection = !generateOptions.NoTracking;
+            serviceConfigurationV4.UseDataServiceCollection = generateOptions.EnableTracking;
 
             Project project = ProjectHelper.CreateProjectInstance(generateOptions.OutputDir);
             BaseCodeGenDescriptor codeGenDescriptor = new CodeGenDescriptorFactory().Create(
@@ -264,7 +264,7 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
             serviceConfiguration.NamespacePrefix = generateOptions.NamespacePrefix;
-            serviceConfiguration.UseDataServiceCollection = !generateOptions.NoTracking;
+            serviceConfiguration.UseDataServiceCollection = generateOptions.EnableTracking;
 
             Project project = ProjectHelper.CreateProjectInstance(generateOptions.OutputDir);
             BaseCodeGenDescriptor codeGenDescriptor = new CodeGenDescriptorFactory().Create(

--- a/src/Microsoft.OData.Cli/GenerateOptions.cs
+++ b/src/Microsoft.OData.Cli/GenerateOptions.cs
@@ -41,6 +41,11 @@ namespace Microsoft.OData.Cli
         public string NamespacePrefix { get; set; }
 
         /// <summary>
+        /// Disables entity and property tracking
+        /// </summary>
+        public bool NoTracking { get; set; }
+
+        /// <summary>
         /// Disables/Enables upper camel casing
         /// </summary>
         public bool UpperCamelCase { get; set; }

--- a/src/Microsoft.OData.Cli/GenerateOptions.cs
+++ b/src/Microsoft.OData.Cli/GenerateOptions.cs
@@ -1,6 +1,6 @@
 ﻿//-----------------------------------------------------------------------------
 // <copyright file="GenerateOptions.cs" company=".NET Foundation">
-//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //----------------------------------------------------------------------------
@@ -30,12 +30,12 @@ namespace Microsoft.OData.Cli
         public string Proxy { get; set; }
 
         /// <summary>
-        /// The name of the generated file name 
+        /// The name of the generated file name
         /// </summary>
         public string FileName { get; set; }
 
         /// <summary>
-        /// The namespace of the client code generated. 
+        /// The namespace of the client code generated.
         /// Example: ODataCliCodeGeneratorSample.NorthWindModel or ODataCliCodeGeneratorSample or it could be a name related to the OData endpoint.
         /// </summary>
         public string NamespacePrefix { get; set; }
@@ -43,7 +43,7 @@ namespace Microsoft.OData.Cli
         /// <summary>
         /// Disables entity and property tracking
         /// </summary>
-        public bool NoTracking { get; set; }
+        public bool EnableTracking { get; set; }
 
         /// <summary>
         /// Disables/Enables upper camel casing
@@ -114,6 +114,5 @@ namespace Microsoft.OData.Cli
         /// A flag to indicate whether to include web proxy network credentials or not.
         /// </summary>
         public bool IncludeWebProxyNetworkCredentials { get; set; }
-
     }
 }


### PR DESCRIPTION
# Motivation

Fix #269 

# Modifications
- Add new option --no-tracking to control the UseDataServiceCollection property of the generator
- Default to false to be aligned with the naming of this option, so it is a breaking change