### PR TITLE
Fix missing ContainerProperty attribute on dynamic properties (issue #380)

### DIFF
--- a/src/ODataConnectedService.Shared/ConnectedServiceFileHandler.cs
+++ b/src/ODataConnectedService.Shared/ConnectedServiceFileHandler.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OData.ConnectedService
                         // Assembly reference (For project reference, SourceProject != null)
                         if (reference.Name.Equals("Microsoft.OData.Client", StringComparison.Ordinal))
                         {
-                            return Version.Parse(reference.Version) > Version.Parse("7.6.4.0");
+                            return Version.Parse(reference.Version) >= Version.Parse("7.6.4.0");
                         }
                     }
                 }

--- a/src/ODataConnectedService.Shared/ConnectedServiceFileHandler.cs
+++ b/src/ODataConnectedService.Shared/ConnectedServiceFileHandler.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OData.ConnectedService
                         // Assembly reference (For project reference, SourceProject != null)
                         if (reference.Name.Equals("Microsoft.OData.Client", StringComparison.Ordinal))
                         {
-                            return Version.Parse(reference.Version) >= Version.Parse("7.6.4.0");
+                            return Version.Parse(reference.Version) > Version.Parse("7.6.4.0");
                         }
                     }
                 }

--- a/src/ODataConnectedService.Shared/ConnectedServiceFileHandler.cs
+++ b/src/ODataConnectedService.Shared/ConnectedServiceFileHandler.cs
@@ -81,9 +81,9 @@ namespace Microsoft.OData.ConnectedService
                     if (reference.SourceProject == null)
                     {
                         // Assembly reference (For project reference, SourceProject != null)
-                        if (reference.Name.Equals("Microsoft.OData.Client", StringComparison.Ordinal) && string.Compare(reference.Version, "7.6.4.0", StringComparison.Ordinal) > 0)
+                        if (reference.Name.Equals("Microsoft.OData.Client", StringComparison.Ordinal))
                         {
-                            return true;
+                            return Version.Parse(reference.Version) >= Version.Parse("7.6.4.0");
                         }
                     }
                 }


### PR DESCRIPTION
### Issues
This pull request fixes issue #380 
When entity is an open type (`<EntityType Name="ResultObject" OpenType="true">`) VS extension generates `IDictionary<string, object> DynamicProperties` property. 
This property must have `ContainerProperty` attribute. 
Otherwise, when connected service is used, the dictionary is not populated from response.
If in the project, referenced `Microsoft.OData.Client` nuget with version >= 7.10.*, `ContainerProperty` attribute not added due to wrong versions comparison.
If I reference `Microsoft.OData.Client` version 7.20.0, the `ContainerProperty` attribute not added because lexically 7.20.0 < 7.6.4
### Description
Fix `Microsoft.OData.Client` versions comparison.