### PR TITLE
UI fixes to allow smoother transitions between pages and paginate schema items

### DIFF
--- a/src/ODataConnectedService.Shared/ViewModels/SchemaTypesViewModel.cs
+++ b/src/ODataConnectedService.Shared/ViewModels/SchemaTypesViewModel.cs
@@ -23,6 +23,16 @@ namespace Microsoft.OData.ConnectedService.ViewModels
     internal class SchemaTypesViewModel : ConnectedServiceWizardPage
     {
         /// <summary>
+        /// Debounces the user input events on the search box so the last event can be executed for pagination.
+        /// </summary>
+        private const int DebounceTimeInMilliseconds = 250;
+        
+        /// <summary>
+        /// Timer for scheduling UI draw events in response to search.
+        /// </summary>
+        private System.Windows.Threading.DispatcherTimer _searchTimer;
+
+        /// <summary>
         /// User settings.
         /// </summary>
         /// <remarks>
@@ -51,12 +61,33 @@ namespace Microsoft.OData.ConnectedService.ViewModels
             set
             {
                 _searchText = value;
-
+                _searchTimer?.Stop();
+                _searchTimer?.Start();
                 this.OnPropertyChanged(nameof(SearchText));
-                this.OnPropertyChanged(nameof(FilteredSchemaTypes));
             }
         }
 
+        /// <summary>
+        /// Schedules the timer to draw after the debounce duration.
+        /// </summary>
+        /// <param name="sender">Event sender.</param>
+        /// <param name="e">Event arguments</param>
+        private void OnSearchTimerTick(object sender, EventArgs e)
+        {
+            _searchTimer?.Stop();
+            RefreshPaginatorView();
+        }
+
+        /// <summary>
+        /// Reloads the paginator in response to user events on the Search text.
+        /// </summary>
+        private void RefreshPaginatorView()
+        {
+            if (this.View is SchemaTypes schemaView)
+            {
+                schemaView.DisplayPage(1);
+            }
+        }
         /// <summary>
         /// Gets the schema types that start with the search text or with it's bound operations start with the search text.
         /// </summary>
@@ -128,8 +159,14 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         /// <param name="args">Event arguments being passed to the method.</param>
         public override async Task OnPageEnteringAsync(WizardEnteringArgs args)
         {
+            _searchTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(DebounceTimeInMilliseconds)
+            };
+            _searchTimer.Tick += OnSearchTimerTick;
+
             this.IsEntered = true;
-            await base.OnPageEnteringAsync(args).ConfigureAwait(false);
+            await base.OnPageEnteringAsync(args);
             View = new SchemaTypes() { DataContext = this };
             PageEntering?.Invoke(this, EventArgs.Empty);
             if (this.View is SchemaTypes view)
@@ -138,6 +175,8 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                 view.SelectedBoundOperationsCount.Text = SchemaTypes
                     .Where(x => x.IsSelected && x.BoundOperations?.Any() == true).SelectMany(x => x.BoundOperations)
                     .Count(x => x.IsSelected).ToString(CultureInfo.InvariantCulture);
+
+                view.DisplayPage(1);
             }
         }
 

--- a/src/ODataConnectedService.Shared/ViewModels/SchemaTypesViewModel.cs
+++ b/src/ODataConnectedService.Shared/ViewModels/SchemaTypesViewModel.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
         /// Debounces the user input events on the search box so the last event can be executed for pagination.
         /// </summary>
         private const int DebounceTimeInMilliseconds = 250;
-        
+
         /// <summary>
         /// Timer for scheduling UI draw events in response to search.
         /// </summary>
@@ -88,6 +88,7 @@ namespace Microsoft.OData.ConnectedService.ViewModels
                 schemaView.DisplayPage(1);
             }
         }
+
         /// <summary>
         /// Gets the schema types that start with the search text or with it's bound operations start with the search text.
         /// </summary>

