### PR TITLE
Fixes #324 partially by extending the MSBuild registration logic

### DIFF
--- a/src/Microsoft.OData.Cli/Program.cs
+++ b/src/Microsoft.OData.Cli/Program.cs
@@ -1,5 +1,8 @@
 ﻿using System.CommandLine;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Build.Locator;
 
 namespace Microsoft.OData.Cli
 {
@@ -7,12 +10,36 @@ namespace Microsoft.OData.Cli
     {
         static async Task Main(string[] args)
         {
-            Build.Locator.MSBuildLocator.RegisterDefaults();
+            RegisterMsBuild();
             GenerateCommand generateCommand = new GenerateCommand();
             RootCommand app = new RootCommand {
                 generateCommand
             };
             await app.InvokeAsync(args);
+        }
+
+        /// <summary>
+        /// Tries to register MSBuild from Visual Studio install folder. If not available, register defaults.
+        /// </summary>
+        private static void RegisterMsBuild()
+        {
+            const string defaultInstallDirOfVisualStudio = @"C:\Program Files\Microsoft Visual Studio\";
+            var installDirOfLatestVisualStudio = Directory.GetDirectories(defaultInstallDirOfVisualStudio, "????", SearchOption.TopDirectoryOnly)
+                .Where(x => Path.GetFileName(x).All(char.IsDigit))
+                .MaxBy(x => Path.GetFileName(x));
+
+            string pathToMsBuildExeInLatestVisualStudioVersion = Path.Combine(
+                Directory.GetDirectories(installDirOfLatestVisualStudio, "*", SearchOption.TopDirectoryOnly).FirstOrDefault() ?? string.Empty,
+                "MSBuild", "Current", "Bin", "MSBuild.exe");
+
+            if (File.Exists(pathToMsBuildExeInLatestVisualStudioVersion))
+            {
+                MSBuildLocator.RegisterMSBuildPath(Path.GetDirectoryName(pathToMsBuildExeInLatestVisualStudioVersion));
+            }
+            else
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OData/ODataConnectedService/issues/324 partially by extending the MSBuild registration logic. It is not a full solution, but should resolve the issue for most of the users.