### PR TITLE
Add no timestamp option (issue #349)

### DIFF
--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -98,7 +98,7 @@ namespace Microsoft.OData.Cli
             Option noTimestamp = new Option<bool>(new[] { "--no-timestamp", "-nt" })
             {
                 Name = "no-timestamp",
-                Description = "Removes the Generation date timestamp in generated files.",
+                Description = "Omit generation timestamp in generated files.",
             };
             noTimestamp.SetDefaultValue(false);
             this.AddOption(noTimestamp);

--- a/src/Microsoft.OData.Cli/GenerateCommand.cs
+++ b/src/Microsoft.OData.Cli/GenerateCommand.cs
@@ -95,6 +95,14 @@ namespace Microsoft.OData.Cli
 
             this.AddOption(internalModifier);
 
+            Option noTimestamp = new Option<bool>(new[] { "--no-timestamp", "-nt" })
+            {
+                Name = "no-timestamp",
+                Description = "Removes the Generation date timestamp in generated files.",
+            };
+            noTimestamp.SetDefaultValue(false);
+            this.AddOption(noTimestamp);
+
             Option multipleFiles = new Option<bool>(new[] { "--multiple-files" })
             {
                 Name = "multiple-files",
@@ -240,6 +248,7 @@ namespace Microsoft.OData.Cli
             serviceConfigurationV4.IgnoreUnexpectedElementsAndAttributes = generateOptions.IgnoreUnexpectedElements;
             serviceConfigurationV4.EnableNamingAlias = generateOptions.UpperCamelCase;
             serviceConfigurationV4.UseDataServiceCollection = generateOptions.EnableTracking;
+            serviceConfigurationV4.NoTimestamp = generateOptions.NoTimestamp;
 
             Project project = ProjectHelper.CreateProjectInstance(generateOptions.OutputDir);
             BaseCodeGenDescriptor codeGenDescriptor = new CodeGenDescriptorFactory().Create(

--- a/src/Microsoft.OData.Cli/GenerateOptions.cs
+++ b/src/Microsoft.OData.Cli/GenerateOptions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OData.Cli
         public bool EnableTracking { get; set; }
 
         /// <summary>
-        /// Do not insert the Generation date timestamp in generated files
+        /// Omit generation timestamp in generated files.
         /// </summary>
         public bool NoTimestamp { get; set; }
 

--- a/src/Microsoft.OData.Cli/GenerateOptions.cs
+++ b/src/Microsoft.OData.Cli/GenerateOptions.cs
@@ -44,6 +44,11 @@ namespace Microsoft.OData.Cli
         public bool EnableTracking { get; set; }
 
         /// <summary>
+        /// Do not insert the Generation date timestamp in generated files
+        /// </summary>
+        public bool NoTimestamp { get; set; }
+
+        /// <summary>
         /// Disables/Enables upper camel casing
         /// </summary>
         public bool UpperCamelCase { get; set; }

--- a/src/Microsoft.OData.CodeGen/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/Microsoft.OData.CodeGen/CodeGeneration/V4CodeGenDescriptor.cs
@@ -28,7 +28,6 @@ namespace Microsoft.OData.CodeGen.CodeGeneration
         {
             ClientNuGetPackageName = Common.Constants.V4ClientNuGetPackage;
             ClientDocUri = Common.Constants.V4DocUri;
-            //  ServiceConfiguration = base.ServiceConfiguration as ServiceConfigurationV4;
             CodeGeneratorFactory = codeGeneratorFactory;
         }
 

--- a/src/Microsoft.OData.CodeGen/CodeGeneration/V4CodeGenDescriptor.cs
+++ b/src/Microsoft.OData.CodeGen/CodeGeneration/V4CodeGenDescriptor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OData.CodeGen.CodeGeneration
         {
             ClientNuGetPackageName = Common.Constants.V4ClientNuGetPackage;
             ClientDocUri = Common.Constants.V4DocUri;
-          //  ServiceConfiguration = base.ServiceConfiguration as ServiceConfigurationV4;
+            //  ServiceConfiguration = base.ServiceConfiguration as ServiceConfigurationV4;
             CodeGeneratorFactory = codeGeneratorFactory;
         }
 
@@ -95,7 +95,7 @@ namespace Microsoft.OData.CodeGen.CodeGeneration
                 await writer.WriteLineAsync("</edmx:Edmx>");
             }
 
-            await FileHandler.AddFileAsync(csdlTempFile, metadataFile, new ODataFileOptions { SuppressOverwritePrompt = true});
+            await FileHandler.AddFileAsync(csdlTempFile, metadataFile, new ODataFileOptions { SuppressOverwritePrompt = true });
 
             FileHandler.SetFileAsEmbeddedResource(csdlFileName);
 
@@ -162,12 +162,13 @@ namespace Microsoft.OData.CodeGen.CodeGeneration
             t4CodeGenerator.EnableNamingAlias = serviceConfiguration.EnableNamingAlias;
             t4CodeGenerator.NamespacePrefix = serviceConfiguration.NamespacePrefix;
             t4CodeGenerator.MakeTypesInternal = serviceConfiguration.MakeTypesInternal;
+            t4CodeGenerator.NoTimestamp = serviceConfiguration.NoTimestamp;
             t4CodeGenerator.GenerateMultipleFiles = serviceConfiguration.GenerateMultipleFiles;
             t4CodeGenerator.ExcludedOperationImports = serviceConfiguration.ExcludedOperationImports;
             t4CodeGenerator.ExcludedBoundOperations = serviceConfiguration.ExcludedBoundOperations;
             t4CodeGenerator.ExcludedSchemaTypes = serviceConfiguration.ExcludedSchemaTypes;
             var headers = new List<string>();
-            if (serviceConfiguration.CustomHttpHeaders !=null)
+            if (serviceConfiguration.CustomHttpHeaders != null)
             {
                 var headerElements = serviceConfiguration.CustomHttpHeaders.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var headerElement in headerElements)
@@ -191,7 +192,7 @@ namespace Microsoft.OData.CodeGen.CodeGeneration
             // Csdl file name is this format [ServiceName]Csdl.xml
             var csdlFileName = string.Concat(serviceConfiguration.ServiceName, Common.Constants.CsdlFileNameSuffix);
             var metadataFile = Path.Combine(referenceFolder, csdlFileName);
-            await FileHandler.AddFileAsync(tempFile, metadataFile, new ODataFileOptions { SuppressOverwritePrompt = true});
+            await FileHandler.AddFileAsync(tempFile, metadataFile, new ODataFileOptions { SuppressOverwritePrompt = true });
 
             FileHandler.SetFileAsEmbeddedResource(csdlFileName);
             t4CodeGenerator.EmitContainerPropertyAttribute = FileHandler.EmitContainerPropertyAttribute();
@@ -213,7 +214,7 @@ namespace Microsoft.OData.CodeGen.CodeGeneration
             }
 
             var outputFile = Path.Combine(referenceFolder, $"{this.GeneratedFileNamePrefix(serviceConfiguration.GeneratedFileNamePrefix)}{(languageOption == LanguageOption.GenerateCSharpCode ? ".cs" : ".vb")}");
-            await FileHandler.AddFileAsync(tempFile, outputFile, new ODataFileOptions { SuppressOverwritePrompt = true});
+            await FileHandler.AddFileAsync(tempFile, outputFile, new ODataFileOptions { SuppressOverwritePrompt = true });
             t4CodeGenerator.MultipleFilesManager?.GenerateFiles(serviceConfiguration.GenerateMultipleFiles, FileHandler, MessageLogger, referenceFolder, true, serviceConfiguration.OpenGeneratedFilesInIDE);
             await MessageLogger.WriteMessageAsync(LogMessageCategory.Information, "Client Proxy for OData V4 was generated.");
         }