--- a/src/ODataConnectedService.Shared/Views/OperationImports.xaml
+++ b/src/ODataConnectedService.Shared/Views/OperationImports.xaml
@@ -82,6 +82,12 @@
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
+        <!-- Pagination Controls -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Bottom">
+            <Button Content="Previous" Click="PreviousButton_Click" Margin="5"/>
+            <TextBlock x:Name="PageInfoTextBlock" VerticalAlignment="Center" Margin="5"/>
+            <Button Content="Next" Click="NextButton_Click" Margin="5"/>
+        </StackPanel>
         <DockPanel Margin="0,5,0,0">
             <CheckBox
                 x:Name="ShowReturnTypeAndParameters"

--- a/src/ODataConnectedService.Shared/Views/OperationImports.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/OperationImports.xaml.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OData.ConnectedService.Views
     public partial class OperationImports : UserControl
     {
         private int currentPage = 1;
-        private int itemsPerPage = 50;
+        private readonly int itemsPerPage = 50;
         public OperationImports()
         {
             InitializeComponent();
@@ -34,6 +34,7 @@ namespace Microsoft.OData.ConnectedService.Views
         /// <param name="pageNumber">The page to view indexes start from 1.</param>
         public void DisplayPage(int pageNumber)
         {
+            pageNumber = pageNumber < 1 ? 1 : pageNumber;
             int startIndex = (pageNumber - 1) * itemsPerPage;
             int endIndex = startIndex + itemsPerPage;
 

--- a/src/ODataConnectedService.Shared/Views/OperationImports.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/OperationImports.xaml.cs
@@ -1,18 +1,8 @@
 ﻿using Microsoft.OData.ConnectedService.ViewModels;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace Microsoft.OData.ConnectedService.Views
 {
@@ -21,6 +11,8 @@ namespace Microsoft.OData.ConnectedService.Views
     /// </summary>
     public partial class OperationImports : UserControl
     {
+        private int currentPage = 1;
+        private int itemsPerPage = 50;
         public OperationImports()
         {
             InitializeComponent();
@@ -34,6 +26,53 @@ namespace Microsoft.OData.ConnectedService.Views
         private void SelectAll_Click(object sender, RoutedEventArgs e)
         {
             (DataContext as OperationImportsViewModel).SelectAll();
+        }
+
+        /// <summary>
+        /// Paginates data for schema types to allow the UI to render only one page of items at a time making the UI more responsive.
+        /// </summary>
+        /// <param name="pageNumber">The page to view indexes start from 1.</param>
+        public void DisplayPage(int pageNumber)
+        {
+            int startIndex = (pageNumber - 1) * itemsPerPage;
+            int endIndex = startIndex + itemsPerPage;
+
+            var items = (DataContext as OperationImportsViewModel)?.FilteredOperationImports;
+            endIndex = endIndex > items.Count() ? items.Count() : endIndex;
+
+            // Get the items for the current page
+            var pageItems = items.Skip(startIndex).Take(endIndex - startIndex);
+
+            OperationImportsList.ItemsSource = pageItems;
+
+            // Update the page info
+            PageInfoTextBlock.Text = $"Page {pageNumber} of {Math.Ceiling((double)items.Count() / itemsPerPage)}";
+        }
+
+        /// <summary>
+        /// Event handler that moves to the next page while ensuring to check bounds.
+        /// </summary>
+        private void NextButton_Click(object sender, RoutedEventArgs e)
+        {
+            var items = (DataContext as OperationImportsViewModel)?.FilteredOperationImports;
+
+            if (currentPage * itemsPerPage < items.Count())
+            {
+                currentPage++;
+                DisplayPage(currentPage);
+            }
+        }
+
+        /// <summary>
+        /// Event handler that moves to the previous page while ensuring to check bounds.
+        /// </summary>
+        private void PreviousButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (currentPage > 1)
+            {
+                currentPage--;
+                DisplayPage(currentPage);
+            }
         }
     }
 }

--- a/src/ODataConnectedService.Shared/Views/SchemaTypes.xaml
+++ b/src/ODataConnectedService.Shared/Views/SchemaTypes.xaml
@@ -158,6 +158,12 @@
                 </HierarchicalDataTemplate>
             </TreeView.ItemTemplate>
         </TreeView>
+        <!-- Pagination Controls -->
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Bottom">
+            <Button Content="Previous" Click="PreviousButton_Click" Margin="5"/>
+            <TextBlock x:Name="PageInfoTextBlock" VerticalAlignment="Center" Margin="5"/>
+            <Button Content="Next" Click="NextButton_Click" Margin="5"/>
+        </StackPanel>
         <StackPanel Margin="0,5,0,5" Orientation="Horizontal">
             <Button
                 x:Name="SelectAllBoundOperations"

--- a/src/ODataConnectedService.Shared/Views/SchemaTypes.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/SchemaTypes.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OData.ConnectedService.ViewModels;
 using System.Windows;
 using System.Windows.Controls;
@@ -12,6 +14,9 @@ namespace Microsoft.OData.ConnectedService.Views
     /// </summary>
     public partial class SchemaTypes : UserControl
     {
+        private int currentPage = 1;
+        private int itemsPerPage = 50;
+
         public SchemaTypes()
         {
             InitializeComponent();
@@ -67,6 +72,54 @@ namespace Microsoft.OData.ConnectedService.Views
         private void DeselectAllBoundOperations_Click(object sender, RoutedEventArgs e)
         {
             (DataContext as SchemaTypesViewModel)?.DeselectAllBoundOperations();
+        }
+
+        /// <summary>
+        /// Paginates data for schema types to allow the UI to render only one page of items at a time making the UI more responsive.
+        /// </summary>
+        /// <param name="pageNumber">The page to view indexes start from 1.</param>
+        public void DisplayPage(int pageNumber)
+        {
+            int startIndex = (pageNumber - 1) * itemsPerPage;
+            int endIndex = startIndex + itemsPerPage;
+
+            var items = (DataContext as SchemaTypesViewModel)?.FilteredSchemaTypes;
+            endIndex = endIndex > items.Count() ? items.Count() : endIndex;
+
+            // Get the items for the current page
+            var pageItems = items.Skip(startIndex).Take(endIndex - startIndex);
+
+            // Bind the items to the ListBox
+            SchemaTypesTreeView.ItemsSource = pageItems;
+
+            // Update the page info
+            PageInfoTextBlock.Text = $"Page {pageNumber} of {Math.Ceiling((double)items.Count() / itemsPerPage)}";
+        }
+
+        /// <summary>
+        /// Event handler that moves to the next page while ensuring to check bounds.
+        /// </summary>
+        private void NextButton_Click(object sender, RoutedEventArgs e)
+        {
+            var items = (DataContext as SchemaTypesViewModel)?.FilteredSchemaTypes;
+
+            if (currentPage * itemsPerPage < items.Count())
+            {
+                currentPage++;
+                DisplayPage(currentPage);
+            }
+        }
+
+        /// <summary>
+        /// Event handler that moves to the previous page while ensuring to check bounds.
+        /// </summary>
+        private void PreviousButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (currentPage > 1)
+            {
+                currentPage--;
+                DisplayPage(currentPage);
+            }
         }
     }
 }

--- a/src/ODataConnectedService.Shared/Views/SchemaTypes.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/SchemaTypes.xaml.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.ConnectedService.Views
     public partial class SchemaTypes : UserControl
     {
         private int currentPage = 1;
-        private int itemsPerPage = 50;
+        private readonly int itemsPerPage = 50;
 
         public SchemaTypes()
         {
@@ -80,6 +80,7 @@ namespace Microsoft.OData.ConnectedService.Views
         /// <param name="pageNumber">The page to view indexes start from 1.</param>
         public void DisplayPage(int pageNumber)
         {
+            pageNumber = pageNumber < 1 ? 1 : pageNumber;
             int startIndex = (pageNumber - 1) * itemsPerPage;
             int endIndex = startIndex + itemsPerPage;
 

--- a/src/ODataConnectedService/source.extension.vsixmanifest
+++ b/src/ODataConnectedService/source.extension.vsixmanifest
@@ -2,7 +2,6 @@
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
         <Identity Id="ODataConnectedService.e30335d6-f9c7-4d08-b66a-f011f3f18477" Version="1.1.0" Language="en-US" Publisher="OData Labs" />
-        <Author>Microsoft</Author>
         <DisplayName>OData Connected Service</DisplayName>
         <Description xml:space="preserve">OData Connected Service for V1-V4</Description>
         <MoreInfo>https://github.com/odata/ODataConnectedService</MoreInfo>

--- a/src/ODataConnectedService_VS2022Plus/ODataConnectedService_VS2022Plus.csproj
+++ b/src/ODataConnectedService_VS2022Plus/ODataConnectedService_VS2022Plus.csproj
@@ -89,22 +89,22 @@
     <PackageReference Include="Microsoft.OData.Edm">
       <Version>7.6.3</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.9.37000" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.11.40262" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.ConnectedServices">
       <Version>16.2.45</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.3.32804.24</Version>
+      <Version>17.11.40262</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.10.2179</Version>
+      <Version>17.11.435</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.VisualStudio">
-      <Version>17.6.0</Version>
+      <Version>17.11.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -111,10 +111,10 @@
       <Version>16.2.45</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.9.37000</Version>
+      <Version>17.11.40262</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.9.3168</Version>
+      <Version>17.11.435</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -128,7 +128,7 @@
       <Version>1.3.2</Version>
     </PackageReference>
     <PackageReference Include="NuGet.VisualStudio">
-      <Version>17.6.0</Version>
+      <Version>17.11.0</Version>
     </PackageReference>
     <PackageReference Include="System.ComponentModel.Annotations">
       <Version>4.5.0</Version>

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -1083,8 +1083,16 @@ namespace ODataConnectedService.Tests
         [Fact]
         public void LoadSchemaTypes_ShouldOnlyShowItemsInPaginator()
         {
-            using (var viewModel = new SchemaTypesViewModel())
+            ServiceConfigurationV4 savedConfig = GetTestConfig();
+            var context = new TestConnectedServiceProviderContext(true, savedConfig);
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
+                var endpointPage = wizard.ConfigODataEndpointViewModel;
+                endpointPage.UserSettings.Endpoint = MetadataPathV3;
+                endpointPage.OnPageLeavingAsync(null).Wait();
+
+                var viewModel = wizard.SchemaTypesViewModel;
+
                 var listToLoad = Enumerable.Range(1, 80)
                     .Select(x => new string(Enumerable.Repeat('A', x).ToArray()))
                     .Select(name => new EdmEntityType("Test", name)).ToArray();
@@ -1107,8 +1115,14 @@ namespace ODataConnectedService.Tests
         [Fact]
         public void LoadOperationTypes_ShouldOnlyShowItemsInPaginator()
         {
-            using (var viewModel = new OperationImportsViewModel())
+            ServiceConfigurationV4 savedConfig = GetTestConfig();
+            var context = new TestConnectedServiceProviderContext(true, savedConfig);
+            using (var wizard = new ODataConnectedServiceWizard(context))
             {
+                var endpointPage = wizard.ConfigODataEndpointViewModel;
+                endpointPage.UserSettings.Endpoint = MetadataPathV3;
+                endpointPage.OnPageLeavingAsync(null).Wait();
+                var viewModel = wizard.OperationImportsViewModel;
 
                 var container = new EdmEntityContainer("Test", "Default");
                 var listToLoad = new List<IEdmOperationImport>(Enumerable.Range(1, 80)

--- a/test/ODataConnectedService.Tests/ViewModels/OperationImportsViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/OperationImportsViewModelTests.cs
@@ -12,6 +12,7 @@ using Microsoft.OData.ConnectedService.ViewModels;
 using Microsoft.OData.Edm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FluentAssertions;
+using Microsoft.OData.ConnectedService.Views;
 
 namespace ODataConnectedService.Tests.ViewModels
 {
@@ -211,6 +212,33 @@ namespace ODataConnectedService.Tests.ViewModels
                     new OperationImportModel { Name = "Func1", IsSelected = true },
                     new OperationImportModel { Name = "AnotherFunc2", IsSelected = true }
                 });
+            }
+        }
+
+        [TestMethod]
+        public void LoadSchemaTypes_ShouldOnlyShowItemsInPaginator()
+        {
+            using (var viewModel = new OperationImportsViewModel())
+            {
+
+                var container = new EdmEntityContainer("Test", "Default");
+                var listToLoad = new List<IEdmOperationImport>(Enumerable.Range(1, 80)
+                    .Select(x => new string(Enumerable.Repeat('A', x).ToArray()))
+                    .Select(name => new EdmActionImport(container, name, new EdmAction("Test",name, null))));
+
+                viewModel.LoadOperationImports(listToLoad, new HashSet<string>(), new Dictionary<string, SchemaTypeModel>());
+
+
+                viewModel.OnPageEnteringAsync(null).Wait();
+                Assert.AreEqual(viewModel.OperationImports.Count(), listToLoad.Count);
+                var view = viewModel.View as OperationImports;
+                Assert.IsNotNull(viewModel);
+                Assert.AreEqual(view.OperationImportsList.Items.Count, 50);
+                Assert.AreEqual(view.PageInfoTextBlock.Text, "Page 1 of 2");
+
+                view.DisplayPage(2);
+                Assert.AreEqual(view.OperationImportsList.Items.Count, 30);
+                Assert.AreEqual(view.PageInfoTextBlock.Text, "Page 2 of 2");
             }
         }
     }

--- a/test/ODataConnectedService.Tests/ViewModels/OperationImportsViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/OperationImportsViewModelTests.cs
@@ -213,33 +213,6 @@ namespace ODataConnectedService.Tests.ViewModels
                     new OperationImportModel { Name = "AnotherFunc2", IsSelected = true }
                 });
             }
-        }
-
-        [TestMethod]
-        public void LoadSchemaTypes_ShouldOnlyShowItemsInPaginator()
-        {
-            using (var viewModel = new OperationImportsViewModel())
-            {
-
-                var container = new EdmEntityContainer("Test", "Default");
-                var listToLoad = new List<IEdmOperationImport>(Enumerable.Range(1, 80)
-                    .Select(x => new string(Enumerable.Repeat('A', x).ToArray()))
-                    .Select(name => new EdmActionImport(container, name, new EdmAction("Test",name, null))));
-
-                viewModel.LoadOperationImports(listToLoad, new HashSet<string>(), new Dictionary<string, SchemaTypeModel>());
-
-
-                viewModel.OnPageEnteringAsync(null).Wait();
-                Assert.AreEqual(viewModel.OperationImports.Count(), listToLoad.Count);
-                var view = viewModel.View as OperationImports;
-                Assert.IsNotNull(viewModel);
-                Assert.AreEqual(view.OperationImportsList.Items.Count, 50);
-                Assert.AreEqual(view.PageInfoTextBlock.Text, "Page 1 of 2");
-
-                view.DisplayPage(2);
-                Assert.AreEqual(view.OperationImportsList.Items.Count, 30);
-                Assert.AreEqual(view.PageInfoTextBlock.Text, "Page 2 of 2");
-            }
-        }
+        }        
     }
 }

