### PR TITLE
Configure test coverage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,8 @@ variables:
   productBinPathVs2022Plus: '$(connectedServiceDir)\src\ODataConnectedService_VS2022Plus\bin\$(BuildConfiguration)'
   productFilesVs2022Plus: 'Microsoft.OData.ConnectedService.VS2022Plus.*?(*.dll|*.config|*.pdb)'
   productFilesODataCLI: 'Microsoft.OData.Cli.*?(*.dll|*.config|*.pdb)'
-  testBinPath: '$(connectedServiceDir)\test\ODataConnectedService.Tests\bin\$(BuildConfiguration)\'
-  testBinPathODataCLI: '$(connectedServiceDir)\test\Microsoft.OData.Cli.Tests\bin\$(BuildConfiguration)\'
+  testBinPath: '$(connectedServiceDir)\test\ODataConnectedService.Tests\bin\$(BuildConfiguration)'
+  testBinPathODataCLI: '$(connectedServiceDir)\test\Microsoft.OData.Cli.Tests\bin\$(BuildConfiguration)'
   vsixPath: '$(productBinPath)'
   vsixFile: 'Microsoft.OData.ConnectedService.vsix'
   vsixFileVs2022Plus: 'Microsoft.OData.ConnectedService.VS2022Plus.vsix'
@@ -67,21 +67,43 @@ stages:
         nobuild: true
 
     - task: VSTest@2
-      displayName: 'Run tests'
+      displayName: 'Unit Tests (ODataConnectedService.Tests)'
       inputs:
         testSelector: 'testAssemblies'
         testAssemblyVer2: '$(testBinPath)\$(testDll)'
         platform: '$(buildPlatform)'
         configuration: '$(buildConfiguration)'
         searchFolder:  '$(System.DefaultWorkingDirectory)'
+        resultsFolder: '$(Agent.TempDirectory)\TestResults'
+        otherConsoleOptions: '/collect:"Code Coverage;Format=Cobertura"'
+        runSettingsFile: '$(Build.SourcesDirectory)\test.runsettings'
+        #codeCoverageEnabled: true
 
     - task: DotNetCoreCLI@2
       displayName: Unit Tests (Microsoft.OData.Cli.Tests)
       inputs:
         command: test
+        publishTestResults: false
         projects: $(connectedServiceDir)\test\Microsoft.OData.Cli.Tests\Microsoft.OData.Cli.Tests.csproj
-        arguments: --configuration $(buildConfiguration) --no-build
+        arguments: '--configuration $(buildConfiguration) --settings $(Build.SourcesDirectory)\test.runsettings --no-build --collect "Code Coverage;Format=Cobertura" --logger trx --results-directory $(Agent.TempDirectory)\TestResults'
         
+    - task: CmdLine@2
+      displayName: Install ReportGenerator tool for code coverage
+      inputs:
+        script: dotnet tool install --global dotnet-reportgenerator-globaltool --version 4.5.8
+
+    - task: CmdLine@2
+      displayName: Create code coverage report
+      inputs:
+        script: reportgenerator -reports:$(Agent.TempDirectory)/TestResults/**/*.cobertura.xml -targetdir:$(Build.SourcesDirectory) -reporttypes:"Cobertura"
+
+    # PublishCodeCoverageResults@2 doesn't support line and branch based coverage - https://stackoverflow.com/a/78276341/752739
+    - task: PublishCodeCoverageResults@1
+      displayName: Publish code coverage
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: $(Build.SourcesDirectory)/Cobertura.xml
+    
     - task: CopyFiles@2
       displayName: 'Copy Files - VSIX to Artifacts Staging'
       inputs:

--- a/src/ODataConnectedService_VS2022Plus/ODataConnectedService_VS2022Plus.csproj
+++ b/src/ODataConnectedService_VS2022Plus/ODataConnectedService_VS2022Plus.csproj
@@ -95,9 +95,6 @@
     <PackageReference Include="Microsoft.VisualStudio.ConnectedServices">
       <Version>16.2.45</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.11.40262</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.11.435</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <!-- Configurations that affect the Test Framework -->
+  <RunConfiguration>
+  </RunConfiguration>
+  <!-- Configurations for data collectors -->
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <CodeCoverage>
+            <ModulePaths>
+              <Include>
+                <ModulePath>.*\Microsoft\.OData\.CodeGen\.dll$</ModulePath>
+                <ModulePath>.*\Microsoft\.OData\.ConnectedService\.dll$</ModulePath>
+                <ModulePath>.*\Microsoft\.OData\.ConnectedService\.VS2022Plus\.dll$</ModulePath>
+                <ModulePath>.*\Microsoft\.OData\.Cli\.dll$</ModulePath>
+              </Include>
+            </ModulePaths>
+             <Functions>
+               <Exclude>
+                 <Function>^Fabrikam\.UnitTest\..*</Function>
+                 <Function>^std::.*</Function>
+                 <Function>^ATL::.*</Function>
+                 <Function>.*::__GetTestMethodInfo.*</Function>
+                 <Function>^Microsoft::VisualStudio::CppCodeCoverageFramework::.*</Function>
+                 <Function>^Microsoft::VisualStudio::CppUnitTestFramework::.*</Function>
+               </Exclude>
+             </Functions>
+             <Attributes>
+               <Exclude>
+                 <Attribute>^System\.Diagnostics\.DebuggerHiddenAttribute$</Attribute>
+                 <Attribute>^System\.Diagnostics\.DebuggerNonUserCodeAttribute$</Attribute>
+                 <Attribute>^System\.Runtime\.CompilerServices\.CompilerGeneratedAttribute$</Attribute>
+                 <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+                 <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+               </Exclude>
+             </Attributes>
+             <Sources>
+               <Exclude>
+                 <Source>.*\\atlmfc\\.*</Source>
+                 <Source>.*\\vctools\\.*</Source>
+                 <Source>.*\\public\\sdk\\.*</Source>
+                 <Source>.*\\microsoft sdks\\.*</Source>
+                 <Source>.*\\vc\\include\\.*</Source>
+               </Exclude>
+             </Sources>
+             <CompanyNames>
+               <Exclude>
+                 <CompanyName>.*microsoft.*</CompanyName>
+               </Exclude>
+             </CompanyNames>
+             <PublicKeyTokens>
+               <Exclude>
+                 <PublicKeyToken>^B77A5C561934E089$</PublicKeyToken>
+                 <PublicKeyToken>^B03F5F7F11D50A3A$</PublicKeyToken>
+                 <PublicKeyToken>^31BF3856AD364E35$</PublicKeyToken>
+                 <PublicKeyToken>^89845DCD8080CC91$</PublicKeyToken>
+                 <PublicKeyToken>^71E9BCE111E9429C$</PublicKeyToken>
+                 <PublicKeyToken>^8F50407C4E9E73B6$</PublicKeyToken>
+                 <PublicKeyToken>^E361AF139669C375$</PublicKeyToken>
+               </Exclude>
+             </PublicKeyTokens>
+             <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+             <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+             <CollectFromChildProcesses>True</CollectFromChildProcesses>
+             <CollectAspDotNet>False</CollectAspDotNet>
+           </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
Configure code coverage.

Restrict code coverage analysis to libraries being tested:

![{6A2AD198-678A-491A-9196-65A39F8DA482}](https://github.com/user-attachments/assets/d4292f58-3f9f-4704-926e-6e5d962373d1)
