### PR TITLE
Update odata-cli to target .NET 8 and .NET 10

### DIFF
--- a/src/Microsoft.OData.Cli/Microsoft.OData.Cli.csproj
+++ b/src/Microsoft.OData.Cli/Microsoft.OData.Cli.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>odata-cli</ToolCommandName>
     <RootNamespace>Microsoft.OData.Cli</RootNamespace>
     <AssemblyName>Microsoft.OData.Cli</AssemblyName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <Version>0.3.1</Version>
+    <Version>0.4.0</Version>
     <Authors>Microsoft</Authors>
     <Product>Microsoft.OData.Cli</Product>
     <Description>The odata-cli is a CLI tool for generating strongly typed C# and Visual Basic client code for a specified OData service. It generates a DataServiceContext class to interact with the service and CLR types for each entity type and complex type in the service model. It does exactly what the OData Connected Service does.  </Description>
@@ -24,10 +24,14 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="NuGet.PackageManagement" Version="6.1.0" />
     <PackageReference Include="NuGet.Protocol" Version="6.3.3" />
+    <!-- NuGet.Frameworks ships inside the .NET SDK/MSBuild. Let the SDK provide it at runtime
+         (resolved via MSBuildLocator) instead of shipping our own copy, which would conflict with
+         the SDK's MSBuild assemblies (MSBuildLocator diagnostic MSBL001). -->
+    <PackageReference Include="NuGet.Frameworks" Version="6.3.3" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="System.CodeDom" Version="7.0.0-preview.1.22076.8" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />

--- a/src/Microsoft.OData.Cli/Program.cs
+++ b/src/Microsoft.OData.Cli/Program.cs
@@ -7,7 +7,10 @@ namespace Microsoft.OData.Cli
     {
         static async Task Main(string[] args)
         {
-            Build.Locator.MSBuildLocator.RegisterDefaults();
+            if (!Build.Locator.MSBuildLocator.IsRegistered)
+            {
+                Build.Locator.MSBuildLocator.RegisterDefaults();
+            }
             GenerateCommand generateCommand = new GenerateCommand();
             RootCommand app = new RootCommand {
                 generateCommand

--- a/test/Microsoft.OData.Cli.Tests/MSBuildRegistration.cs
+++ b/test/Microsoft.OData.Cli.Tests/MSBuildRegistration.cs
@@ -1,0 +1,31 @@
+//-----------------------------------------------------------------------------------
+// <copyright file="MSBuildRegistration.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using Microsoft.Build.Locator;
+
+namespace Microsoft.OData.Cli.Tests
+{
+    /// <summary>
+    /// Registers the MSBuild assemblies from the running .NET SDK before any test exercises the
+    /// <c>Microsoft.Build.Evaluation</c> APIs (as the CLI does via <c>ProjectHelper</c> when handling
+    /// the <c>generate</c> command). This mirrors the registration performed in <c>Program.Main</c>.
+    /// Without it the test host has no MSBuild instance registered and the code-generation tests fail
+    /// with "No instances of MSBuild could be detected".
+    /// </summary>
+    internal static class MSBuildRegistration
+    {
+        [ModuleInitializer]
+        internal static void Register()
+        {
+            if (!MSBuildLocator.IsRegistered)
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
+        }
+    }
+}

--- a/test/Microsoft.OData.Cli.Tests/Microsoft.OData.Cli.Tests.csproj
+++ b/test/Microsoft.OData.Cli.Tests/Microsoft.OData.Cli.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -57,11 +57,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.11.2" />
+    <!-- NuGet.Frameworks flows in transitively (via the CLI's NuGet client packages); it ships with
+         the SDK/MSBuild, so exclude its runtime asset here too to satisfy MSBuildLocator (MSBL001). -->
+    <PackageReference Include="NuGet.Frameworks" Version="6.3.3" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #429
Fixes #324
Fixes #428
Fixes #448

`odata-cli` targets `net6.0`, which is out of support, so it crashes on startup with "No instances of MSBuild could be detected" when no net6 SDK is installed.

Multi-targets the CLI (and its tests) to `net8.0;net10.0` and bumps `Microsoft.Build.Locator` to 1.11.2 so it locates the installed SDK's MSBuild. Also fixes the test project to register MSBuild — the part #432 missed that failed CI — and bumps the version to 0.4.0.

Tests pass on net8.0 and net10.0, and the packed tool runs `generate` on a .NET 8/10-only machine without the crash.