--- a/src/Microsoft.OData.CodeGen/Microsoft.OData.CodeGen.csproj
+++ b/src/Microsoft.OData.CodeGen/Microsoft.OData.CodeGen.csproj
@@ -83,7 +83,6 @@
     <Compile Include="FileHandling\ODataFileOptions.cs" />
     <Compile Include="Logging\IMessageLogger.cs" />
     <Compile Include="Logging\LogMessageCategory.cs" />
-    <Compile Include="Logging\LogMessageCategory.cs" />
     <Compile Include="PackageInstallation\IPackageInstaller.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Models\BoundOperationModel.cs" />

--- a/src/Microsoft.OData.CodeGen/Models/ServiceConfiguration.cs
+++ b/src/Microsoft.OData.CodeGen/Models/ServiceConfiguration.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.CodeGen.Models
         public string WebProxyNetworkCredentialsDomain { get; set; }
         public bool IncludeCustomHeaders { get; set; }
         public bool StoreCustomHttpHeaders { get; set; }
-        public List<string> ExcludedSchemaTypes { get; set; }        
+        public List<string> ExcludedSchemaTypes { get; set; }
 
     }
 
@@ -43,5 +43,6 @@ namespace Microsoft.OData.CodeGen.Models
         public bool IncludeT4File { get; set; }
         public List<string> ExcludedOperationImports { get; set; }
         public List<string> ExcludedBoundOperations { get; set; }
+        public bool NoTimestamp { get; set; }
     }
 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -4181,7 +4181,6 @@ this.Write("\r\n//\r\n//     Changes to this file may cause incorrect behavior a
         "f\r\n//     the code is regenerated.\r\n// </auto-generated>\r\n//--------------------" +
         "----------------------------------------------------------\r\n\r\n");
 
-
     if (!this.context.NoTimestamp)
     {
 

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -397,7 +397,7 @@ public bool MakeTypesInternal
 }
 
 /// <summary>
-/// true to disable the Generation date timestamp, false to include the timestamp
+/// true to omit generation timestamp; otherwise false.
 /// </summary>
 public bool NoTimestamp
 {

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -73,6 +73,7 @@ namespace Microsoft.OData.CodeGen.Templates
             MetadataFileRelativePath = this.MetadataFileRelativePath,
             MakeTypesInternal = this.MakeTypesInternal,
             MultipleFilesManager = new FilesManager(null),
+            NoTimestamp = this.NoTimestamp,
             GenerateMultipleFiles = this.GenerateMultipleFiles,
             ExcludedOperationImports = this.ExcludedOperationImports,
             ExcludedBoundOperations = this.ExcludedBoundOperations,
@@ -113,6 +114,7 @@ namespace Microsoft.OData.CodeGen.Templates
             MetadataFileRelativePath = this.MetadataFileRelativePath,
             MakeTypesInternal = this.MakeTypesInternal,
             MultipleFilesManager = new FilesManager(null),
+            NoTimestamp = this.NoTimestamp,
             GenerateMultipleFiles = this.GenerateMultipleFiles,
             ExcludedOperationImports = this.ExcludedOperationImports,
             ExcludedBoundOperations = this.ExcludedBoundOperations,
@@ -203,6 +205,9 @@ public static class Configuration
 	// If set to true, generated types will have an "internal" class modifier ("Friend" in VB) instead of "public"
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = false;
+
+	// If set to true, Generation date timestamps will be left out of generated files
+	public const bool NoTimestamp = false;
 
 	//This files indicates whether to generate the files into multiple files or single.
     //If set to true then multiple files will be generated. Otherwise only a single file is generated.
@@ -386,6 +391,15 @@ public bool IgnoreUnexpectedElementsAndAttributes
 /// otherwise "public" is used
 /// </summary>
 public bool MakeTypesInternal
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// true to disable the Generation date timestamp, false to include the timestamp
+/// </summary>
+public bool NoTimestamp
 {
     get;
     set;
@@ -735,6 +749,7 @@ private void ApplyParametersFromConfigurationClass()
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
     this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
     this.MakeTypesInternal = Configuration.MakeTypesInternal;
+    this.NoTimestamp = Configuration.NoTimestamp;
     this.MetadataFilePath = Configuration.MetadataFilePath;
     this.MetadataFileRelativePath = Configuration.MetadataFileRelativePath;
     this.GenerateMultipleFiles = Configuration.GenerateMultipleFiles;
@@ -1183,6 +1198,15 @@ public class CodeGenerationContext
 	/// This is useful if you don't want the generated classes to be visible outside the assembly
 	/// </summary>
     public bool MakeTypesInternal
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// true to disable the Generation date timestamp, false to include the timestamp
+    /// </summary>
+    public bool NoTimestamp
     {
         get;
         set;
@@ -4155,12 +4179,20 @@ this.Write(this.ToStringHelper.ToStringWithCulture(Environment.Version));
 
 this.Write("\r\n//\r\n//     Changes to this file may cause incorrect behavior and will be lost i" +
         "f\r\n//     the code is regenerated.\r\n// </auto-generated>\r\n//--------------------" +
-        "----------------------------------------------------------\r\n\r\n// Generation date" +
-        ": ");
+        "----------------------------------------------------------\r\n\r\n");
+
+
+    if (!this.context.NoTimestamp)
+    {
+
+this.Write("// Generation date: ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(DateTime.Now.ToString(global::System.Globalization.CultureInfo.CurrentCulture)));
 
 this.Write("\r\n");
+
+
+    }
 
 
     }
@@ -6296,13 +6328,20 @@ this.Write(@"
 
 Option Strict Off
 Option Explicit On
+");
 
 
-'Generation date: ");
+    if (!this.context.NoTimestamp)
+    {
+
+this.Write("\'Generation date: ");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(DateTime.Now.ToString(System.Globalization.CultureInfo.CurrentCulture)));
 
 this.Write("\r\n");
+
+
+    }
 
 
     }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -4181,6 +4181,7 @@ this.Write("\r\n//\r\n//     Changes to this file may cause incorrect behavior a
         "f\r\n//     the code is regenerated.\r\n// </auto-generated>\r\n//--------------------" +
         "----------------------------------------------------------\r\n\r\n");
 
+
     if (!this.context.NoTimestamp)
     {
 
@@ -4192,8 +4193,6 @@ this.Write("\r\n");
 
 
     }
-
-
     }
 
     internal override void WriteNamespaceStart(string fullNamespace)
@@ -6341,8 +6340,6 @@ this.Write("\r\n");
 
 
     }
-
-
     }
 
     internal override void WriteNamespaceStart(string fullNamespace)

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -206,7 +206,7 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = false;
 