--- a/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using FluentAssertions;
 using Microsoft.OData.CodeGen.Models;
 using Microsoft.OData.ConnectedService.ViewModels;
+using Microsoft.OData.ConnectedService.Views;
 using Microsoft.OData.Edm;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -922,6 +923,30 @@ namespace ODataConnectedService.Tests.ViewModels
                         }
                     }
                 });
+            }
+        }
+
+        [TestMethod]
+        public void LoadSchemaTypes_ShouldOnlyShowItemsInPaginator()
+        {
+            using (var viewModel = new SchemaTypesViewModel())
+            {
+                var listToLoad = Enumerable.Range(1, 80)
+                    .Select(x => new string(Enumerable.Repeat('A', x).ToArray()))
+                    .Select(name => new EdmEntityType("Test", name)).ToArray();
+        
+                viewModel.LoadSchemaTypes(listToLoad, new Dictionary<IEdmType, List<IEdmOperation>>());
+
+                viewModel.OnPageEnteringAsync(null).Wait();
+                Assert.AreEqual(viewModel.SchemaTypes.Count(), listToLoad.Length);
+                var view = viewModel.View as SchemaTypes;
+                Assert.IsNotNull(viewModel);
+                Assert.AreEqual(view.SchemaTypesTreeView.Items.Count, 50);
+                Assert.AreEqual(view.PageInfoTextBlock.Text, "Page 1 of 2");
+
+                view.DisplayPage(2);
+                Assert.AreEqual(view.SchemaTypesTreeView.Items.Count, 30);
+                Assert.AreEqual(view.PageInfoTextBlock.Text, "Page 2 of 2");
             }
         }
     }

