### PR TITLE
Update publisher name on pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,7 +173,7 @@ stages:
                 --base-directory "$(Pipeline.Workspace)/VSIX" `
                 --output "$(Build.ArtifactStagingDirectory)/SignedVSIX" `
                 --file-list "$(Pipeline.Workspace)/configs/filelist.txt" `
-                --publisher-name "Microsoft OData" `
+                --publisher-name "OData Labs" `
                 --description "OData Connected Service" `
                 --description-url "https://github.com/OData/ODataConnectedService" `
                 --azure-key-vault-managed-identity `
@@ -223,7 +223,7 @@ stages:
                 --base-directory "$(Pipeline.Workspace)/VSIX2022Plus" `
                 --output "$(Build.ArtifactStagingDirectory)/SignedVSIX2022Plus" `
                 --file-list "$(Pipeline.Workspace)/configs/filelist.txt" `
-                --publisher-name "Microsoft OData" `
+                --publisher-name "OData Labs" `
                 --description "OData Connected Service 2022+" `
                 --description-url "https://github.com/OData/ODataConnectedService" `
                 --azure-key-vault-managed-identity `
@@ -282,11 +282,11 @@ stages:
               scriptLocation: inlineScript
               inlineScript: |
                 .\sign code azure-key-vault `
-                "**/*.{dll,zip,nupkg}" `
+                "**/*.{{dll,exe,zip,nupkg}}" `
                 --base-directory "$(Pipeline.Workspace)\ODataCLINupkg" `
                 --output "$(Build.ArtifactStagingDirectory)\SignedODataCLINupkg" `
                 --file-list "$(Pipeline.Workspace)\configs\filelist.txt" `
-                --publisher-name "Microsoft OData" `
+                --publisher-name "OData Labs" `
                 --description "OData CLI" `
                 --description-url "https://github.com/OData/ODataConnectedService" `
                 --azure-key-vault-managed-identity `

--- a/configs/filelist.txt
+++ b/configs/filelist.txt
@@ -1,2 +1,5 @@
 Microsoft.OData.ConnectedService.dll
 Microsoft.OData.ConnectedService.VS2022Plus.dll
+Microsoft.OData.CodeGen.dll
+Microsoft.OData.Cli.exe
+Microsoft.OData.Cli.dll


### PR DESCRIPTION
This pull request
- updates publisher name on the pipeline
- adds `exe` as a target file type for OData CLI signing since it's an executable command line tool - signing still works without this change.
- adds `Microsoft.OData.Cli.dll`, `Microsoft.OData.CodeGen.dll` and `Microsoft.OData.Cli.exe` to the file list referenced during signing  - signing still works without this change.