-	// If set to true, Generation date timestamps will be left out of generated files
+	// If set to true, generation timestamps will be left out of generated files
 	public const bool NoTimestamp = false;
 
 	//This files indicates whether to generate the files into multiple files or single.

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -1204,7 +1204,7 @@ public class CodeGenerationContext
     }
 
     /// <summary>
-    /// true to disable the Generation date timestamp, false to include the timestamp
+    /// true to omit generation timestamp; otherwise false.
     /// </summary>
     public bool NoTimestamp
     {

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.tt
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.tt
@@ -36,7 +36,7 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = false;
 
-	// If set to true, Generation date timestamps will be left out of generated files
+	// If set to true, generation timestamps will be left out of generated files
 	public const bool NoTimestamp = false;
 
 	//This files indicates whether to generate the files into multiple files or single.

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.tt
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.tt
@@ -36,6 +36,9 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = false;
 
+	// If set to true, Generation date timestamps will be left out of generated files
+	public const bool NoTimestamp = false;
+
 	//This files indicates whether to generate the files into multiple files or single.
     //If set to true then multiple files will be generated. Otherwise only a single file is generated.
     public const bool GenerateMultipleFiles = false;

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -4042,8 +4042,6 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
 // Generation date: <#= DateTime.Now.ToString(global::System.Globalization.CultureInfo.CurrentCulture) #>
 <#+
     }
-#>
-<#+
     }
 
     internal override void WriteNamespaceStart(string fullNamespace)
@@ -5246,8 +5244,6 @@ Option Explicit On
 'Generation date: <#= DateTime.Now.ToString(System.Globalization.CultureInfo.CurrentCulture) #>
 <#+
     }
-#>
-<#+
     }
 
     internal override void WriteNamespaceStart(string fullNamespace)

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -52,6 +52,7 @@
             MetadataFileRelativePath = this.MetadataFileRelativePath,
             MakeTypesInternal = this.MakeTypesInternal,
             MultipleFilesManager = new FilesManager(null),
+            NoTimestamp = this.NoTimestamp,
             GenerateMultipleFiles = this.GenerateMultipleFiles,
             ExcludedOperationImports = this.ExcludedOperationImports,
             ExcludedBoundOperations = this.ExcludedBoundOperations,
@@ -92,6 +93,7 @@
             MetadataFileRelativePath = this.MetadataFileRelativePath,
             MakeTypesInternal = this.MakeTypesInternal,
             MultipleFilesManager = new FilesManager(null),
+            NoTimestamp = this.NoTimestamp,
             GenerateMultipleFiles = this.GenerateMultipleFiles,
             ExcludedOperationImports = this.ExcludedOperationImports,
             ExcludedBoundOperations = this.ExcludedBoundOperations,
@@ -244,6 +246,15 @@ public bool IgnoreUnexpectedElementsAndAttributes
 /// otherwise "public" is used
 /// </summary>
 public bool MakeTypesInternal
+{
+    get;
+    set;
+}
+
+/// <summary>
+/// true to disable the Generation date timestamp, false to include the timestamp
+/// </summary>
+public bool NoTimestamp
 {
     get;
     set;
@@ -593,6 +604,7 @@ private void ApplyParametersFromConfigurationClass()
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
     this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
     this.MakeTypesInternal = Configuration.MakeTypesInternal;
+    this.NoTimestamp = Configuration.NoTimestamp;
     this.MetadataFilePath = Configuration.MetadataFilePath;
     this.MetadataFileRelativePath = Configuration.MetadataFileRelativePath;
     this.GenerateMultipleFiles = Configuration.GenerateMultipleFiles;
@@ -1041,6 +1053,15 @@ public class CodeGenerationContext
 	/// This is useful if you don't want the generated classes to be visible outside the assembly
 	/// </summary>
     public bool MakeTypesInternal
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// true to disable the Generation date timestamp, false to include the timestamp
+    /// </summary>
+    public bool NoTimestamp
     {
         get;
         set;
@@ -4014,7 +4035,14 @@ public sealed class ODataClientCSharpTemplate : ODataClientTemplate
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+<#+
+    if (!this.context.NoTimestamp)
+    {
+#>
 // Generation date: <#= DateTime.Now.ToString(global::System.Globalization.CultureInfo.CurrentCulture) #>
+<#+
+    }
+#>
 <#+
     }
 
@@ -5211,9 +5239,14 @@ public sealed class ODataClientVBTemplate : ODataClientTemplate
 
 Option Strict Off
 Option Explicit On
-
-
+<#+
+    if (!this.context.NoTimestamp)
+    {
+#>
 'Generation date: <#= DateTime.Now.ToString(System.Globalization.CultureInfo.CurrentCulture) #>
+<#+
+    }
+#>
 <#+
     }
 

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -252,7 +252,7 @@ public bool MakeTypesInternal
 }
 
 /// <summary>
-/// true to disable the Generation date timestamp, false to include the timestamp
+/// true to omit generation timestamp; otherwise false.
 /// </summary>
 public bool NoTimestamp
 {
@@ -1059,7 +1059,7 @@ public class CodeGenerationContext
     }
 
     /// <summary>
-    /// true to disable the Generation date timestamp, false to include the timestamp
+    /// true to omit generation timestamp; otherwise false.
     /// </summary>
     public bool NoTimestamp
     {

--- a/src/ODataConnectedService.Shared/Models/UserSettings.cs
+++ b/src/ODataConnectedService.Shared/Models/UserSettings.cs
@@ -65,6 +65,8 @@ namespace Microsoft.OData.CodeGen.Models
 
         private bool ignoreUnexpectedElementsAndAttributes;
 
+        private bool noTimestamp;
+
         private bool includeT4File;
 
         private bool includeWebProxy;
@@ -232,6 +234,17 @@ namespace Microsoft.OData.CodeGen.Models
             set
             {
                 ignoreUnexpectedElementsAndAttributes = value;
+                OnPropertyChanged();
+            }
+        }
+
+        [DataMember]
+        public bool NoTimestamp
+        {
+            get { return noTimestamp; }
+            set
+            {
+                noTimestamp = value;
                 OnPropertyChanged();
             }
         }

--- a/src/ODataConnectedService.Shared/ODataConnectedServiceWizard.cs
+++ b/src/ODataConnectedService.Shared/ODataConnectedServiceWizard.cs
@@ -11,12 +11,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.OData.CodeGen.Common;
 using Microsoft.OData.CodeGen.Models;
-using Microsoft.OData.CodeGen;
+using Microsoft.OData.ConnectedService.Common;
 using Microsoft.OData.ConnectedService.ViewModels;
 using Microsoft.OData.ConnectedService.Views;
 using Microsoft.OData.Edm;
 using Microsoft.VisualStudio.ConnectedServices;
-using Microsoft.OData.ConnectedService.Common;
 
 namespace Microsoft.OData.ConnectedService
 {
@@ -187,6 +186,7 @@ namespace Microsoft.OData.ConnectedService
 
                     if (ServiceConfig.EdmxVersion == Constants.EdmxVersion4)
                     {
+                        advancedSettings.NoTimestamp.IsEnabled = !Context.IsUpdating;
                         advancedSettings.IncludeT4File.IsEnabled = !Context.IsUpdating;
                     }
                 }

