### PR TITLE
Harden DateOnly/TimeOnly version detection, modernize NuGet APIs, and add E2E coverage

### DIFF
--- a/src/Microsoft.OData.Cli/Microsoft.OData.Cli.csproj
+++ b/src/Microsoft.OData.Cli/Microsoft.OData.Cli.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.OData.Cli</RootNamespace>
     <AssemblyName>Microsoft.OData.Cli</AssemblyName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
     <Authors>Microsoft</Authors>
     <Product>Microsoft.OData.Cli</Product>
     <Description>The odata-cli is a CLI tool for generating strongly typed C# and Visual Basic client code for a specified OData service. It generates a DataServiceContext class to interact with the service and CLR types for each entity type and complex type in the service model. It does exactly what the OData Connected Service does.  </Description>

--- a/src/Microsoft.OData.Cli/ODataCliFileHandler.cs
+++ b/src/Microsoft.OData.Cli/ODataCliFileHandler.cs
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Cli
         /// <returns>A bool indicating whether to emit native date and time types or not</returns>
         public Task<bool> EmitNativeDateTimeTypesAsync()
         {
-            return Task.FromResult(this.project.CheckODataClientVersion());
+            return this.project.CheckODataClientVersionAsync(this.logger);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Cli/ODataCliMessageLogger.cs
+++ b/src/Microsoft.OData.Cli/ODataCliMessageLogger.cs
@@ -37,9 +37,10 @@ namespace Microsoft.OData.Cli
         /// <returns>A completed Task</returns>
         public Task WriteMessageAsync(LogMessageCategory logMessageCategory, string message, params object[] args)
         {
-            if (logMessageCategory == LogMessageCategory.Error)
+            if (logMessageCategory == LogMessageCategory.Error || logMessageCategory == LogMessageCategory.Warning)
             {
-                this.console.Error.Write(message + "\n");
+                string prefix = logMessageCategory == LogMessageCategory.Warning ? "Warning: " : string.Empty;
+                this.console.Error.Write(prefix + message + "\n");
             }
             else if (logMessageCategory == LogMessageCategory.Information)
             {

--- a/src/Microsoft.OData.Cli/ProjectHelper.cs
+++ b/src/Microsoft.OData.Cli/ProjectHelper.cs
@@ -243,11 +243,7 @@ namespace Microsoft.OData.Cli
                     }
                 }
             }
-            catch (IOException)
-            {
-                return false;
-            }
-            catch (JsonException)
+            catch (Exception)
             {
                 return false;
             }

