### PR TITLE
Resolve conflicts when two csdl names have similar suffixes

### DIFF
--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -5121,7 +5121,8 @@ this.Write(@""")]
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(assembly.GetManifestResourceNames().OrderBy(n => n.Length), str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -5122,7 +5122,9 @@ this.Write(@""")]
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
-                    var resourcePath = global::System.Linq.Enumerable.First(assembly.GetManifestResourceNames().OrderBy(n => n.Length), str => str.EndsWith(filePath));
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -7300,7 +7300,11 @@ this.Write(@""")>  _
             Private Shared Function CreateXmlReader() As Global.System.Xml.XmlReader
                 Try
                     Dim assembly As Global.System.Reflection.Assembly = Global.System.Reflection.Assembly.GetExecutingAssembly()
-                    Dim resourcePath As Global.System.String = Global.System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), Function(str) str.EndsWith(filePath))
+                    ' If multiple resource names end with the file name, select the shortest one.
+                    Dim resourcePath As Global.System.String =
+                        Global.System.Linq.Enumerable.First(
+                            Global.System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), Function(n) n.Length),
+                            Function(str) str.EndsWith(filePath))
                     Dim stream As Global.System.IO.Stream = assembly.GetManifestResourceStream(resourcePath)
                     Return Global.System.Xml.XmlReader.Create(New Global.System.IO.StreamReader(stream))
                 Catch e As Global.System.Xml.XmlException

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -5123,8 +5123,9 @@ this.Write(@""")]
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }
@@ -7303,8 +7304,9 @@ this.Write(@""")>  _
                     ' If multiple resource names end with the file name, select the shortest one.
                     Dim resourcePath As Global.System.String =
                         Global.System.Linq.Enumerable.First(
-                            Global.System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), Function(n) n.Length),
-                            Function(str) str.EndsWith(filePath))
+                            Global.System.Linq.Enumerable.OrderBy(
+                                Global.System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), Function(name) name.EndsWith(filePath)),
+                                Function(filteredName) filteredName.Length))
                     Dim stream As Global.System.IO.Stream = assembly.GetManifestResourceStream(resourcePath)
                     Return Global.System.Xml.XmlReader.Create(New Global.System.IO.StreamReader(stream))
                 Catch e As Global.System.Xml.XmlException

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -4684,7 +4684,9 @@ namespace <#= fullNamespace #>
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
-                    var resourcePath = global::System.Linq.Enumerable.First(assembly.GetManifestResourceNames().OrderBy(n => n.Length), str => str.EndsWith(filePath));
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -4685,8 +4685,9 @@ namespace <#= fullNamespace #>
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }
@@ -5876,8 +5877,9 @@ Namespace <#= fullNamespace #>
                     ' If multiple resource names end with the file name, select the shortest one.
                     Dim resourcePath As Global.System.String =
                         Global.System.Linq.Enumerable.First(
-                            Global.System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), Function(n) n.Length),
-                            Function(str) str.EndsWith(filePath))
+                            Global.System.Linq.Enumerable.OrderBy(
+                                Global.System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), Function(name) name.EndsWith(filePath)),
+                                Function(filteredName) filteredName.Length))
                     Dim stream As Global.System.IO.Stream = assembly.GetManifestResourceStream(resourcePath)
                     Return Global.System.Xml.XmlReader.Create(New Global.System.IO.StreamReader(stream))
                 Catch e As Global.System.Xml.XmlException

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -5873,7 +5873,11 @@ Namespace <#= fullNamespace #>
             Private Shared Function CreateXmlReader() As Global.System.Xml.XmlReader
                 Try
                     Dim assembly As Global.System.Reflection.Assembly = Global.System.Reflection.Assembly.GetExecutingAssembly()
-                    Dim resourcePath As Global.System.String = Global.System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), Function(str) str.EndsWith(filePath))
+                    ' If multiple resource names end with the file name, select the shortest one.
+                    Dim resourcePath As Global.System.String =
+                        Global.System.Linq.Enumerable.First(
+                            Global.System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), Function(n) n.Length),
+                            Function(str) str.EndsWith(filePath))
                     Dim stream As Global.System.IO.Stream = assembly.GetManifestResourceStream(resourcePath)
                     Return Global.System.Xml.XmlReader.Create(New Global.System.IO.StreamReader(stream))
                 Catch e As Global.System.Xml.XmlException

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.ttinclude
@@ -4683,7 +4683,8 @@ namespace <#= fullNamespace #>
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(assembly.GetManifestResourceNames().OrderBy(n => n.Length), str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4EnableInternalProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4EnableInternalProxy.cs
@@ -574,7 +574,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4EnableInternalProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4EnableInternalProxy.cs
@@ -576,8 +576,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4EnableTrackingProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4EnableTrackingProxy.cs
@@ -653,8 +653,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4EnableTrackingProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4EnableTrackingProxy.cs
@@ -651,7 +651,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedBoundOperationsProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedBoundOperationsProxy.cs
@@ -575,7 +575,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedBoundOperationsProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedBoundOperationsProxy.cs
@@ -577,8 +577,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedOperationImportsProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedOperationImportsProxy.cs
@@ -574,7 +574,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedOperationImportsProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedOperationImportsProxy.cs
@@ -576,8 +576,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedSchemaTypesProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedSchemaTypesProxy.cs
@@ -471,8 +471,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedSchemaTypesProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ExcludedSchemaTypesProxy.cs
@@ -469,7 +469,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4MultipleFilesProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4MultipleFilesProxy.cs
@@ -145,8 +145,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4MultipleFilesProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4MultipleFilesProxy.cs
@@ -143,7 +143,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4MultipleOptionsProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4MultipleOptionsProxy.cs
@@ -548,8 +548,9 @@ namespace Client.SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4MultipleOptionsProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4MultipleOptionsProxy.cs
@@ -546,7 +546,10 @@ namespace Client.SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4NamespacePrefixProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4NamespacePrefixProxy.cs
@@ -614,7 +614,10 @@ namespace Client.SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4NamespacePrefixProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4NamespacePrefixProxy.cs
@@ -616,8 +616,9 @@ namespace Client.SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4Proxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4Proxy.cs
@@ -574,7 +574,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4Proxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4Proxy.cs
@@ -576,8 +576,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ServiceNameProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ServiceNameProxy.cs
@@ -574,7 +574,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ServiceNameProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4ServiceNameProxy.cs
@@ -576,8 +576,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4UpperCamelCaseProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4UpperCamelCaseProxy.cs
@@ -646,8 +646,9 @@ namespace SampleServiceV4.Default
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
                     // If multiple resource names end with the file name, select the shortest one.
                     var resourcePath = global::System.Linq.Enumerable.First(
-                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
-                        str => str.EndsWith(filePath));
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4UpperCamelCaseProxy.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/Artifacts/SampleServiceV4UpperCamelCaseProxy.cs
@@ -644,7 +644,10 @@ namespace SampleServiceV4.Default
                 try
                 {
                     var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
-                    var resourcePath = global::System.Linq.Enumerable.Single(assembly.GetManifestResourceNames(), str => str.EndsWith(filePath));
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(assembly.GetManifestResourceNames(), n => n.Length),
+                        str => str.EndsWith(filePath));
                     global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
                     return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
                 }


### PR DESCRIPTION
Fixes #405 

We store the CSDL file as an embedded resource. When we want to load the and parse the CSDL in memory, we find the resource that matches the target CSDL file name. We use `resourceName.EndsWith(filePath)` to find the match. However, this causes a conflict when one CSDL name is a substring of the other, e.g.:

- `OData ServiceCsdl.xml`
- `Another OData ServiceCsdl.xml`

Currently an exception is thrown when such a conflict is detected. This PR fixes this issue by resolving the conflict by selecting the shortest resource name that ends with the target filename.

This solves the problem for simple cases, and possibly all practical common scenarios. However, it would be problematic in the following cases:
- The user manually creates a file called `OData ServiceCsdl.xml` in the same project and adds it as an embedded resource.
- The user renames the embedded resources or folders that were generated by the connected service or code generation tool.

I did not address the concerns because:
- Our code generation tool has the convention of adding the `Csdl.xml` suffix the service name set in the connected service configuration when generating the CSDL file. We do not expect the user to create files with this exact naming convention manually.
- We do not expect users to manually rename any files generated by the code generation tool. Doing so should be considered undefined behaviour.
- It would complicate the code.


The main issue here is that we `EndsWith` to match the files and resources. Why don't we just check the full resource name? The full resource name does not match the file name, it's generated based on the assembly namespace and connected service folder. It as the format: `<Namespace>.Connected_services.OData_Services.<filename>`. I am reluctant to generate a match based on the full resource name because I have not seen an official documentation of this resource naming convention. I am concerned about taking a dependency on a format that's not documented when there other easier alternatives. I don't know if there's a guarantee that this naming convention would not be changed in some future version of Visual Studio or .NET without our knowledge.

### About the tests

Frist, you many notice that while I have updated a lot of generated C# client code in the tests, I have not updated any test generated VB client code. This is because all of the tests in `ODataConnectedServiceTests` test against code that includes the CSDL in the reference code as a string, instead of as a separate file that's compiled as an embedded resource. That code path is not affected by the change in this PR. Only that `OData.Cli.Tests` test this code path. But we don't have any CLI tests for Visual Basic.

That made me realize that the OData CLI does not actually support Visual Basic, despite the fact the documentation says it does. I've created a separate issue to track that: https://github.com/OData/ODataConnectedService/issues/408

Secondly, while we do have tests to verify that the generate code looks as expected and compiles without errors, we don't have tests to verify that the code we generate runs as expected. For example, testing that when you run the generated code with two schemas that have overlapping names does not throw an exception or that the correct schema is selected. We achieve that using manual testing, which is tedious and not enforced consistently. I've created a separate issue to track an E2E testing environment: https://github.com/OData/ODataConnectedService/issues/409