--- a/src/ODataConnectedService.Shared/Views/AdvancedSettings.xaml
+++ b/src/ODataConnectedService.Shared/Views/AdvancedSettings.xaml
@@ -52,7 +52,7 @@
                 </CheckBox>
                 <CheckBox x:Name="NoTimestamp" IsChecked="{Binding Path=UserSettings.NoTimestamp, Mode=TwoWay}"
 					HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5">
-                    <TextBlock TextWrapping="Wrap" Margin="0, 0, 40, 0">Disable the generation timestamp in generated files (Enable this if you don't need generation timestamps in generated files.)</TextBlock>
+                    <TextBlock TextWrapping="Wrap" Margin="0, 0, 40, 0">Omit generation timestamp in generated files (Enable this if you don't need generation timestamps in generated files.)</TextBlock>
                 </CheckBox>
                 <CheckBox x:Name="IncludeT4File" Content="Add code templates (Whether to include the T4 files into this project.)" IsChecked="{Binding Path=UserSettings.IncludeT4File, Mode=TwoWay}"
             		HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 15" FontWeight="Medium"/>

--- a/src/ODataConnectedService.Shared/Views/AdvancedSettings.xaml
+++ b/src/ODataConnectedService.Shared/Views/AdvancedSettings.xaml
@@ -50,6 +50,10 @@
                     HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5">
                     <TextBlock TextWrapping="Wrap" Margin="0, 0, 40, 0">Make generated types internal (Enable this if you don't want to expose the generated types outside of your assembly.)</TextBlock>
                 </CheckBox>
+                <CheckBox x:Name="NoTimestamp" IsChecked="{Binding Path=UserSettings.NoTimestamp, Mode=TwoWay}"
+					HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 5">
+                    <TextBlock TextWrapping="Wrap" Margin="0, 0, 40, 0">Disable the generation timestamp in generated files (Enable this if you don't need generation timestamps in generated files.)</TextBlock>
+                </CheckBox>
                 <CheckBox x:Name="IncludeT4File" Content="Add code templates (Whether to include the T4 files into this project.)" IsChecked="{Binding Path=UserSettings.IncludeT4File, Mode=TwoWay}"
             		HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0, 15" FontWeight="Medium"/>
                 <CheckBox x:Name="OpenGeneratedFilesInIDE" Content="Open generated files in the IDE when generation completes." IsChecked="{Binding Path=UserSettings.OpenGeneratedFilesInIDE, Mode=TwoWay}"

--- a/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
@@ -77,6 +77,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
                         UseNamespacePrefix = true,
                         NamespacePrefix = "Namespace",
                         MakeTypesInternal = true,
+                        NoTimestamp = true,
                         GeneratedFileNamePrefix = "GeneratedCode",
                         GenerateMultipleFiles = true,
                         OpenGeneratedFilesInIDE = true,
@@ -104,6 +105,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
                         UseNamespacePrefix = false,
                         NamespacePrefix = "Namespace",
                         MakeTypesInternal = false,
+                        NoTimestamp = false,
                         GeneratedFileNamePrefix = "Reference",
                         GenerateMultipleFiles = false,
                         OpenGeneratedFilesInIDE = false,
@@ -137,6 +139,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             Assert.AreEqual(serviceConfig.EnableNamingAlias, generator.EnableNamingAlias);
             Assert.AreEqual(serviceConfig.IgnoreUnexpectedElementsAndAttributes, generator.IgnoreUnexpectedElementsAndAttributes);
             Assert.AreEqual(serviceConfig.MakeTypesInternal, generator.MakeTypesInternal);
+            Assert.AreEqual(serviceConfig.NoTimestamp, generator.NoTimestamp);
             Assert.AreEqual(serviceConfig.NamespacePrefix, generator.NamespacePrefix);
             Assert.AreEqual(serviceConfig.ExcludedOperationImports, generator.ExcludedOperationImports);
             Assert.AreEqual(serviceConfig.ExcludedSchemaTypes, generator.ExcludedSchemaTypes);
@@ -328,7 +331,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             {
                 languageOption = ODataT4CodeGenerator.LanguageOption.CSharp;
             }
-            else 
+            else
             {
                 languageOption = ODataT4CodeGenerator.LanguageOption.VB;
             }
@@ -877,7 +880,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
         }
     }
 
-    class TestV3CodeGenDescriptor: V3CodeGenDescriptor
+    class TestV3CodeGenDescriptor : V3CodeGenDescriptor
     {
         public TestV3CodeGenDescriptor(IFileHandler fileHandler, IMessageLogger messageLogger, IPackageInstaller packageInstaller) : base(fileHandler, messageLogger, packageInstaller)
         {

--- a/test/ODataConnectedService.Tests/CodeGeneration/TestConfigAllOptionsSet.txt
+++ b/test/ODataConnectedService.Tests/CodeGeneration/TestConfigAllOptionsSet.txt
@@ -36,6 +36,9 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = true;
 
+	// If set to true, Generation date timestamps will be left out of generated files
+	public const bool NoTimestamp = true;
+
 	//This files indicates whether to generate the files into multiple files or single.
     //If set to true then multiple files will be generated. Otherwise only a single file is generated.
     public const bool GenerateMultipleFiles = true;

--- a/test/ODataConnectedService.Tests/CodeGeneration/TestConfigAllOptionsSet.txt
+++ b/test/ODataConnectedService.Tests/CodeGeneration/TestConfigAllOptionsSet.txt
@@ -36,7 +36,7 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = true;
 
-	// If set to true, Generation date timestamps will be left out of generated files
+	// If set to true, generation timestamps will be left out of generated files
 	public const bool NoTimestamp = true;
 
 	//This files indicates whether to generate the files into multiple files or single.

--- a/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasic.txt
+++ b/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasic.txt
@@ -36,7 +36,7 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = false;
 
-	// If set to true, Generation date timestamps will be left out of generated files
+	// If set to true, generation timestamps will be left out of generated files
 	public const bool NoTimestamp = false;
 
 	//This files indicates whether to generate the files into multiple files or single.

--- a/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasic.txt
+++ b/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasic.txt
@@ -36,6 +36,9 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = false;
 
+	// If set to true, Generation date timestamps will be left out of generated files
+	public const bool NoTimestamp = false;
+
 	//This files indicates whether to generate the files into multiple files or single.
     //If set to true then multiple files will be generated. Otherwise only a single file is generated.
     public const bool GenerateMultipleFiles = false;

--- a/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasicVB.txt
+++ b/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasicVB.txt
@@ -36,7 +36,7 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = false;
 
-	// If set to true, Generation date timestamps will be left out of generated files
+	// If set to true, generation timestamps will be left out of generated files
 	public const bool NoTimestamp = false;
 
 	//This files indicates whether to generate the files into multiple files or single.

--- a/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasicVB.txt
+++ b/test/ODataConnectedService.Tests/CodeGeneration/TestConfigBasicVB.txt
@@ -36,6 +36,9 @@ public static class Configuration
 	// thereby making them invisible outside the assembly
 	public const bool MakeTypesInternal = false;
 
+	// If set to true, Generation date timestamps will be left out of generated files
+	public const bool NoTimestamp = false;
+
 	//This files indicates whether to generate the files into multiple files or single.
     //If set to true then multiple files will be generated. Otherwise only a single file is generated.
     public const bool GenerateMultipleFiles = false;

--- a/test/ODataConnectedService.Tests/Common/ExtensionMethodsTests.cs
+++ b/test/ODataConnectedService.Tests/Common/ExtensionMethodsTests.cs
@@ -33,6 +33,7 @@ namespace ODataConnectedService.Tests
             userSettings.IncludeWebProxy = true;
             userSettings.IncludeWebProxyNetworkCredentials = true;
             userSettings.MakeTypesInternal = true;
+            userSettings.NoTimestamp = true;
             userSettings.NamespacePrefix = "Test";
             userSettings.OpenGeneratedFilesInIDE = true;
             userSettings.ServiceName = "Test";
@@ -65,6 +66,7 @@ namespace ODataConnectedService.Tests
             serviceConfig.IncludeWebProxy = true;
             serviceConfig.IncludeWebProxyNetworkCredentials = true;
             serviceConfig.MakeTypesInternal = true;
+            serviceConfig.NoTimestamp = true;
             serviceConfig.NamespacePrefix = "Test";
             serviceConfig.OpenGeneratedFilesInIDE = true;
             serviceConfig.ServiceName = "Test";
@@ -101,6 +103,7 @@ namespace ODataConnectedService.Tests
             Assert.True(serviceConfig.IncludeWebProxy);
             Assert.True(serviceConfig.IncludeWebProxyNetworkCredentials);
             Assert.True(serviceConfig.MakeTypesInternal);
+            Assert.True(serviceConfig.NoTimestamp);
             Assert.Equal("Test", serviceConfig.NamespacePrefix);
             Assert.True(serviceConfig.OpenGeneratedFilesInIDE);
             Assert.Equal("Test", serviceConfig.ServiceName);
@@ -135,6 +138,7 @@ namespace ODataConnectedService.Tests
             Assert.True(userSettings.IncludeWebProxy);
             Assert.True(userSettings.IncludeWebProxyNetworkCredentials);
             Assert.True(userSettings.MakeTypesInternal);
+            Assert.True(userSettings.NoTimestamp);
             Assert.Equal("Test", userSettings.NamespacePrefix);
             Assert.True(userSettings.OpenGeneratedFilesInIDE);
             Assert.Equal("Test", userSettings.ServiceName);

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -14,19 +14,18 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Documents;
 using FluentAssertions;
+using Microsoft.OData.CodeGen.Common;
+using Microsoft.OData.CodeGen.Models;
 using Microsoft.OData.ConnectedService;
 using Microsoft.OData.ConnectedService.Views;
 using Microsoft.VisualStudio.ConnectedServices;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.OData.CodeGen;
-using Microsoft.OData.CodeGen.Common;
-using Microsoft.OData.CodeGen.Models;
 using Xunit;
 
 namespace ODataConnectedService.Tests
 {
 
-    public sealed class ODataConnectedServiceWizardTests: IDisposable
+    public sealed class ODataConnectedServiceWizardTests : IDisposable
     {
         readonly UserSettings initialSettings;
         readonly string MetadataPath = Path.GetFullPath("TestMetadataCsdl.xml");
@@ -72,6 +71,7 @@ namespace ODataConnectedService.Tests
                 EnableNamingAlias = true,
                 OpenGeneratedFilesInIDE = true,
                 MakeTypesInternal = true,
+                NoTimestamp = true,
                 IgnoreUnexpectedElementsAndAttributes = true,
                 IncludeT4File = true,
                 ExcludedOperationImports = new List<string>()
@@ -263,6 +263,7 @@ namespace ODataConnectedService.Tests
                 Assert.False(advancedPage.UserSettings.GenerateMultipleFiles);
                 Assert.True(advancedPage.UserSettings.IgnoreUnexpectedElementsAndAttributes);
                 Assert.False(advancedPage.UserSettings.MakeTypesInternal);
+                Assert.False(advancedPage.UserSettings.NoTimestamp);
             }
         }
 
@@ -287,7 +288,7 @@ namespace ODataConnectedService.Tests
                 Assert.Equal("http://localhost:8080", endpointPage.UserSettings.WebProxyHost);
                 Assert.True(endpointPage.UserSettings.IncludeWebProxyNetworkCredentials);
                 Assert.True(endpointPage.UserSettings.StoreWebProxyNetworkCredentials);
-                Assert.Equal("domain", endpointPage.UserSettings.WebProxyNetworkCredentialsDomain);                                
+                Assert.Equal("domain", endpointPage.UserSettings.WebProxyNetworkCredentialsDomain);
                 // username and password are not restored from the config
                 Assert.Equal("username", endpointPage.UserSettings.WebProxyNetworkCredentialsUsername);
                 Assert.Equal("password", endpointPage.UserSettings.WebProxyNetworkCredentialsPassword);
@@ -427,6 +428,7 @@ namespace ODataConnectedService.Tests
                 Assert.True(advancedPage.UserSettings.GenerateMultipleFiles);
                 Assert.True(advancedPage.UserSettings.IgnoreUnexpectedElementsAndAttributes);
                 Assert.True(advancedPage.UserSettings.MakeTypesInternal);
+                Assert.True(advancedPage.UserSettings.NoTimestamp);
             }
         }
 
@@ -457,6 +459,7 @@ namespace ODataConnectedService.Tests
                 var advancedView = advancedPage.View as AdvancedSettings;
                 Assert.False(advancedView.IncludeT4File.IsEnabled);
                 Assert.False(advancedView.GenerateMultipleFiles.IsEnabled);
+                Assert.False(advancedView.NoTimestamp.IsEnabled);
             }
         }
 
