### PR TITLE
Add --use-data-service-collection (-dsc) option

### DIFF
--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -69,6 +69,14 @@ namespace Microsoft.OData.Cli
 
             this.AddOption(ns);
 
+            Option useDataServiceCollection = new Option<bool>(new[] { "--use-data-service-collection", "-dsc" })
+            {
+                Name = "use-data-service-collection",
+                Description = "Allows the DataServiceContext to keep track of changes made to entities on the client side. This option generates events that are triggered when properties of the entities change. Aligns with the \"Enable Entity and Property Tracking\" advanced option in the VS Extension."
+            };
+
+            this.AddOption(useDataServiceCollection);
+
             Option upperCamelCase = new Option<bool>(new[] { "--upper-camel-case", "-ucc" })
             {
                 Name = "upper-camel-case",
@@ -228,6 +236,7 @@ namespace Microsoft.OData.Cli
             serviceConfigurationV4.ExcludedOperationImports = generateOptions.ExcludedOperationImports;
             serviceConfigurationV4.IgnoreUnexpectedElementsAndAttributes = generateOptions.IgnoreUnexpectedElements;
             serviceConfigurationV4.EnableNamingAlias = generateOptions.UpperCamelCase;
+            serviceConfigurationV4.UseDataServiceCollection = generateOptions.UseDataServiceCollection;
 
             Project project = ProjectHelper.CreateProjectInstance(generateOptions.OutputDir);
             BaseCodeGenDescriptor codeGenDescriptor = new CodeGenDescriptorFactory().Create(
@@ -253,6 +262,7 @@ namespace Microsoft.OData.Cli
             serviceConfiguration.WebProxyNetworkCredentialsPassword = generateOptions.WebProxyNetworkCredentialsPassword;
             serviceConfiguration.WebProxyNetworkCredentialsDomain = generateOptions.WebProxyNetworkCredentialsDomain;
             serviceConfiguration.NamespacePrefix = generateOptions.NamespacePrefix;
+            serviceConfiguration.UseDataServiceCollection= generateOptions.UseDataServiceCollection;
 
             Project project = ProjectHelper.CreateProjectInstance(generateOptions.OutputDir);
             BaseCodeGenDescriptor codeGenDescriptor = new CodeGenDescriptorFactory().Create(

--- a/src/Microsoft.OData.Cli/GenerateOptions.cs
+++ b/src/Microsoft.OData.Cli/GenerateOptions.cs
@@ -41,6 +41,12 @@ namespace Microsoft.OData.Cli
         public string NamespacePrefix { get; set; }
 
         /// <summary>
+        /// Allows the DataServiceContext to keep track of changes made to entities on the client side. This option generates events that are triggered when properties of the entities change.
+        /// Aligns with "Enable Entity and Property Tracking" advanced option in the VS Extension
+        /// </summary>
+        public bool UseDataServiceCollection { get; set; }
+
+        /// <summary>
         /// Disables/Enables upper camel casing
         /// </summary>
         public bool UpperCamelCase { get; set; }


### PR DESCRIPTION
Add --use-data-service-collection (-dsc) option which aligns with the "Enable Entity and Property Tracking" advanced option in the VS Extension.  Related to issue #269 but I implemented this as a new option --use-data-service-collection instead of --no-tracking, so that it is not a change in the defaults for existing odata-cli users.  Users that would like to opt in to this functionality can use the new parameter.