### PR TITLE
rerun build

### DIFF
--- a/src/Microsoft.OData.Cli/PackageInstallers/PackageInstallerHelpers.cs
+++ b/src/Microsoft.OData.Cli/PackageInstallers/PackageInstallerHelpers.cs
@@ -90,7 +90,7 @@ namespace Microsoft.OData.Cli.PackageInstallers
         /// </summary>
         /// <param name="packageId">The package to install</param>
         /// <param name="projectTargetVersion">The version of .net framework that the project targets.</param>
-        /// <returns>A completed task of the package installation</returns>
+        /// <returns>A completed task of the package installation.</returns>
         internal async Task InstallPackagesOnDotNetV4FrameworkProjects(string packageId, string projectTargetVersion)
         {
             using (SourceCacheContext cacheContext = new SourceCacheContext())


### PR DESCRIPTION
I've added a minor change so the build can run again. The version for the OData-CLI had already been updated to v0.2.0