@@ -464,7 +467,7 @@ namespace ODataConnectedService.Tests
         public void TestGetFinishedServiceInstanceAsync_SavesUserSettingsAndReturnsServiceInstanceWithConfigFromTheWizard()
         {
             var context = new TestConnectedServiceProviderContext(false);
-            using(var wizard = new ODataConnectedServiceWizard(context))
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
                 var endpointPage = wizard.ConfigODataEndpointViewModel;
                 endpointPage.UserSettings.ServiceName = "TestService";
@@ -473,7 +476,7 @@ namespace ODataConnectedService.Tests
                 endpointPage.UserSettings.IncludeCustomHeaders = true;
                 endpointPage.UserSettings.StoreCustomHttpHeaders = true;
                 endpointPage.UserSettings.CustomHttpHeaders = "Key:val";
-                endpointPage.UserSettings.IncludeWebProxy = true;                
+                endpointPage.UserSettings.IncludeWebProxy = true;
                 endpointPage.UserSettings.WebProxyHost = "http://localhost:8080";
                 endpointPage.UserSettings.IncludeWebProxyNetworkCredentials = true;
                 endpointPage.UserSettings.StoreWebProxyNetworkCredentials = true;
@@ -531,6 +534,7 @@ namespace ODataConnectedService.Tests
                 advancedPage.UserSettings.IncludeT4File = true;
                 advancedPage.UserSettings.GenerateMultipleFiles = true;
                 advancedPage.UserSettings.OpenGeneratedFilesInIDE = true;
+                advancedPage.UserSettings.NoTimestamp = true;
 
                 operationsPage.OnPageLeavingAsync(new WizardLeavingArgs(typesPage)).Wait();
                 typesPage.OnPageLeavingAsync(new WizardLeavingArgs(advancedPage)).Wait();
@@ -613,6 +617,7 @@ namespace ODataConnectedService.Tests
                 Assert.True(config.IncludeT4File);
                 Assert.True(config.GenerateMultipleFiles);
                 Assert.True(config.OpenGeneratedFilesInIDE);
+                Assert.True(config.NoTimestamp);
             }
         }
 
