### PR TITLE
Remove managed identity from Azure key vault commands and fix invalid glob pattern

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,7 +198,6 @@ stages:
                 --publisher-name "OData Labs" `
                 --description "OData Connected Service" `
                 --description-url "https://github.com/OData/ODataConnectedService" `
-                --azure-key-vault-managed-identity `
                 --azure-key-vault-certificate "$(SignKeyVaultCertificate)" `
                 --azure-key-vault-url "$(SignKeyVaultUrl)"
             displayName: Code signing - VSIX
@@ -248,7 +247,6 @@ stages:
                 --publisher-name "OData Labs" `
                 --description "OData Connected Service 2022+" `
                 --description-url "https://github.com/OData/ODataConnectedService" `
-                --azure-key-vault-managed-identity `
                 --azure-key-vault-certificate "$(SignKeyVaultCertificate)" `
                 --azure-key-vault-url "$(SignKeyVaultUrl)"
             displayName: Code signing - VSIX2022Plus
@@ -304,14 +302,13 @@ stages:
               scriptLocation: inlineScript
               inlineScript: |
                 .\sign code azure-key-vault `
-                "**/*.{{dll,exe,zip,nupkg}}" `
+                "**/*.{dll,exe,zip,nupkg}" `
                 --base-directory "$(Pipeline.Workspace)\ODataCLINupkg" `
                 --output "$(Build.ArtifactStagingDirectory)\SignedODataCLINupkg" `
                 --file-list "$(Pipeline.Workspace)\configs\filelist.txt" `
                 --publisher-name "OData Labs" `
                 --description "OData CLI" `
                 --description-url "https://github.com/OData/ODataConnectedService" `
-                --azure-key-vault-managed-identity `
                 --azure-key-vault-certificate "$(SignKeyVaultCertificate)" `
                 --azure-key-vault-url "$(SignKeyVaultUrl)"
             displayName: Code signing - ODataCLINupkg              


### PR DESCRIPTION
Addresses the following warning in the build logs:
```
2026-04-01T09:01:09.0731433Z The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.
```

Also fixes invalid glob pattern causing signing of OData CLI package to fail:
`**/*.{{dll,exe,zip,nupkg}}` => `**/*.{dll,exe,zip,nupkg}`