--- a/src/Microsoft.OData.Cli/ProjectHelper.cs
+++ b/src/Microsoft.OData.Cli/ProjectHelper.cs
@@ -9,7 +9,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.Build.Evaluation;
+using Microsoft.OData.CodeGen.Common;
+using Microsoft.OData.CodeGen.Logging;
+using NuGet.Versioning;
 
 namespace Microsoft.OData.Cli
 {
@@ -149,28 +154,128 @@ namespace Microsoft.OData.Cli
         /// </summary>
         /// <param name="project">An instance of the loaded <see cref="Project"/>.</param>
         /// <returns>True if the Microsoft.OData.Client version is at least 9.0.0; otherwise, false.</returns>
-        internal static bool CheckODataClientVersion(this Project project)
+        internal static async Task<bool> CheckODataClientVersionAsync(this Project project, IMessageLogger logger)
         {
             if (project == null)
             {
                 return false;
             }
 
-            var version = project.GetItems("PackageReference")
-                .FirstOrDefault(pr => pr.EvaluatedInclude.Equals("Microsoft.OData.Client", StringComparison.OrdinalIgnoreCase))
-                ?.GetMetadataValue("Version");
+            ProjectItem packageReference = project.GetItems("PackageReference")
+                .FirstOrDefault(pr => pr.EvaluatedInclude.Equals(Constants.V4ClientNuGetPackage, StringComparison.OrdinalIgnoreCase));
 
-            if (string.IsNullOrEmpty(version))
+            if (packageReference == null)
             {
                 return false;
             }
 
-            if (version.Contains('-'))
+            if (TryGetODataClientVersion(project, packageReference, out Version version))
             {
-                version = version.Substring(0, version.IndexOf("-"));
+                return ODataClientVersionChecker.SupportsNativeDateTimeTypes(version);
             }
 
-            return Version.TryParse(version, out Version odataClientVersion) && odataClientVersion >= Version.Parse("9.0.0");
+            if (logger != null)
+            {
+                await logger.WriteMessageAsync(
+                    LogMessageCategory.Warning,
+                    "Microsoft.OData.Client is referenced, but its version could not be resolved. Legacy date and time types will be generated.")
+                    .ConfigureAwait(false);
+            }
+
+            return false;
+        }
+
+        private static bool TryGetODataClientVersion(Project project, ProjectItem packageReference, out Version version)
+        {
+            if (TryGetVersionFromAssetsFile(project, out version))
+            {
+                return true;
+            }
+
+            if (TryParseVersionExpression(packageReference.GetMetadataValue("VersionOverride"), out version))
+            {
+                return true;
+            }
+
+            ProjectItem packageVersion = project.GetItems("PackageVersion")
+                .FirstOrDefault(item => item.EvaluatedInclude.Equals(Constants.V4ClientNuGetPackage, StringComparison.OrdinalIgnoreCase));
+            if (packageVersion != null && TryParseVersionExpression(packageVersion.GetMetadataValue("Version"), out version))
+            {
+                return true;
+            }
+
+            return TryParseVersionExpression(packageReference.GetMetadataValue("Version"), out version);
+        }
+
+        private static bool TryGetVersionFromAssetsFile(Project project, out Version version)
+        {
+            version = null;
+            string assetsFile = project.GetPropertyValue("ProjectAssetsFile");
+            if (string.IsNullOrWhiteSpace(assetsFile))
+            {
+                assetsFile = Path.Combine(project.DirectoryPath, "obj", "project.assets.json");
+            }
+
+            if (!File.Exists(assetsFile))
+            {
+                return false;
+            }
+
+            try
+            {
+                using (JsonDocument document = JsonDocument.Parse(File.ReadAllText(assetsFile)))
+                {
+                    if (!document.RootElement.TryGetProperty("libraries", out JsonElement libraries))
+                    {
+                        return false;
+                    }
+
+                    foreach (JsonProperty library in libraries.EnumerateObject())
+                    {
+                        int separatorIndex = library.Name.LastIndexOf('/');
+                        if (separatorIndex <= 0 ||
+                            !library.Name.Substring(0, separatorIndex).Equals(Constants.V4ClientNuGetPackage, StringComparison.OrdinalIgnoreCase))
+                        {
+                            continue;
+                        }
+
+                        return TryParseVersionExpression(library.Name.Substring(separatorIndex + 1), out version);
+                    }
+                }
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
+
+            return false;
+        }
+
+        private static bool TryParseVersionExpression(string versionExpression, out Version version)
+        {
+            version = null;
+            if (string.IsNullOrWhiteSpace(versionExpression))
+            {
+                return false;
+            }
+
+            if (NuGetVersion.TryParse(versionExpression, out NuGetVersion nuGetVersion))
+            {
+                version = nuGetVersion.Version;
+                return true;
+            }
+
+            if (VersionRange.TryParse(versionExpression, out VersionRange versionRange) && versionRange.MinVersion != null)
+            {
+                version = versionRange.MinVersion.Version;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.OData.CodeGen/Common/ODataClientVersionChecker.cs
+++ b/src/Microsoft.OData.CodeGen/Common/ODataClientVersionChecker.cs
@@ -1,0 +1,51 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataClientVersionChecker.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//----------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.OData.CodeGen.Common
+{
+    /// <summary>
+    /// Evaluates capabilities provided by Microsoft.OData.Client versions.
+    /// </summary>
+    public static class ODataClientVersionChecker
+    {
+        /// <summary>
+        /// The first Microsoft.OData.Client version that supports System.DateOnly and System.TimeOnly.
+        /// </summary>
+        public static readonly Version NativeDateTimeTypesMinimumVersion = new Version(9, 0, 0);
+
+        /// <summary>
+        /// Determines whether a client version supports native date and time types.
+        /// </summary>
+        /// <param name="version">The Microsoft.OData.Client version.</param>
+        /// <returns>True when native date and time types are supported; otherwise, false.</returns>
+        public static bool SupportsNativeDateTimeTypes(Version version)
+        {
+            return version != null && version >= NativeDateTimeTypesMinimumVersion;
+        }
+
+        /// <summary>
+        /// Parses a NuGet or assembly version, ignoring prerelease and build metadata.
+        /// </summary>
+        /// <param name="version">The version string.</param>
+        /// <param name="parsedVersion">The parsed version.</param>
+        /// <returns>True when the version can be parsed; otherwise, false.</returns>
+        public static bool TryParseVersion(string version, out Version parsedVersion)
+        {
+            parsedVersion = null;
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                return false;
+            }
+
+            int suffixIndex = version.IndexOfAny(new[] { '-', '+' });
+            string normalizedVersion = suffixIndex >= 0 ? version.Substring(0, suffixIndex) : version;
+            return Version.TryParse(normalizedVersion, out parsedVersion);
+        }
+    }
+}

--- a/src/Microsoft.OData.CodeGen/Microsoft.OData.CodeGen.csproj
+++ b/src/Microsoft.OData.CodeGen/Microsoft.OData.CodeGen.csproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <Compile Include="Common\LanguageOption.cs" />
     <Compile Include="Common\MetadataReader.cs" />
+    <Compile Include="Common\ODataClientVersionChecker.cs" />
     <Compile Include="FileHandling\IFileHandler.cs" />
     <Compile Include="FileHandling\ODataFileOptions.cs" />
     <Compile Include="Logging\IMessageLogger.cs" />

--- a/src/ODataConnectedService.Shared/ConnectedServiceFileHandler.cs
+++ b/src/ODataConnectedService.Shared/ConnectedServiceFileHandler.cs
@@ -6,14 +6,28 @@
 //----------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using EnvDTE;
+using Microsoft.OData.CodeGen.Common;
 using Microsoft.OData.CodeGen.FileHandling;
+using Microsoft.OData.CodeGen.Logging;
 using Microsoft.OData.ConnectedService.Threading;
+using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ConnectedServices;
 using Microsoft.VisualStudio.Shell;
+using NuGet.VisualStudio;
 using VSLangProj;
 using Task = System.Threading.Tasks.Task;
+#if VS2022PLUS
+using System.Threading;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using NuGet.VisualStudio.Contracts;
+#endif
 
 namespace Microsoft.OData.ConnectedService
 {
@@ -24,10 +38,14 @@ namespace Microsoft.OData.ConnectedService
     {
         private ConnectedServiceHandlerContext Context;
         private readonly IThreadHelper threadHelper;
+        private readonly IMessageLogger messageLogger;
+        private readonly IInstalledPackagesProvider packagesProvider;
 
-        // Cache the OData Client version to avoid multiple project references enumeration
+        // Cache the OData Client version to avoid multiple installed-package queries.
         private Version odataClientVersion = null;
         private bool isOdataClientVersionCached = false;
+        private bool isOdataClientPackageInstalled = false;
+        private bool versionResolutionWarningLogged = false;
 
         public Project Project { get; private set; }
 
@@ -38,10 +56,22 @@ namespace Microsoft.OData.ConnectedService
         /// <param name="project">An object of the project.</param>
         /// <param name="threadHelper">A thread helper that marshals the thread to the correct thread.</param>
         public ConnectedServiceFileHandler(ConnectedServiceHandlerContext context, Project project, IThreadHelper threadHelper)
+            : this(context, project, threadHelper, new ConnectedServiceMessageLogger(context))
+        {
+        }
+
+        internal ConnectedServiceFileHandler(
+            ConnectedServiceHandlerContext context,
+            Project project,
+            IThreadHelper threadHelper,
+            IMessageLogger messageLogger,
+            IInstalledPackagesProvider packagesProvider = null)
         {
             this.Context = context;
             this.Project = project;
             this.threadHelper = threadHelper;
+            this.messageLogger = messageLogger;
+            this.packagesProvider = packagesProvider;
         }
 
         /// <summary>
@@ -90,56 +120,204 @@ namespace Microsoft.OData.ConnectedService
         /// </summary>
         /// <returns>A task that represents the asynchronous operation. True if native date and time types are supported; otherwise, false.</returns>
         public Task<bool> EmitNativeDateTimeTypesAsync()
-            => this.CheckODataClientVersionAsync(version => version >= Version.Parse("9.0.0") || version >= Version.Parse("9.0.0.0"));
+            => this.CheckODataClientVersionAsync(ODataClientVersionChecker.SupportsNativeDateTimeTypes);
 
         /// <summary>
         /// Checks if the Microsoft.OData.Client reference meets a version condition.
         /// </summary>
         /// <param name="versionPredicate">A predicate to evaluate against the OData Client version.</param>
         /// <returns>True if the reference exists and meets the version condition; otherwise false.</returns>
-        private Task<bool> CheckODataClientVersionAsync(Func<Version, bool> versionPredicate)
+        private async Task<bool> CheckODataClientVersionAsync(Func<Version, bool> versionPredicate)
         {
-            return this.threadHelper.RunInUiThreadAsync(() =>
+            if (!this.isOdataClientVersionCached)
             {
-                if (this.isOdataClientVersionCached && this.odataClientVersion != null)
+                IReadOnlyList<InstalledPackageInfo> installedPackages =
+                    await this.GetInstalledPackagesAsync().ConfigureAwait(false);
+
+                InstalledPackageInfo odataClientPackage = installedPackages?.FirstOrDefault(
+                    package => package.Id.Equals(
+                        Microsoft.OData.CodeGen.Common.Constants.V4ClientNuGetPackage,
+                        StringComparison.OrdinalIgnoreCase));
+
+                this.isOdataClientPackageInstalled = odataClientPackage != null;
+                if (odataClientPackage != null &&
+                    ODataClientVersionChecker.TryParseVersion(odataClientPackage.Version, out Version parsedVersion))
                 {
-                    return versionPredicate(this.odataClientVersion);
+                    this.odataClientVersion = parsedVersion;
                 }
 
+                this.isOdataClientVersionCached = true;
+            }
+
+            Version version = this.odataClientVersion;
+
+            if (version == null &&
+                this.isOdataClientPackageInstalled &&
+                !this.versionResolutionWarningLogged &&
+                this.messageLogger != null)
+            {
+                this.versionResolutionWarningLogged = true;
+                await this.messageLogger.WriteMessageAsync(
+                    LogMessageCategory.Warning,
+                    "Microsoft.OData.Client is installed, but its version could not be resolved. Legacy date and time types will be generated.")
+                    .ConfigureAwait(false);
+            }
+
+            return version != null && versionPredicate(version);
+        }
+
+        /// <summary>
+        /// Gets the packages installed in the project, using the injected
+        /// <see cref="IInstalledPackagesProvider"/> when one is supplied (for testing) or the
+        /// platform-specific NuGet query otherwise.
+        /// </summary>
+        /// <returns>The installed packages.</returns>
+        private Task<IReadOnlyList<InstalledPackageInfo>> GetInstalledPackagesAsync()
+        {
+            if (this.packagesProvider != null)
+            {
+                return this.packagesProvider.GetInstalledPackagesAsync();
+            }
+
+            return this.ResolveInstalledPackagesAsync();
+        }
+
+#if VS2022PLUS
+        /// <summary>
+        /// Resolves the installed packages using the brokered <see cref="INuGetProjectService"/>,
+        /// which supersedes the obsolete <c>IVsPackageInstallerServices</c> API.
+        /// </summary>
+        /// <returns>The installed packages.</returns>
+        private async Task<IReadOnlyList<InstalledPackageInfo>> ResolveInstalledPackagesAsync()
+        {
+            Guid projectGuid = await this.threadHelper.RunInUiThreadAsync(() => this.TryGetProjectGuid()).ConfigureAwait(false);
+            IBrokeredServiceContainer serviceContainer = await this.threadHelper.RunInUiThreadAsync(() =>
+            {
 #pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
-                if (this.Project?.Object is VSProject vsProject)
+                return Package.GetGlobalService(typeof(SVsBrokeredServiceContainer)) as IBrokeredServiceContainer;
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
+            }).ConfigureAwait(false);
+
+            if (projectGuid == Guid.Empty || serviceContainer == null)
+            {
+                return Array.Empty<InstalledPackageInfo>();
+            }
+
+            IServiceBroker serviceBroker = serviceContainer.GetFullAccessServiceBroker();
+            INuGetProjectService nugetProjectService = await serviceBroker
+                .GetProxyAsync<INuGetProjectService>(NuGetServices.NuGetProjectServiceV1)
+                .ConfigureAwait(false);
+
+            try
+            {
+                if (nugetProjectService == null)
                 {
-                    foreach (Reference reference in vsProject.References)
-                    {
-                        if (reference.SourceProject == null &&
-                            reference.Name.Equals("Microsoft.OData.Client", StringComparison.Ordinal))
-                        {
-                            var currentVersion = reference.Version;
-                            var hyphenIndex = currentVersion?.IndexOf('-') ?? -1;
-                            if (hyphenIndex >= 0)
-                            {
-                                currentVersion = currentVersion.Substring(0, hyphenIndex);
-                            }
-
-                            if (Version.TryParse(currentVersion, out var parsedVersion))
-                            {
-                                this.odataClientVersion = parsedVersion;
-                                this.isOdataClientVersionCached = true;
-                                return versionPredicate(this.odataClientVersion);
-                            }
-
-                            this.odataClientVersion = null;
-                            this.isOdataClientVersionCached = true;
-                            return false;
-                        }
-                    }
+                    return Array.Empty<InstalledPackageInfo>();
                 }
+
+                InstalledPackagesResult result = await nugetProjectService
+                    .GetInstalledPackagesAsync(projectGuid, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                if (result == null ||
+                    result.Status != InstalledPackageResultStatus.Successful ||
+                    result.Packages == null)
+                {
+                    return Array.Empty<InstalledPackageInfo>();
+                }
+
+                return result.Packages
+                    .Select(package => new InstalledPackageInfo(package.Id, package.Version))
+                    .ToList();
+            }
+            finally
+            {
+                (nugetProjectService as IDisposable)?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Resolves the project GUID required by <see cref="INuGetProjectService"/>. Must be called on the UI thread.
+        /// </summary>
+        /// <returns>The project GUID, or <see cref="Guid.Empty"/> when it could not be resolved.</returns>
+        private Guid TryGetProjectGuid()
+        {
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
+            if (Package.GetGlobalService(typeof(SVsSolution)) is IVsSolution solution &&
+                solution.GetProjectOfUniqueName(this.Project.UniqueName, out IVsHierarchy hierarchy) == VSConstants.S_OK &&
+                hierarchy != null &&
+                hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ProjectIDGuid, out Guid projectGuid) == VSConstants.S_OK)
+            {
+                return projectGuid;
+            }
 #pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
 
-                this.odataClientVersion = null;
-                this.isOdataClientVersionCached = true;
-                return false;
+            return Guid.Empty;
+        }
+#else
+        /// <summary>
+        /// Resolves the installed packages using <c>IVsPackageInstallerServices</c>.
+        /// </summary>
+        /// <returns>The installed packages.</returns>
+        private Task<IReadOnlyList<InstalledPackageInfo>> ResolveInstalledPackagesAsync()
+        {
+            return this.threadHelper.RunInUiThreadAsync<IReadOnlyList<InstalledPackageInfo>>(() =>
+            {
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
+                IVsPackageInstallerServices packageInstallerServices = null;
+                if (Package.GetGlobalService(typeof(SComponentModel)) is IComponentModel componentModel)
+                {
+                    packageInstallerServices = componentModel.GetService<IVsPackageInstallerServices>();
+                }
+
+                if (packageInstallerServices == null)
+                {
+                    return Array.Empty<InstalledPackageInfo>();
+                }
+
+                return packageInstallerServices
+                    .GetInstalledPackages(this.Project)
+                    .Select(metadata => new InstalledPackageInfo(metadata.Id, metadata.VersionString))
+                    .ToList();
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
             });
         }
+#endif
+    }
+
+    /// <summary>
+    /// Provides the packages installed in a project. Abstracts the VS-version-specific NuGet
+    /// query API so OData client version resolution can be unit tested.
+    /// </summary>
+    internal interface IInstalledPackagesProvider
+    {
+        /// <summary>
+        /// Gets the packages installed in the project.
+        /// </summary>
+        /// <returns>The installed packages.</returns>
+        Task<IReadOnlyList<InstalledPackageInfo>> GetInstalledPackagesAsync();
+    }
+
+    /// <summary>
+    /// Represents an installed NuGet package id and version, independent of the VS-version-specific API.
+    /// </summary>
+    internal sealed class InstalledPackageInfo
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="InstalledPackageInfo"/>.
+        /// </summary>
+        /// <param name="id">The package id.</param>
+        /// <param name="version">The installed package version string.</param>
+        public InstalledPackageInfo(string id, string version)
+        {
+            this.Id = id;
+            this.Version = version;
+        }
+
+        /// <summary>Gets the package id.</summary>
+        public string Id { get; }
+
+        /// <summary>Gets the installed package version string.</summary>
+        public string Version { get; }
     }
 }

--- a/src/ODataConnectedService.Shared/ConnectedServicePackageInstaller.cs
+++ b/src/ODataConnectedService.Shared/ConnectedServicePackageInstaller.cs
@@ -14,6 +14,15 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.ConnectedServices;
 using NuGet.VisualStudio;
 using Shell = Microsoft.VisualStudio.Shell;
+#if VS2022PLUS
+using System.Linq;
+using System.Threading;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using NuGet.VisualStudio.Contracts;
+#endif
 
 
 namespace Microsoft.OData.ConnectedService
@@ -28,7 +37,9 @@ namespace Microsoft.OData.ConnectedService
         public IMessageLogger MessageLogger { get; private set; }
         public IVsPackageInstaller PackageInstaller { get; protected set; }
 
+#if !VS2022PLUS
         public IVsPackageInstallerServices PackageInstallerServices { get; protected set; }
+#endif
 
         /// <summary>
         /// Creates an instance of <see cref="ConnectedServicePackageInstaller"/> 
@@ -52,7 +63,9 @@ namespace Microsoft.OData.ConnectedService
             var componentModel = (IComponentModel)Shell.Package.GetGlobalService(typeof(SComponentModel));
             if (componentModel != null)
             {
+#if !VS2022PLUS
                 this.PackageInstallerServices = componentModel.GetService<IVsPackageInstallerServices>();
+#endif
                 this.PackageInstaller = componentModel.GetService<IVsPackageInstaller>();
             }
         }
@@ -64,11 +77,11 @@ namespace Microsoft.OData.ConnectedService
         /// <param name="packageName">The name of the package to be installed</param>
         public async Task CheckAndInstallNuGetPackageAsync(string packageSource, string packageName)
         {
-            if (PackageInstallerServices != null)
+            if (PackageInstaller != null)
             {
                 try
                 {
-                    if (!PackageInstallerServices.IsPackageInstalled(this.Project, packageName))
+                    if (!await this.IsPackageInstalledAsync(packageName).ConfigureAwait(false))
                     {
                         PackageInstaller.InstallPackage(packageSource, this.Project, packageName, (string)null, false);
 
@@ -89,5 +102,82 @@ namespace Microsoft.OData.ConnectedService
                 await (this.MessageLogger?.WriteMessageAsync(LogMessageCategory.Error, $"The packages were not installed. An error occurred during the installation of packages.")).ConfigureAwait(false);
             }
         }
+
+#if VS2022PLUS
+        /// <summary>
+        /// Determines whether the specified package is installed in the project using the brokered
+        /// <see cref="INuGetProjectService"/>, which supersedes the obsolete <c>IVsPackageInstallerServices</c> API.
+        /// </summary>
+        /// <param name="packageName">The package id to look for.</param>
+        /// <returns>True if the package is installed; otherwise false.</returns>
+        private async Task<bool> IsPackageInstalledAsync(string packageName)
+        {
+            await Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            Guid projectGuid = this.TryGetProjectGuid();
+            IBrokeredServiceContainer serviceContainer = Shell.Package.GetGlobalService(typeof(SVsBrokeredServiceContainer)) as IBrokeredServiceContainer;
+
+            if (projectGuid == Guid.Empty || serviceContainer == null)
+            {
+                return false;
+            }
+
+            IServiceBroker serviceBroker = serviceContainer.GetFullAccessServiceBroker();
+            INuGetProjectService nugetProjectService = await serviceBroker
+                .GetProxyAsync<INuGetProjectService>(NuGetServices.NuGetProjectServiceV1)
+                .ConfigureAwait(false);
+
+            try
+            {
+                if (nugetProjectService == null)
+                {
+                    return false;
+                }
+
+                InstalledPackagesResult result = await nugetProjectService
+                    .GetInstalledPackagesAsync(projectGuid, CancellationToken.None)
+                    .ConfigureAwait(false);
+
+                return result != null &&
+                    result.Status == InstalledPackageResultStatus.Successful &&
+                    result.Packages != null &&
+                    result.Packages.Any(p => p.Id.Equals(packageName, StringComparison.OrdinalIgnoreCase));
+            }
+            finally
+            {
+                (nugetProjectService as IDisposable)?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Resolves the project GUID required by <see cref="INuGetProjectService"/>. Must be called on the UI thread.
+        /// </summary>
+        /// <returns>The project GUID, or <see cref="Guid.Empty"/> when it could not be resolved.</returns>
+        private Guid TryGetProjectGuid()
+        {
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
+            if (Shell.Package.GetGlobalService(typeof(SVsSolution)) is IVsSolution solution &&
+                solution.GetProjectOfUniqueName(this.Project.UniqueName, out IVsHierarchy hierarchy) == VSConstants.S_OK &&
+                hierarchy != null &&
+                hierarchy.GetGuidProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ProjectIDGuid, out Guid projectGuid) == VSConstants.S_OK)
+            {
+                return projectGuid;
+            }
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
+
+            return Guid.Empty;
+        }
+#else
+        /// <summary>
+        /// Determines whether the specified package is installed in the project using <c>IVsPackageInstallerServices</c>.
+        /// </summary>
+        /// <param name="packageName">The package id to look for.</param>
+        /// <returns>True if the package is installed; otherwise false.</returns>
+        private Task<bool> IsPackageInstalledAsync(string packageName)
+        {
+            return Task.FromResult(this.PackageInstallerServices != null &&
+                this.PackageInstallerServices.IsPackageInstalled(this.Project, packageName));
+        }
+#endif
     }
 }

--- a/src/ODataConnectedService_VS2022Plus/ODataConnectedService_VS2022Plus.csproj
+++ b/src/ODataConnectedService_VS2022Plus/ODataConnectedService_VS2022Plus.csproj
@@ -29,7 +29,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;VS2022PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;VS2022PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -101,6 +101,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.VisualStudio">
+      <Version>17.14.0</Version>
+    </PackageReference>
+    <PackageReference Include="NuGet.VisualStudio.Contracts">
       <Version>17.14.0</Version>
     </PackageReference>
   </ItemGroup>

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/ODataCliCodeGenerationTests.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/ODataCliCodeGenerationTests.cs
@@ -531,6 +531,145 @@ namespace Microsoft.OData.Cli.Tests.CodeGeneration
             Assert.Contains("public virtual global::Microsoft.OData.Edm.TimeOfDay OrderTime", generatedCode);
         }
 
+        [Fact]
+        public void TestCodeGeneration_WithCentralPackageManagement_UsesNativeDateTimeTypes()
+        {
+            // Version comes from a <PackageVersion> item (Directory.Packages.props style), not the <PackageReference>.
+            this.WriteTestProject($@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include=""Microsoft.OData.Client"" Version=""9.0.0"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.OData.Client"" />
+  </ItemGroup>
+</Project>");
+
+            var parseResult = this.generateCommand.Parse($"--metadata-uri {this.metadataUriWithDateOnlyAndTimeOnly} --outputdir {this.outputDir}");
+            parseResult.Invoke();
+
+            var referenceProxyFile = Assert.Single(Directory.GetFiles(this.outputDir, $"{Constants.DefaultReferenceFileName}.cs"));
+            var generatedCode = File.ReadAllText(referenceProxyFile);
+
+            Assert.NotNull(generatedCode);
+            Assert.NotEmpty(generatedCode);
+            Assert.Contains("public virtual global::System.DateOnly OrderDate", generatedCode);
+            Assert.Contains("public virtual global::System.TimeOnly OrderTime", generatedCode);
+        }
+
+        [Fact]
+        public void TestCodeGeneration_WithVersionOverride_UsesNativeDateTimeTypes()
+        {
+            // Central version is < 9, but VersionOverride bumps it to a supported version.
+            this.WriteTestProject($@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include=""Microsoft.OData.Client"" Version=""8.0.0"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.OData.Client"" VersionOverride=""9.0.0"" />
+  </ItemGroup>
+</Project>");
+
+            var parseResult = this.generateCommand.Parse($"--metadata-uri {this.metadataUriWithDateOnlyAndTimeOnly} --outputdir {this.outputDir}");
+            parseResult.Invoke();
+
+            var referenceProxyFile = Assert.Single(Directory.GetFiles(this.outputDir, $"{Constants.DefaultReferenceFileName}.cs"));
+            var generatedCode = File.ReadAllText(referenceProxyFile);
+
+            Assert.NotNull(generatedCode);
+            Assert.NotEmpty(generatedCode);
+            Assert.Contains("public virtual global::System.DateOnly OrderDate", generatedCode);
+            Assert.Contains("public virtual global::System.TimeOnly OrderTime", generatedCode);
+        }
+
+        [Fact]
+        public void TestCodeGeneration_WithMSBuildPropertyVersion_UsesNativeDateTimeTypes()
+        {
+            // Version is expressed as an MSBuild property and must be evaluated.
+            this.WriteTestProject($@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ODataClientVersion>9.0.0</ODataClientVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.OData.Client"" Version=""$(ODataClientVersion)"" />
+  </ItemGroup>
+</Project>");
+
+            var parseResult = this.generateCommand.Parse($"--metadata-uri {this.metadataUriWithDateOnlyAndTimeOnly} --outputdir {this.outputDir}");
+            parseResult.Invoke();
+
+            var referenceProxyFile = Assert.Single(Directory.GetFiles(this.outputDir, $"{Constants.DefaultReferenceFileName}.cs"));
+            var generatedCode = File.ReadAllText(referenceProxyFile);
+
+            Assert.NotNull(generatedCode);
+            Assert.NotEmpty(generatedCode);
+            Assert.Contains("public virtual global::System.DateOnly OrderDate", generatedCode);
+            Assert.Contains("public virtual global::System.TimeOnly OrderTime", generatedCode);
+        }
+
+        [Fact]
+        public void TestCodeGeneration_WithVersionRange_UsesNativeDateTimeTypes()
+        {
+            // A version range whose minimum is supported.
+            this.WriteTestProject($@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.OData.Client"" Version=""[9.0.0,10.0.0)"" />
+  </ItemGroup>
+</Project>");
+
+            var parseResult = this.generateCommand.Parse($"--metadata-uri {this.metadataUriWithDateOnlyAndTimeOnly} --outputdir {this.outputDir}");
+            parseResult.Invoke();
+
+            var referenceProxyFile = Assert.Single(Directory.GetFiles(this.outputDir, $"{Constants.DefaultReferenceFileName}.cs"));
+            var generatedCode = File.ReadAllText(referenceProxyFile);
+
+            Assert.NotNull(generatedCode);
+            Assert.NotEmpty(generatedCode);
+            Assert.Contains("public virtual global::System.DateOnly OrderDate", generatedCode);
+            Assert.Contains("public virtual global::System.TimeOnly OrderTime", generatedCode);
+        }
+
+        [Fact]
+        public void TestCodeGeneration_WithRestoredAssetsFile_UsesNativeDateTimeTypes()
+        {
+            // Declared version is < 9, but the restored project.assets.json resolves a supported version and must win.
+            this.WriteTestProject($@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.OData.Client"" Version=""8.0.0"" />
+  </ItemGroup>
+</Project>");
+
+            Directory.CreateDirectory(Path.Combine(this.outputDir, "obj"));
+            File.WriteAllText(
+                Path.Combine(this.outputDir, "obj", "project.assets.json"),
+                @"{ ""version"": 3, ""libraries"": { ""Microsoft.OData.Client/9.0.0"": { ""type"": ""package"" } } }");
+
+            var parseResult = this.generateCommand.Parse($"--metadata-uri {this.metadataUriWithDateOnlyAndTimeOnly} --outputdir {this.outputDir}");
+            parseResult.Invoke();
+
+            var referenceProxyFile = Assert.Single(Directory.GetFiles(this.outputDir, $"{Constants.DefaultReferenceFileName}.cs"));
+            var generatedCode = File.ReadAllText(referenceProxyFile);
+
+            Assert.NotNull(generatedCode);
+            Assert.NotEmpty(generatedCode);
+            Assert.Contains("public virtual global::System.DateOnly OrderDate", generatedCode);
+            Assert.Contains("public virtual global::System.TimeOnly OrderTime", generatedCode);
+        }
+
         public void Dispose()
         {
             try
@@ -559,7 +698,7 @@ namespace Microsoft.OData.Cli.Tests.CodeGeneration
 
             var projectPath = Path.Combine(this.outputDir, "TestProject.csproj");
 
-            var projectContent = $@"<Project>
+            var projectContent = $@"<Project Sdk=""Microsoft.NET.Sdk"">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -580,6 +719,16 @@ namespace Microsoft.OData.Cli.Tests.CodeGeneration
 </Project>";
 
             File.WriteAllText(projectPath, projectContent);
+        }
+
+        private void WriteTestProject(string projectContent)
+        {
+            if (!Directory.Exists(this.outputDir))
+            {
+                Directory.CreateDirectory(this.outputDir);
+            }
+
+            File.WriteAllText(Path.Combine(this.outputDir, "TestProject.csproj"), projectContent);
         }
 
         private static void EnsureMSBuildLoadedIfNot()

--- a/test/Microsoft.OData.Cli.Tests/FileHandling/ODataCliFileHandlerTests.cs
+++ b/test/Microsoft.OData.Cli.Tests/FileHandling/ODataCliFileHandlerTests.cs
@@ -122,13 +122,97 @@ namespace Microsoft.OData.Cli.Tests.FileHandling
         {
             // Arrange
             var project = CreateProjectWithODataClientVersion("invalid-version");
-            var fileHandler = CreateFileHandler(project);
+            var loggerMock = new Mock<IMessageLogger>();
+            var fileHandler = CreateFileHandler(project, loggerMock);
 
             // Act
             var result = await fileHandler.EmitNativeDateTimeTypesAsync();
 
             // Assert
             Assert.False(result);
+            loggerMock.Verify(
+                logger => logger.WriteMessageAsync(
+                    LogMessageCategory.Warning,
+                    It.Is<string>(message => message.Contains("could not be resolved")),
+                    It.IsAny<object[]>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task EmitNativeDateTimeTypesAsync_ShouldUseCentralPackageVersion()
+        {
+            var project = CreateCentrallyManagedProject("9.0.0");
+            var fileHandler = CreateFileHandler(project);
+
+            var result = await fileHandler.EmitNativeDateTimeTypesAsync();
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task EmitNativeDateTimeTypesAsync_ShouldPreferVersionOverride()
+        {
+            var project = CreateCentrallyManagedProject("8.0.0", "9.0.0");
+            var fileHandler = CreateFileHandler(project);
+
+            var result = await fileHandler.EmitNativeDateTimeTypesAsync();
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task EmitNativeDateTimeTypesAsync_ShouldEvaluatePropertyBasedVersion()
+        {
+            var pre = ProjectRootElement.Create();
+            pre.AddPropertyGroup().AddProperty("ODataClientVersion", "9.0.0");
+            var packageReference = pre.AddItemGroup().AddItem("PackageReference", "Microsoft.OData.Client");
+            packageReference.AddMetadata("Version", "$(ODataClientVersion)", expressAsAttribute: true);
+            var project = new Project(pre);
+            project.ReevaluateIfNecessary();
+
+            var result = await CreateFileHandler(project).EmitNativeDateTimeTypesAsync();
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task EmitNativeDateTimeTypesAsync_ShouldSupportVersionRangeWithSupportedMinimum()
+        {
+            var project = CreateProjectWithODataClientVersion("[9.0.0,10.0.0)");
+
+            var result = await CreateFileHandler(project).EmitNativeDateTimeTypesAsync();
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task EmitNativeDateTimeTypesAsync_ShouldPreferRestoredAssetsVersion()
+        {
+            string projectDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(Path.Combine(projectDirectory, "obj"));
+            string assetsFile = Path.Combine(projectDirectory, "obj", "project.assets.json");
+            File.WriteAllText(
+                assetsFile,
+                @"{ ""version"": 3, ""libraries"": { ""Microsoft.OData.Client/9.0.0"": { ""type"": ""package"" } } }");
+
+            try
+            {
+                var pre = ProjectRootElement.Create();
+                pre.AddPropertyGroup().AddProperty("ProjectAssetsFile", assetsFile);
+                var packageReference = pre.AddItemGroup().AddItem("PackageReference", "Microsoft.OData.Client");
+                packageReference.AddMetadata("Version", "8.0.0", expressAsAttribute: true);
+                var project = new Project(pre);
+                project.ReevaluateIfNecessary();
+
+                var result = await CreateFileHandler(project).EmitNativeDateTimeTypesAsync();
+
+                Assert.True(result);
+            }
+            finally
+            {
+                ProjectCollection.GlobalProjectCollection.UnloadAllProjects();
+                Directory.Delete(projectDirectory, true);
+            }
         }
 
         private static Project CreateProjectWithODataClientVersion(string version)
@@ -168,10 +252,34 @@ namespace Microsoft.OData.Cli.Tests.FileHandling
             return project;
         }
 
-        private static ODataCliFileHandler CreateFileHandler(Project project)
+        private static Project CreateCentrallyManagedProject(string centralVersion, string? versionOverride = null)
         {
-            var loggerMock = new Mock<IMessageLogger>();
-            return new ODataCliFileHandler(loggerMock.Object, project);
+            var pre = ProjectRootElement.Create();
+            var propertyGroup = pre.AddPropertyGroup();
+            propertyGroup.AddProperty("TargetFramework", "net8.0");
+            propertyGroup.AddProperty("ManagePackageVersionsCentrally", "true");
+
+            var packageVersion = pre.AddItemGroup().AddItem("PackageVersion", "Microsoft.OData.Client");
+            packageVersion.AddMetadata("Version", centralVersion, expressAsAttribute: true);
+
+            var packageReference = pre.AddItemGroup().AddItem("PackageReference", "Microsoft.OData.Client");
+            if (!string.IsNullOrEmpty(versionOverride))
+            {
+                packageReference.AddMetadata("VersionOverride", versionOverride, expressAsAttribute: true);
+            }
+
+            var project = new Project(pre);
+            project.ReevaluateIfNecessary();
+            return project;
+        }
+
+        private static ODataCliFileHandler CreateFileHandler(Project? project, Mock<IMessageLogger>? loggerMock = null)
+        {
+            loggerMock ??= new Mock<IMessageLogger>();
+            loggerMock
+                .Setup(logger => logger.WriteMessageAsync(It.IsAny<LogMessageCategory>(), It.IsAny<string>(), It.IsAny<object[]>()))
+                .Returns(Task.CompletedTask);
+            return new ODataCliFileHandler(loggerMock.Object, project!);
         }
 
         private static void EnsureMSBuildLoadedIfNot()

--- a/test/Microsoft.OData.Cli.Tests/Microsoft.OData.Cli.Tests.csproj
+++ b/test/Microsoft.OData.Cli.Tests/Microsoft.OData.Cli.Tests.csproj
@@ -58,7 +58,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
@@ -883,7 +883,8 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
                 new ConnectedServicePackageInstaller(context, project, new ConnectedServiceMessageLogger(context)),
                 new ODataT4CodeGeneratorFactory());
 
-            descriptor.AddGeneratedClientCodeAsync(serviceConfig.Endpoint, referenceFolderPath, LanguageOption.GenerateCSharpCode, serviceConfig).Wait();
+            descriptor.AddGeneratedClientCodeAsync(serviceConfig.Endpoint, referenceFolderPath, LanguageOption.GenerateCSharpCode, serviceConfig)
+                .ConfigureAwait(false).GetAwaiter().GetResult();
 
             var addedFile = handlerHelper.AddedFiles.FirstOrDefault();
             Assert.IsNotNull(addedFile, "The V4 code generator did not produce any output file.");

--- a/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
@@ -617,6 +617,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             Assert.IsTrue(installer.InstalledPackages.Contains(Microsoft.OData.CodeGen.Common.Constants.V4SpatialNuGetPackage));
         }
 
+#if !VS2022PLUS
         [Ignore]
         [TestMethod]
         public void TestAddNugetPackageAsync_ShouldNotInstalledODataClientLibrariesIfAlreadyInstalled()
@@ -652,6 +653,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             Assert.IsFalse(installer.InstalledPackages.Contains(Microsoft.OData.CodeGen.Common.Constants.V4ODataNuGetPackage));
             Assert.IsFalse(installer.InstalledPackages.Contains(Microsoft.OData.CodeGen.Common.Constants.V4SpatialNuGetPackage));
         }
+#endif
 
         [Ignore]
         [TestMethod]
@@ -822,6 +824,73 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             GeneratedCodeHelpers.VerifyGeneratedCode(expectedCode, generatedCode);
         }
 
+        [TestMethod]
+        public void TestV4AddGeneratedClientCode_WithODataClient9_EmitsNativeDateTimeTypes()
+        {
+            var generatedCode = GenerateV4CodeWithODataClientVersion("9.0.0");
+
+            Assert.IsTrue(generatedCode.Contains("global::System.DateOnly OrderDate"),
+                "Expected native System.DateOnly to be emitted for Microsoft.OData.Client 9.0.0.");
+            Assert.IsTrue(generatedCode.Contains("global::System.TimeOnly OrderTime"),
+                "Expected native System.TimeOnly to be emitted for Microsoft.OData.Client 9.0.0.");
+        }
+
+        [TestMethod]
+        public void TestV4AddGeneratedClientCode_WithODataClientVersionLessThan9_EmitsEdmDateTimeTypes()
+        {
+            var generatedCode = GenerateV4CodeWithODataClientVersion("8.0.0");
+
+            Assert.IsTrue(generatedCode.Contains("global::Microsoft.OData.Edm.Date OrderDate"),
+                "Expected legacy Microsoft.OData.Edm.Date to be emitted for Microsoft.OData.Client 8.0.0.");
+            Assert.IsTrue(generatedCode.Contains("global::Microsoft.OData.Edm.TimeOfDay OrderTime"),
+                "Expected legacy Microsoft.OData.Edm.TimeOfDay to be emitted for Microsoft.OData.Client 8.0.0.");
+        }
+
+        /// <summary>
+        /// Runs the real V4 code generator end-to-end against a metadata document that contains
+        /// Edm.Date and Edm.TimeOfDay properties, using an injected package provider to simulate the
+        /// installed Microsoft.OData.Client version, and returns the generated source code.
+        /// </summary>
+        static string GenerateV4CodeWithODataClientVersion(string odataClientVersion)
+        {
+            var serviceName = "DateTimeService";
+            var referenceFolderPath = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName);
+            Directory.CreateDirectory(referenceFolderPath);
+            Project project = CreateTestProject(TestProjectRootPath, ODataT4CodeGenerator.LanguageOption.CSharp);
+            var serviceConfig = new ServiceConfigurationV4()
+            {
+                Endpoint = Path.Combine(Directory.GetCurrentDirectory(), "CodeGeneration", "SampleServiceV4WithDateOnlyAndTimeOnly.xml"),
+                ServiceName = serviceName,
+                GeneratedFileNamePrefix = "Reference",
+                EdmxVersion = Microsoft.OData.CodeGen.Common.Constants.EdmxVersion4,
+                IncludeT4File = false
+            };
+            var serviceInstance = new ODataConnectedServiceInstance()
+            {
+                ServiceConfig = serviceConfig,
+                Name = serviceName
+            };
+
+            var handlerHelper = new TestConnectedServiceHandlerHelper { ServicesRootFolder = ServicesRootFolder };
+            ConnectedServiceHandlerContext context = new TestConnectedServiceHandlerContext(serviceInstance, handlerHelper);
+
+            var packagesProvider = new FakeInstalledPackagesProvider(new InstalledPackageInfo("Microsoft.OData.Client", odataClientVersion));
+            var fileHandler = new ConnectedServiceFileHandler(context, project, new TestThreadHelper(), new ConnectedServiceMessageLogger(context), packagesProvider);
+
+            var descriptor = new TestV4CodeGenDescriptor(
+                fileHandler,
+                new ConnectedServiceMessageLogger(context),
+                new ConnectedServicePackageInstaller(context, project, new ConnectedServiceMessageLogger(context)),
+                new ODataT4CodeGeneratorFactory());
+
+            descriptor.AddGeneratedClientCodeAsync(serviceConfig.Endpoint, referenceFolderPath, LanguageOption.GenerateCSharpCode, serviceConfig).Wait();
+
+            var addedFile = handlerHelper.AddedFiles.FirstOrDefault();
+            Assert.IsNotNull(addedFile, "The V4 code generator did not produce any output file.");
+
+            return File.ReadAllText(addedFile.SourceFile);
+        }
+
         static V4CodeGenDescriptor SetupCodeGenDescriptor(ServiceConfiguration serviceConfig, string serviceName, IODataT4CodeGeneratorFactory codeGenFactory, TestConnectedServiceHandlerHelper handlerHelper, ODataT4CodeGenerator.LanguageOption targetLanguage = ODataT4CodeGenerator.LanguageOption.CSharp)
         {
             var referenceFolderPath = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName);
@@ -874,6 +943,21 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
         public TestV4CodeGenDescriptor(IFileHandler fileHandler, IMessageLogger messageLogger, IPackageInstaller packageInstaller, IODataT4CodeGeneratorFactory codeGenFactory)
             : base(fileHandler, messageLogger, packageInstaller, codeGenFactory)
         {
+        }
+    }
+
+    sealed class FakeInstalledPackagesProvider : IInstalledPackagesProvider
+    {
+        private readonly IReadOnlyList<InstalledPackageInfo> packages;
+
+        public FakeInstalledPackagesProvider(params InstalledPackageInfo[] packages)
+        {
+            this.packages = packages;
+        }
+
+        public Task<IReadOnlyList<InstalledPackageInfo>> GetInstalledPackagesAsync()
+        {
+            return Task.FromResult(this.packages);
         }
     }
 

--- a/test/ODataConnectedService.Tests/CodeGeneration/SampleServiceV4WithDateOnlyAndTimeOnly.xml
+++ b/test/ODataConnectedService.Tests/CodeGeneration/SampleServiceV4WithDateOnlyAndTimeOnly.xml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SampleServiceV4.Models">
+      <EntityType Name="Customer">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Name" Type="Edm.String" Nullable="false"/>
+        <NavigationProperty Name="Orders" Type="Collection(SampleServiceV4.Models.Order)"/>
+      </EntityType>
+      <EntityType Name="Order">
+        <Key>
+          <PropertyRef Name="Id"/>
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false"/>
+        <Property Name="Amount" Type="Edm.Decimal" Nullable="false" Scale="Variable"/>
+		<Property Name="OrderTime" Type="Edm.TimeOfDay" Nullable="false"/>
+		<Property Name="OrderDate" Type="Edm.Date" Nullable="false"/>
+        <NavigationProperty Name="Customer" Type="SampleServiceV4.Models.Customer" Nullable="false"/>
+      </EntityType>
+      <ComplexType Name="Address">
+        <Property Name="Street" Type="Edm.String" Nullable="false"/>
+        <Property Name="City" Type="SampleServiceV4.Models.City" Nullable="false"/>
+      </ComplexType>
+      <ComplexType Name="City">
+        <Property Name="Name" Type="Edm.String" Nullable="false"/>
+      </ComplexType>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="SampleServiceV4.Default">
+      <Function Name="GetTopCustomers" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Collection(SampleServiceV4.Models.Customer)"/>
+        <ReturnType Type="Collection(SampleServiceV4.Models.Customer)"/>
+      </Function>
+      <Action Name="RateCustomer" IsBound="true">
+        <Parameter Name="bindingParameter" Type="SampleServiceV4.Models.Customer"/>
+        <Parameter Name="rating" Type="Edm.Int32" Nullable="false"/>
+      </Action>
+      <Action Name="ProcessOrder" IsBound="true">
+        <Parameter Name="bindingParameter" Type="SampleServiceV4.Models.Order"/>
+      </Action>
+      <Action Name="BackupDataSource"/>
+      <Action Name="ResetDataSource"/>
+      <Action Name="RepairDataSource"/>
+      <EntityContainer Name="Container">
+        <EntitySet Name="Customers" EntityType="SampleServiceV4.Models.Customer">
+          <NavigationPropertyBinding Path="Orders" Target="Orders"/>
+        </EntitySet>
+        <EntitySet Name="Orders" EntityType="SampleServiceV4.Models.Order">
+          <NavigationPropertyBinding Path="Customer" Target="Customers"/>
+        </EntitySet>
+        <ActionImport Name="BackupDataSource" Action="SampleServiceV4.Default.BackupDataSource"/>
+        <ActionImport Name="ResetDataSource" Action="SampleServiceV4.Default.ResetDataSource"/>
+        <ActionImport Name="RepairDataSource" Action="SampleServiceV4.Default.RepairDataSource"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/test/ODataConnectedService.Tests/FileHandling/ConnectedServiceFileHandlerTests.cs
+++ b/test/ODataConnectedService.Tests/FileHandling/ConnectedServiceFileHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------------
+//-----------------------------------------------------------------------------
 // <copyright file="ConnectedServiceFileHandlerTests.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
 //      See License.txt in the project root for license information.
@@ -8,13 +8,13 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EnvDTE;
+using Microsoft.OData.CodeGen.Logging;
 using Microsoft.OData.CodeGen.Models;
 using Microsoft.OData.ConnectedService;
 using Microsoft.OData.ConnectedService.Tests.TestHelpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using ODataConnectedService.Tests.TestHelpers;
-using VSLangProj;
 
 namespace ODataConnectedService.Tests.FileHandling
 {
@@ -25,8 +25,8 @@ namespace ODataConnectedService.Tests.FileHandling
         public async Task EmitNativeDateTimeTypesAsync_ShouldReturnTrue_WhenODataClientVersionIsGreaterThanOrEqualTo9_0_0Async()
         {
             // Arrange
-            var project = CreateProjectWithODataClientVersion("9.0.0");
-            var fileHandler = CreateFileHandler(project);
+            var project = new Mock<Project>().Object;
+            var fileHandler = CreateFileHandler(project, CreateProvider("Microsoft.OData.Client", "9.0.0"));
 
             // Act
             var result = await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false);
@@ -39,8 +39,8 @@ namespace ODataConnectedService.Tests.FileHandling
         public async Task EmitNativeDateTimeTypesAsync_ShouldReturnTrue_WhenODataClientVersionIsPrereleaseAsync()
         {
             // Arrange
-            var project = CreateProjectWithODataClientVersion("9.0.0-preview.3");
-            var fileHandler = CreateFileHandler(project);
+            var project = new Mock<Project>().Object;
+            var fileHandler = CreateFileHandler(project, CreateProvider("Microsoft.OData.Client", "9.0.0-preview.3"));
 
             // Act
             var result = await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false);
@@ -53,8 +53,8 @@ namespace ODataConnectedService.Tests.FileHandling
         public async Task EmitNativeDateTimeTypesAsync_ShouldReturnFalse_WhenODataClientVersionIsLessThan9_0_0_Async()
         {
             // Arrange
-            var project = CreateProjectWithODataClientVersion("8.0.0");
-            var fileHandler = CreateFileHandler(project);
+            var project = new Mock<Project>().Object;
+            var fileHandler = CreateFileHandler(project, CreateProvider("Microsoft.OData.Client", "8.0.0"));
 
             // Act
             var result = await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false);
@@ -67,8 +67,8 @@ namespace ODataConnectedService.Tests.FileHandling
         public async Task EmitNativeDateTimeTypesAsync_ShouldReturnFalse_WhenODataClientReferenceNotFoundAsync()
         {
             // Arrange
-            var project = CreateProjectWithoutODataClient();
-            var fileHandler = CreateFileHandler(project);
+            var project = new Mock<Project>().Object;
+            var fileHandler = CreateFileHandler(project, new FakeInstalledPackagesProvider());
 
             // Act
             var result = await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false);
@@ -81,27 +81,9 @@ namespace ODataConnectedService.Tests.FileHandling
         public async Task CheckODataClientVersionAsync_ShouldCacheVersion_AndReuseOnSubsequentCallsAsync()
         {
             // Arrange
-            var referenceMock = new Mock<Reference>();
-            referenceMock.SetupGet(r => r.Name).Returns("Microsoft.OData.Client");
-            referenceMock.SetupGet(r => r.Version).Returns("9.0.0.0");
-            referenceMock.SetupGet(r => r.SourceProject).Returns((Project)null);
-
-            var referencesMock = new Mock<References>();
-            var callCount = 0;
-            referencesMock.Setup(r => r.GetEnumerator())
-                .Returns(() =>
-                {
-                    callCount++;
-                    return new List<Reference> { referenceMock.Object }.GetEnumerator();
-                });
-
-            var vsProjectMock = new Mock<VSProject>();
-            vsProjectMock.SetupGet(vsp => vsp.References).Returns(referencesMock.Object);
-
+            var provider = new FakeInstalledPackagesProvider(new InstalledPackageInfo("Microsoft.OData.Client", "9.0.0"));
             var projectMock = new Mock<Project>();
-            projectMock.SetupGet(p => p.Object).Returns(vsProjectMock.Object);
-
-            var fileHandler = CreateFileHandler(projectMock.Object);
+            var fileHandler = CreateFileHandler(projectMock.Object, provider);
 
             // Act
             var result1 = await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false);
@@ -110,50 +92,59 @@ namespace ODataConnectedService.Tests.FileHandling
             // Assert
             Assert.IsTrue(result1);
             Assert.IsTrue(result2);
-            Assert.AreEqual(1, callCount, "References should only be enumerated once due to caching");
+            Assert.AreEqual(1, provider.CallCount, "Installed packages should only be enumerated once due to caching");
         }
 
-        private static Project CreateProjectWithODataClientVersion(string version)
+        [TestMethod]
+        public async Task CheckODataClientVersionAsync_ShouldCacheMissingPackageAsync()
         {
-            var referenceMock = new Mock<Reference>();
-            referenceMock.SetupGet(r => r.Name).Returns("Microsoft.OData.Client");
-            referenceMock.SetupGet(r => r.Version).Returns(version);
-            referenceMock.SetupGet(r => r.SourceProject).Returns((Project)null);
+            var provider = new FakeInstalledPackagesProvider();
+            var fileHandler = CreateFileHandler(new Mock<Project>().Object, provider);
 
-            var referencesMock = new Mock<References>();
-            referencesMock.Setup(r => r.GetEnumerator())
-                .Returns(new List<Reference> { referenceMock.Object }.GetEnumerator());
-
-            var vsProjectMock = new Mock<VSProject>();
-            vsProjectMock.SetupGet(vsp => vsp.References).Returns(referencesMock.Object);
-
-            var projectMock = new Mock<Project>();
-            projectMock.SetupGet(p => p.Object).Returns(vsProjectMock.Object);
-
-            return projectMock.Object;
+            Assert.IsFalse(await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false));
+            Assert.IsFalse(await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false));
+            Assert.AreEqual(1, provider.CallCount);
         }
 
-        private static Project CreateProjectWithoutODataClient()
+        [TestMethod]
+        public async Task EmitNativeDateTimeTypesAsync_ShouldMatchPackageIdCaseInsensitivelyAsync()
         {
-            var referenceMock = new Mock<Reference>();
-            referenceMock.SetupGet(r => r.Name).Returns("System.Core");
-            referenceMock.SetupGet(r => r.Version).Returns("4.0.0.0");
-            referenceMock.SetupGet(r => r.SourceProject).Returns((Project)null);
+            var project = new Mock<Project>().Object;
+            var fileHandler = CreateFileHandler(project, CreateProvider("microsoft.odata.client", "9.0.0"));
 
-            var referencesMock = new Mock<References>();
-            referencesMock.Setup(r => r.GetEnumerator())
-                .Returns(new List<Reference> { referenceMock.Object }.GetEnumerator());
+            var result = await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false);
 
-            var vsProjectMock = new Mock<VSProject>();
-            vsProjectMock.SetupGet(vsp => vsp.References).Returns(referencesMock.Object);
-
-            var projectMock = new Mock<Project>();
-            projectMock.SetupGet(p => p.Object).Returns(vsProjectMock.Object);
-
-            return projectMock.Object;
+            Assert.IsTrue(result);
         }
 
-        private static ConnectedServiceFileHandler CreateFileHandler(Project project)
+        [TestMethod]
+        public async Task EmitNativeDateTimeTypesAsync_ShouldWarnOnce_WhenInstalledVersionCannotBeParsedAsync()
+        {
+            var logger = new Mock<IMessageLogger>();
+            logger.Setup(value => value.WriteMessageAsync(It.IsAny<LogMessageCategory>(), It.IsAny<string>(), It.IsAny<object[]>()))
+                .Returns(Task.CompletedTask);
+            var provider = CreateProvider("Microsoft.OData.Client", "invalid-version");
+            var fileHandler = CreateFileHandler(new Mock<Project>().Object, provider, logger.Object);
+
+            Assert.IsFalse(await fileHandler.EmitNativeDateTimeTypesAsync().ConfigureAwait(false));
+            Assert.IsFalse(await fileHandler.EmitContainerPropertyAttributeAsync().ConfigureAwait(false));
+            logger.Verify(
+                value => value.WriteMessageAsync(
+                    LogMessageCategory.Warning,
+                    It.Is<string>(message => message.Contains("could not be resolved")),
+                    It.IsAny<object[]>()),
+                Times.Once);
+        }
+
+        private static FakeInstalledPackagesProvider CreateProvider(string packageId, string version)
+        {
+            return new FakeInstalledPackagesProvider(new InstalledPackageInfo(packageId, version));
+        }
+
+        private static ConnectedServiceFileHandler CreateFileHandler(
+            Project project,
+            IInstalledPackagesProvider packagesProvider = null,
+            IMessageLogger logger = null)
         {
             var serviceConfig = new ServiceConfigurationV4 { ServiceName = "TestService" };
             var serviceInstance = new ODataConnectedServiceInstance
@@ -170,7 +161,26 @@ namespace ODataConnectedService.Tests.FileHandling
             var context = new TestConnectedServiceHandlerContext(serviceInstance, handlerHelper);
             var threadHelper = new TestThreadHelper();
 
-            return new ConnectedServiceFileHandler(context, project, threadHelper);
+            logger = logger ?? new Mock<IMessageLogger>().Object;
+            return new ConnectedServiceFileHandler(context, project, threadHelper, logger, packagesProvider);
+        }
+
+        private sealed class FakeInstalledPackagesProvider : IInstalledPackagesProvider
+        {
+            private readonly IReadOnlyList<InstalledPackageInfo> packages;
+
+            public FakeInstalledPackagesProvider(params InstalledPackageInfo[] packages)
+            {
+                this.packages = packages;
+            }
+
+            public int CallCount { get; private set; }
+
+            public Task<IReadOnlyList<InstalledPackageInfo>> GetInstalledPackagesAsync()
+            {
+                this.CallCount++;
+                return Task.FromResult(this.packages);
+            }
         }
     }
 }

--- a/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
+++ b/test/ODataConnectedService.Tests/ODataConnectedService.Tests.csproj
@@ -25,7 +25,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;VS2022PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -34,7 +34,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;VS2022PLUS</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -246,6 +246,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="CodeGeneration\SampleServiceV2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="CodeGeneration\SampleServiceV4WithDateOnlyAndTimeOnly.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <EmbeddedResource Include="CodeGenReferences\AbstractEntityTypeWithoutKey.xml" />


### PR DESCRIPTION
Follow-up to #442. The DateOnly/TimeOnly feature only read the `Microsoft.OData.Client` version from a direct `<PackageReference>`, so it silently emitted legacy `Edm.Date`/`Edm.TimeOfDay` whenever the version came from anywhere else. This PR makes detection robust, modernizes the NuGet API, and adds E2E tests to prevent regressions.

- **Version detection** - resolve the client version from the restored `project.assets.json`, Central Package Management, `VersionOverride`, MSBuild property expressions, and version ranges (not just the literal `<PackageReference Version>`).

- **NuGet API** - replace the obsolete `IVsPackageInstallerServices.GetInstalledPackages` (UI-thread delays) with `INuGetProjectService.GetInstalledPackagesAsync`, gated behind `#if VS2022PLUS`; the legacy VSIX keeps the old API.

- Bump `Microsoft.OData.Cli` version to `0.3.2`

- **Tests** - CLI + VS end-to-end tests that generate real proxies for each version source (9.0.0 → native `System.DateOnly`/`System.TimeOnly`, 8.0.0 → legacy `Edm` types), plus expanded unit coverage. Also fixes an MSBuildLocator engine-mismatch that broke the in-process generation tests on multi-SDK machines (`ExcludeAssets="runtime"` on `Microsoft.Build`).