@@ -622,7 +627,7 @@ namespace ODataConnectedService.Tests
             var savedConfig = GetTestConfig();
             savedConfig.Endpoint = MetadataPath;
             var context = new TestConnectedServiceProviderContext(true, savedConfig);
-            using(var wizard = new ODataConnectedServiceWizard(context))
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
                 var endpointPage = wizard.ConfigODataEndpointViewModel;
                 endpointPage.OnPageEnteringAsync(null).Wait();
@@ -671,6 +676,7 @@ namespace ODataConnectedService.Tests
                 Assert.True(config.IncludeT4File);
                 Assert.True(config.GenerateMultipleFiles);
                 Assert.True(config.OpenGeneratedFilesInIDE);
+                Assert.True(config.NoTimestamp);
             }
         }
 
@@ -678,7 +684,7 @@ namespace ODataConnectedService.Tests
         public void ShouldPreserveState_WhenMovingBetweenPagesAndBack()
         {
             var context = new TestConnectedServiceProviderContext();
-            using(var wizard = new ODataConnectedServiceWizard(context))
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
                 var endpointPage = wizard.ConfigODataEndpointViewModel;
                 endpointPage.OnPageEnteringAsync(null).Wait();
@@ -721,6 +727,7 @@ namespace ODataConnectedService.Tests
                 advancedPage.UserSettings.UseDataServiceCollection = true;
                 advancedPage.UserSettings.MakeTypesInternal = true;
                 advancedPage.UserSettings.UseNamespacePrefix = true;
+                advancedPage.UserSettings.NoTimestamp = true;
                 advancedPage.OnPageLeavingAsync(null).Wait();
 
                 endpointPage.OnPageEnteringAsync(null).Wait();
@@ -737,6 +744,7 @@ namespace ODataConnectedService.Tests
                 Assert.True(advancedPage.UserSettings.UseNamespacePrefix);
                 Assert.True(advancedPage.UserSettings.UseDataServiceCollection);
                 Assert.True(advancedPage.UserSettings.MakeTypesInternal);
+                Assert.True(advancedPage.UserSettings.NoTimestamp);
                 advancedPage.UserSettings.NamespacePrefix = "MyNamespace";
                 advancedPage.UserSettings.GenerateMultipleFiles = true;
                 advancedPage.UserSettings.UseDataServiceCollection = false;
@@ -773,6 +781,7 @@ namespace ODataConnectedService.Tests
                 Assert.Equal("A:b", config.CustomHttpHeaders);
                 Assert.True(config.GenerateMultipleFiles);
                 Assert.True(config.MakeTypesInternal);
+                Assert.True(config.NoTimestamp);
                 Assert.True(config.UseNamespacePrefix);
                 Assert.Equal("MyNamespace", config.NamespacePrefix);
                 Assert.False(config.UseDataServiceCollection);
@@ -798,7 +807,7 @@ namespace ODataConnectedService.Tests
             var savedConfig = GetTestConfig();
             savedConfig.Endpoint = MetadataPath;
             var context = new TestConnectedServiceProviderContext(true, savedConfig);
-            using(var wizard = new ODataConnectedServiceWizard(context))
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
                 var endpointPage = wizard.ConfigODataEndpointViewModel;
                 endpointPage.OnPageEnteringAsync(null).Wait();
@@ -828,6 +837,7 @@ namespace ODataConnectedService.Tests
                 advancedPage.UserSettings.UseDataServiceCollection = true;
                 advancedPage.UserSettings.MakeTypesInternal = true;
                 advancedPage.UserSettings.UseNamespacePrefix = true;
+                advancedPage.UserSettings.NoTimestamp = true;
                 advancedPage.OnPageLeavingAsync(null).Wait();
 
                 endpointPage.OnPageEnteringAsync(null).Wait();
@@ -841,6 +851,7 @@ namespace ODataConnectedService.Tests
                 Assert.True(advancedPage.UserSettings.UseNamespacePrefix);
                 Assert.True(advancedPage.UserSettings.UseDataServiceCollection);
                 Assert.True(advancedPage.UserSettings.MakeTypesInternal);
+                Assert.True(advancedPage.UserSettings.NoTimestamp);
                 advancedPage.UserSettings.NamespacePrefix = "MyNamespace";
                 advancedPage.UserSettings.GenerateMultipleFiles = true;
                 advancedPage.UserSettings.UseDataServiceCollection = false;
@@ -876,6 +887,7 @@ namespace ODataConnectedService.Tests
                 Assert.Equal("A:b", config.CustomHttpHeaders);
                 Assert.True(config.GenerateMultipleFiles);
                 Assert.True(config.MakeTypesInternal);
+                Assert.True(config.NoTimestamp);
                 Assert.True(config.UseNamespacePrefix);
                 Assert.Equal("MyNamespace", config.NamespacePrefix);
                 Assert.False(config.UseDataServiceCollection);
@@ -906,7 +918,7 @@ namespace ODataConnectedService.Tests
         public void ShouldReloadOperationsAndTypesForNewEndpoint_WhenEndpointIsChangedBeforeFinishing()
         {
             var context = new TestConnectedServiceProviderContext();
-            using(var wizard = new ODataConnectedServiceWizard(context))
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
                 var endpointPage = wizard.ConfigODataEndpointViewModel;
                 endpointPage.OnPageEnteringAsync(null).Wait();
@@ -970,7 +982,7 @@ namespace ODataConnectedService.Tests
         public void ShouldDeselectOperations_WhenRelatedTypeIsDeselectedBefore()
         {
             var context = new TestConnectedServiceProviderContext();
-            using(var wizard = new ODataConnectedServiceWizard(context))
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
                 var endpointPage = wizard.ConfigODataEndpointViewModel;
                 endpointPage.OnPageEnteringAsync(null).Wait();
@@ -1004,7 +1016,7 @@ namespace ODataConnectedService.Tests
         public void ShouldDeselectBoundOperations_WhenRelatedTypeIsDeselectedBefore()
         {
             var context = new TestConnectedServiceProviderContext();
-            using(var wizard = new ODataConnectedServiceWizard(context))
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
                 var endpointPage = wizard.ConfigODataEndpointViewModel;
                 endpointPage.OnPageEnteringAsync(null).Wait();
@@ -1046,7 +1058,7 @@ namespace ODataConnectedService.Tests
         public void UnsupportedFeaturesAreDisabledOrHidden_WhenServiceIsV3OrLess()
         {
             var context = new TestConnectedServiceProviderContext();
-            using(var wizard = new ODataConnectedServiceWizard(context))
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
                 var endpointPage = wizard.ConfigODataEndpointViewModel;
                 endpointPage.UserSettings.Endpoint = MetadataPathV3;
@@ -1080,7 +1092,7 @@ namespace ODataConnectedService.Tests
         }
     }
 
-    internal class TestConnectedServiceProviderContext: ConnectedServiceProviderContext
+    internal class TestConnectedServiceProviderContext : ConnectedServiceProviderContext
     {
         ServiceConfigurationV4 savedData;
 

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTest.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTest.cs
@@ -5,8 +5,8 @@
 // </copyright>
 //---------------------------------------------------------------------------------
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.OData.CodeGen.Templates;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ODataConnectedService.Tests.TestHelpers;
 
 namespace Microsoft.OData.ConnectedService.Tests.Templates
@@ -15,7 +15,7 @@ namespace Microsoft.OData.ConnectedService.Tests.Templates
     public class ODataT4CodeGeneratorTest
     {
 
-        
+
         [TestMethod]
         public void TestEntitiesComplexTypesEnumsFunctions()
         {
@@ -61,6 +61,22 @@ namespace Microsoft.OData.ConnectedService.Tests.Templates
             GeneratedCodeHelpers.VerifyGeneratedCode(expected, output);
         }
 
+
+        [TestMethod]
+        public void TestEntitiesComplexTypesEnumFunctionsWithNoTimestamp()
+        {
+            string edmx = GeneratedCodeHelpers.LoadReferenceContent("EntitiesEnumsFunctions.xml");
+            string expected = GeneratedCodeHelpers.LoadReferenceContent("EntitiesEnumsFunctions.cs");
+            var generator = new ODataT4CodeGenerator()
+            {
+                Edmx = edmx,
+                TargetLanguage = ODataT4CodeGenerator.LanguageOption.CSharp,
+                NoTimestamp = true,
+            };
+            var output = generator.TransformText();
+            GeneratedCodeHelpers.VerifyGeneratedCodeNoTimestamp(expected, output);
+        }
+
         [TestMethod]
         public void TestEntitiesComplexTypesEnumFunctionsDSCWithInternalTypes()
         {
@@ -76,6 +92,38 @@ namespace Microsoft.OData.ConnectedService.Tests.Templates
             };
             var output = generator.TransformText();
             GeneratedCodeHelpers.VerifyGeneratedCode(expected, output);
+        }
+
+        [TestMethod]
+        public void TestEntitiesComplexTypesEnumFunctionsDSCWithNoTimestamp()
+        {
+            string edmx = GeneratedCodeHelpers.LoadReferenceContent("EntitiesEnumsFunctions.xml");
+            string expected = GeneratedCodeHelpers.LoadReferenceContent("EntitiesEnumsFunctionsDSC.cs");
+            var generator = new ODataT4CodeGenerator()
+            {
+                Edmx = edmx,
+                TargetLanguage = ODataT4CodeGenerator.LanguageOption.CSharp,
+                UseDataServiceCollection = true,
+                NoTimestamp = true,
+            };
+            var output = generator.TransformText();
+            GeneratedCodeHelpers.VerifyGeneratedCodeNoTimestamp(expected, output);
+        }
+        [TestMethod]
+        public void TestEntitiesComplexTypesEnumFunctionsDSCWithInternalTypesWithNoTimestamp()
+        {
+            string edmx = GeneratedCodeHelpers.LoadReferenceContent("EntitiesEnumsFunctions.xml");
+            string expected = GeneratedCodeHelpers.LoadReferenceContent("EntitiesEnumsFunctionsDSCWithInternalTypes.cs");
+            var generator = new ODataT4CodeGenerator()
+            {
+                Edmx = edmx,
+                TargetLanguage = ODataT4CodeGenerator.LanguageOption.CSharp,
+                UseDataServiceCollection = true,
+                MakeTypesInternal = true,
+                NoTimestamp = true,
+            };
+            var output = generator.TransformText();
+            GeneratedCodeHelpers.VerifyGeneratedCodeNoTimestamp(expected, output);
         }
 
         [TestMethod]

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
@@ -6,22 +6,21 @@
 //---------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
+using System.Net;
+using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Xml;
 using FluentAssertions;
+using Microsoft.OData.CodeGen.Templates;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ODataConnectedService.Tests.TestHelpers;
 
 namespace ODataConnectedService.Tests
 {
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Net;
-    using System.Reflection;
-    using System.Text.RegularExpressions;
-    using Microsoft.OData.CodeGen.Templates;
-    using ODataConnectedService.Tests.TestHelpers;
-
     [TestClass]
     public class ODataT4CodeGeneratorTests
     {

--- a/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
+++ b/test/ODataConnectedService.Tests/Templates/ODataT4CodeGeneratorTests.cs
@@ -5,32 +5,22 @@
 // </copyright>
 //---------------------------------------------------------------------------------
 
-using FluentAssertions;
-using Microsoft.CSharp;
-using Microsoft.OData.Edm;
-using Microsoft.Spatial;
-using Microsoft.VisualBasic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.CodeDom.Compiler;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Xml;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ODataConnectedService.Tests
 {
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Net;
     using System.Reflection;
-    using Microsoft.OData;
     using System.Text.RegularExpressions;
     using Microsoft.OData.CodeGen.Templates;
-    using Microsoft.OData.Client;
-    using System.Collections.Generic;
-    using System.Net;
     using ODataConnectedService.Tests.TestHelpers;
-    using System.Globalization;
-    using System.ComponentModel.DataAnnotations;
 
     [TestClass]
     public class ODataT4CodeGeneratorTests
@@ -90,7 +80,7 @@ namespace ODataConnectedService.Tests
             {
                 T4TransformToolPath = T4TransformToolPathVSVer2017Community;
             }
-            else if(File.Exists(T4TransformToolPathVer11))
+            else if (File.Exists(T4TransformToolPathVer11))
             {
                 T4TransformToolPath = T4TransformToolPathVer11;
             }
@@ -186,7 +176,7 @@ namespace ODataConnectedService.Tests
         [TestMethod]
         public void CodeGenSimpleEdmxMultipleFiles()
         {
-            string code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.SimpleMultipleFiles.Metadata, null, true, false, generateMultipleFiles : true);
+            string code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.SimpleMultipleFiles.Metadata, null, true, false, generateMultipleFiles: true);
 
             string expectedTestType = GeneratedCodeHelpers.NormalizeGeneratedCode(ODataT4CodeGeneratorTestDescriptors.GetFileContent("SimpleMultipleTestType.cs"));
             string actualTestType = GeneratedCodeHelpers.NormalizeGeneratedCode(File.ReadAllText(Path.Combine(Path.GetTempPath(), "TestType.cs")));
@@ -405,7 +395,7 @@ namespace ODataConnectedService.Tests
         [TestMethod]
         public void CodeGenWithMultiReferenceModelRelativeUri()
         {
-            string code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.MultiReferenceModelRelativeUri.Metadata, null, true, false, metadataDocumentUri: ODataT4CodeGeneratorTestDescriptors.EdmxWithMultiReferenceModelRelativeUriFilePath );
+            string code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.MultiReferenceModelRelativeUri.Metadata, null, true, false, metadataDocumentUri: ODataT4CodeGeneratorTestDescriptors.EdmxWithMultiReferenceModelRelativeUriFilePath);
             ODataT4CodeGeneratorTestDescriptors.MultiReferenceModelRelativeUri.Verify(code, true /*isCSharp*/, false /*useDSC*/);
 
             code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.MultiReferenceModelRelativeUri.Metadata, null, false, false, metadataDocumentUri: ODataT4CodeGeneratorTestDescriptors.EdmxWithMultiReferenceModelRelativeUriFilePath);
@@ -590,7 +580,7 @@ namespace ODataConnectedService.Tests
                 $"{@namespace}PublicTransportation"
             };
 
-            string code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.EntitiesEnumsFunctionsSelectTypes.Metadata, null, true, false, false, false, null, true,excludedSchemaTypes : excludedSchemaTypes);
+            string code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.EntitiesEnumsFunctionsSelectTypes.Metadata, null, true, false, false, false, null, true, excludedSchemaTypes: excludedSchemaTypes);
             ODataT4CodeGeneratorTestDescriptors.EntitiesEnumsFunctionsSelectTypes.Verify(code, true/*isCSharp*/, false/*useDSC*/);
 
             code = CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.EntitiesEnumsFunctionsSelectTypes.Metadata, null, false/*isCSharp*/, false, false, false, null, true, excludedSchemaTypes: excludedSchemaTypes);