--- a/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
+++ b/test/ODataConnectedService.Tests/ViewModels/SchemaTypesViewModelTests.cs
@@ -925,29 +925,5 @@ namespace ODataConnectedService.Tests.ViewModels
                 });
             }
         }
-
-        [TestMethod]
-        public void LoadSchemaTypes_ShouldOnlyShowItemsInPaginator()
-        {
-            using (var viewModel = new SchemaTypesViewModel())
-            {
-                var listToLoad = Enumerable.Range(1, 80)
-                    .Select(x => new string(Enumerable.Repeat('A', x).ToArray()))
-                    .Select(name => new EdmEntityType("Test", name)).ToArray();
-        
-                viewModel.LoadSchemaTypes(listToLoad, new Dictionary<IEdmType, List<IEdmOperation>>());
-
-                viewModel.OnPageEnteringAsync(null).Wait();
-                Assert.AreEqual(viewModel.SchemaTypes.Count(), listToLoad.Length);
-                var view = viewModel.View as SchemaTypes;
-                Assert.IsNotNull(viewModel);
-                Assert.AreEqual(view.SchemaTypesTreeView.Items.Count, 50);
-                Assert.AreEqual(view.PageInfoTextBlock.Text, "Page 1 of 2");
-
-                view.DisplayPage(2);
-                Assert.AreEqual(view.SchemaTypesTreeView.Items.Count, 30);
-                Assert.AreEqual(view.PageInfoTextBlock.Text, "Page 2 of 2");
-            }
-        }
     }
 }


### PR DESCRIPTION
Breaks the UI code from the Async refactor in https://github.com/OData/ODataConnectedService/pull/411 

I added a simple paginator to improve the draw events on the schema page and operation imports page to reduce drawing overhead and increase how responsive the UI is.

The model since it is used severally in the Wizard the results are now cached after transitioning from the ConfigureODataModel page. So moving forward will ensure the UI responds smoothly eliminating IO.

with pagination.
![image](https://github.com/user-attachments/assets/fa34d63f-7465-4488-b348-482e958eb75c)

Paginator with filter
![image](https://github.com/user-attachments/assets/03bc871e-a0d5-4f10-9dc2-bba6fc15d800)
![image](https://github.com/user-attachments/assets/337a8fe1-dbdd-4521-8da5-a5d3b3d68896)