@@ -676,9 +666,8 @@ namespace ODataConnectedService.Tests
             bool useDataServiceCollection, bool enableNamingAlias = false,
             bool ignoreUnexpectedElementsAndAttributes = false,
             Func<Uri, WebProxy, IList<string>, XmlReader> getReferencedModelReaderFunc = null,
-            bool appendDSCSuffix = false, string MetadataFilePath = null, bool generateMultipleFiles = false, string metadataDocumentUri = null,
-            IEnumerable<string> excludedSchemaTypes = default(List<string>))
-
+            bool appendDSCSuffix = false, string MetadataFilePath = null, bool generateMultipleFiles = false, bool noTimestamp = false,
+            string metadataDocumentUri = null, IEnumerable<string> excludedSchemaTypes = default(List<string>))
         {
             if (useDataServiceCollection
                 && appendDSCSuffix) // hack now
@@ -703,6 +692,7 @@ namespace ODataConnectedService.Tests
                 EnableNamingAlias = enableNamingAlias,
                 IgnoreUnexpectedElementsAndAttributes = ignoreUnexpectedElementsAndAttributes,
                 GenerateMultipleFiles = generateMultipleFiles,
+                NoTimestamp = noTimestamp,
                 ExcludedSchemaTypes = excludedSchemaTypes
             };
 
@@ -779,7 +769,7 @@ namespace ODataConnectedService.Tests
             Assert.IsNotNull(filename, "null filename");
             Assert.IsTrue(File.Exists(filename) && !Directory.Exists(filename), "missing file: {0}", filename);
 
-            using(var process = new Process())
+            using (var process = new Process())
             {
                 process.StartInfo.FileName = filename;
                 process.StartInfo.Arguments = arguments;

--- a/test/ODataConnectedService.Tests/TestHelpers/GeneratedCodeHelpers.cs
+++ b/test/ODataConnectedService.Tests/TestHelpers/GeneratedCodeHelpers.cs
@@ -5,21 +5,21 @@
 // </copyright>
 //---------------------------------------------------------------------------------
 
-using Microsoft.CSharp;
-using Microsoft.OData.Edm;
-using Microsoft.OData;
-using Microsoft.Spatial;
-using Microsoft.VisualBasic;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.CodeDom.Compiler;
+using System.ComponentModel.DataAnnotations;
+using System.Data.Services.Client;
 using System.IO;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using System.Data.Services.Client;
-using System.ComponentModel.DataAnnotations;
-using Microsoft.OData.CodeGen.Templates;
 using FluentAssertions;
+using Microsoft.CSharp;
+using Microsoft.OData;
+using Microsoft.OData.CodeGen.Templates;
+using Microsoft.OData.Edm;
+using Microsoft.Spatial;
+using Microsoft.VisualBasic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ODataConnectedService.Tests.TestHelpers
 {
@@ -62,6 +62,31 @@ namespace ODataConnectedService.Tests.TestHelpers
                "global::System.CodeDom.Compiler.GeneratedCodeAttribute\\(.*\\)",
                "global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Microsoft.OData.Client.Design.T4\", \"" + T4Version + "\")",
                RegexOptions.Multiline);
+
+            //Remove the spaces from the string to avoid indentation change errors
+            normalized = Regex.Replace(normalized, @"\s+", "");
+
+            return normalized;
+        }
+
+        public static void VerifyGeneratedCodeNoTimestamp(string expectedCode, string actualCode)
+        {
+            var normalizedExpected = NormalizeGeneratedCode(expectedCode);
+            var normalizedActual = NormalizeGeneratedCodeKeepGenerationDate(actualCode);
+            Assert.AreEqual(normalizedExpected, normalizedActual);
+
+            var normalizedActualWithoutTimestamp = NormalizeGeneratedCode(actualCode);
+            Assert.AreEqual(normalizedActualWithoutTimestamp, normalizedActual);
+        }
+
+        public static string NormalizeGeneratedCodeKeepGenerationDate(string code)
+        {
+            var normalized = Regex.Replace(code, "//     Runtime Version:.*", string.Empty, RegexOptions.Multiline);
+            normalized = Regex.Replace(normalized, "'     Runtime Version:.*", string.Empty, RegexOptions.Multiline);
+            normalized = Regex.Replace(normalized,
+                "global::System.CodeDom.Compiler.GeneratedCodeAttribute\\(.*\\)",
+                "global::System.CodeDom.Compiler.GeneratedCodeAttribute(\"Microsoft.OData.Client.Design.T4\", \"" + T4Version + "\")",
+                RegexOptions.Multiline);
 
             //Remove the spaces from the string to avoid indentation change errors
             normalized = Regex.Replace(normalized, @"\s+", "");

--- a/test/ODataConnectedService.Tests/Views/UserSettingsTest.cs
+++ b/test/ODataConnectedService.Tests/Views/UserSettingsTest.cs
@@ -32,6 +32,7 @@ namespace ODataConnectedService.Tests.Views
             userSettings.GeneratedFileNamePrefix = "MyPrefix";
             userSettings.GenerateMultipleFiles = true;
             userSettings.MakeTypesInternal = true;
+            userSettings.NoTimestamp = true;
 
             // Save settings
             userSettings.Save();
@@ -43,6 +44,7 @@ namespace ODataConnectedService.Tests.Views
             Assert.Equal("MyPrefix", settings.GeneratedFileNamePrefix);
             Assert.True(settings.GenerateMultipleFiles);
             Assert.True(settings.MakeTypesInternal);
+            Assert.True(settings.NoTimestamp);
         }
 
         [Fact]
@@ -65,7 +67,7 @@ namespace ODataConnectedService.Tests.Views
 
             // Add an endpoint.
             userSettings.AddMruEndpoint(endpoint1);
-            Assert.Single(userSettings.MruEndpoints);            
+            Assert.Single(userSettings.MruEndpoints);
 
             // Add another endpoint.The latest endpoint to be added is at the top of the MruList.
             userSettings.AddMruEndpoint(endpoint2);


### PR DESCRIPTION
Add the NoTimestamp option to disable the Generated date timestamp in generated files.
Added to OData-CLI and to VS Extension
Tests added and updated to take into account NoTimestamp option

Fixes #349 