### PR TITLE
Omit optional request values from connected-service designer data

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ as the class it is testing, followed by the suffix `Test`.
 Example: for some class `Microsoft.OData.ConnectedService.X.Y` located in `src\X\Y.cs`,
 the test class would be `Microsoft.OData.Tests.ConnectedService.Tests.X.YTest` located in `test\X\YTest.cs`
 
+#### Legacy persistence options feature flag
+
+The endpoint configuration view has a default-off `AppContext` switch:
+
+```text
+Microsoft.OData.ConnectedService.ShowLegacyPersistenceOptions
+```
+
+When the switch is disabled or not defined, the legacy **store custom headers** and **store proxy credentials** controls remain collapsed. When it is enabled, both controls are visible. The switch only controls UI visibility; custom HTTP headers and proxy username/password values are still excluded from connected-service designer data.
+
+Set the switch before creating the endpoint configuration view:
+
+```csharp
+AppContext.SetSwitch(
+    "Microsoft.OData.ConnectedService.ShowLegacyPersistenceOptions",
+    true);
+```
+
+`ConfigODataEndpoint` reads the switch during construction, so changing it does not affect views that have already been created. Set the value to `false`, or leave the switch undefined, to retain the default behavior.
+
 ### Building Command-line 
 The project can also be build using on the command-line by relying on the provided build.cmd
 

--- a/src/Microsoft.OData.CodeGen/Models/ServiceConfiguration.cs
+++ b/src/Microsoft.OData.CodeGen/Models/ServiceConfiguration.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Microsoft.OData.CodeGen.Models
 {
@@ -22,12 +23,21 @@ namespace Microsoft.OData.CodeGen.Models
         public bool MakeTypesInternal { get; set; }
         public bool OpenGeneratedFilesInIDE { get; set; }
         public bool GenerateMultipleFiles { get; set; }
+        [IgnoreDataMember]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public string CustomHttpHeaders { get; set; }
         public bool IncludeWebProxy { get; set; }
         public string WebProxyHost { get; set; }
         public bool IncludeWebProxyNetworkCredentials { get; set; }
         public bool StoreWebProxyNetworkCredentials { get; set; }
+        [IgnoreDataMember]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public string WebProxyNetworkCredentialsUsername { get; set; }
+        [IgnoreDataMember]
+        [Newtonsoft.Json.JsonIgnore]
+        [System.Text.Json.Serialization.JsonIgnore]
         public string WebProxyNetworkCredentialsPassword { get; set; }
         public string WebProxyNetworkCredentialsDomain { get; set; }
         public bool IncludeCustomHeaders { get; set; }

--- a/src/ODataConnectedService.Shared/Common/FeatureFlags.cs
+++ b/src/ODataConnectedService.Shared/Common/FeatureFlags.cs
@@ -1,0 +1,21 @@
+﻿//---------------------------------------------------------------------------------
+// <copyright file="FeatureFlags.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.OData.ConnectedService.Common
+{
+    internal static class FeatureFlags
+    {
+        internal const string ShowLegacyPersistenceOptions = "Microsoft.OData.ConnectedService.ShowLegacyPersistenceOptions";
+
+        internal static bool IsEnabled(string switchName)
+        {
+            return AppContext.TryGetSwitch(switchName, out bool isEnabled) && isEnabled;
+        }
+    }
+}

--- a/src/ODataConnectedService.Shared/ODataConnectedService.Shared.projitems
+++ b/src/ODataConnectedService.Shared/ODataConnectedService.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Common\EdmHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\ExtensionMethods.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\ExtensionsHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\FeatureFlags.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\ProjectHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\UserSettingsPersistenceHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ConnectedServiceFileHandler.cs" />

--- a/src/ODataConnectedService.Shared/ODataConnectedServiceHandler.cs
+++ b/src/ODataConnectedService.Shared/ODataConnectedServiceHandler.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using EnvDTE;
 using Microsoft.OData.CodeGen;
 using Microsoft.OData.CodeGen.CodeGeneration;
+using Microsoft.OData.CodeGen.Models;
 using Microsoft.OData.ConnectedService.Common;
 using Microsoft.VisualStudio.ConnectedServices;
 using ODataConnectedService.Shared;
@@ -51,20 +52,34 @@ namespace Microsoft.OData.ConnectedService
         {
             Project project = ProjectHelper.GetProjectFromHierarchy(context.ProjectHierarchy);
             var serviceInstance = (ODataConnectedServiceInstance)context.ServiceInstance;
-            var codeGenDescriptor = await GenerateCodeAsync(serviceInstance.ServiceConfig.Endpoint, serviceInstance.ServiceConfig.EdmxVersion, context, project).ConfigureAwait(false);            
-            if (!serviceInstance.ServiceConfig.StoreCustomHttpHeaders)
+            var codeGenDescriptor = await GenerateCodeAsync(serviceInstance.ServiceConfig.Endpoint, serviceInstance.ServiceConfig.EdmxVersion, context, project).ConfigureAwait(false);
+            context.SetExtendedDesignerData(CreatePersistedServiceConfiguration(serviceInstance.ServiceConfig));
+            return codeGenDescriptor;
+        }
+
+        private static ServiceConfiguration CreatePersistedServiceConfiguration(ServiceConfiguration serviceConfiguration)
+        {
+            if (serviceConfiguration.CustomHttpHeaders == null
+                && serviceConfiguration.WebProxyNetworkCredentialsUsername == null
+                && serviceConfiguration.WebProxyNetworkCredentialsPassword == null
+                && !serviceConfiguration.StoreCustomHttpHeaders
+                && !serviceConfiguration.StoreWebProxyNetworkCredentials)
             {
-                serviceInstance.ServiceConfig.CustomHttpHeaders = null;
-            }
-            if (!serviceInstance.ServiceConfig.StoreWebProxyNetworkCredentials)
-            {
-                serviceInstance.ServiceConfig.WebProxyNetworkCredentialsUsername = null;
-                serviceInstance.ServiceConfig.WebProxyNetworkCredentialsPassword = null;
-                serviceInstance.ServiceConfig.WebProxyNetworkCredentialsDomain = null;
+                return serviceConfiguration;
             }
 
-            context.SetExtendedDesignerData(serviceInstance.ServiceConfig);
-            return codeGenDescriptor;
+            var persistedServiceConfiguration = serviceConfiguration is ServiceConfigurationV4
+                ? new ServiceConfigurationV4()
+                : new ServiceConfiguration();
+
+            persistedServiceConfiguration.CopyPropertiesFrom(serviceConfiguration);
+            persistedServiceConfiguration.CustomHttpHeaders = null;
+            persistedServiceConfiguration.WebProxyNetworkCredentialsUsername = null;
+            persistedServiceConfiguration.WebProxyNetworkCredentialsPassword = null;
+            persistedServiceConfiguration.StoreCustomHttpHeaders = false;
+            persistedServiceConfiguration.StoreWebProxyNetworkCredentials = false;
+
+            return persistedServiceConfiguration;
         }
 
         private async Task<BaseCodeGenDescriptor> GenerateCodeAsync(string metadataUri, Version edmxVersion, ConnectedServiceHandlerContext context, Project project)

--- a/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml
+++ b/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml
@@ -119,6 +119,15 @@
                     </ToolTip>
                 </TextBox.ToolTip>
             </TextBox>
+            <CheckBox
+                x:Name="StoreCustomHttpHeaders"
+                Margin="0,5"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Content="Save Custom Http Headers In Settings Config File"
+                FontWeight="Medium"
+                IsChecked="{Binding Path=UserSettings.StoreCustomHttpHeaders, Mode=TwoWay}"
+                Visibility="Collapsed" />
         </StackPanel>
 
         <CheckBox
@@ -197,6 +206,15 @@
                     HorizontalAlignment="Left"
                     Text="{Binding Path=UserSettings.WebProxyNetworkCredentialsDomain, Mode=TwoWay}"
                     TextWrapping="Wrap" />
+                <CheckBox
+                    x:Name="StoreWebProxyNetworkCredentials"
+                    Margin="0,10"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Content="Save Web Proxy Credentials In Settings Config File"
+                    FontWeight="Medium"
+                    IsChecked="{Binding Path=UserSettings.StoreWebProxyNetworkCredentials, Mode=TwoWay}"
+                    Visibility="Collapsed" />
             </StackPanel>
         </StackPanel>
     </StackPanel>

--- a/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml
+++ b/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml
@@ -119,14 +119,6 @@
                     </ToolTip>
                 </TextBox.ToolTip>
             </TextBox>
-            <CheckBox
-                x:Name="StoreCustomHttpHeaders"
-                Margin="0,5"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Top"
-                Content="Save Custom Http Headers In Settings Config File"
-                FontWeight="Medium"
-                IsChecked="{Binding Path=UserSettings.StoreCustomHttpHeaders, Mode=TwoWay}" />
         </StackPanel>
 
         <CheckBox
@@ -205,15 +197,6 @@
                     HorizontalAlignment="Left"
                     Text="{Binding Path=UserSettings.WebProxyNetworkCredentialsDomain, Mode=TwoWay}"
                     TextWrapping="Wrap" />
-                <CheckBox
-                    x:Name="StoreWebProxyNetworkCredentials"
-                    Margin="0,10"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Top"
-                    Content="Save Web Proxy Credentials In Settings Config File"
-                    FontWeight="Medium"
-                    IsChecked="{Binding Path=UserSettings.StoreWebProxyNetworkCredentials, Mode=TwoWay}" />
-
             </StackPanel>
         </StackPanel>
     </StackPanel>

--- a/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
+++ b/src/ODataConnectedService.Shared/Views/ConfigODataEndpoint.xaml.cs
@@ -22,8 +22,19 @@ namespace Microsoft.OData.ConnectedService.Views
         internal UserSettings UserSettings { get; set; }
 
         public ConfigODataEndpoint()
+            : this(FeatureFlags.IsEnabled(FeatureFlags.ShowLegacyPersistenceOptions))
+        {
+        }
+
+        internal ConfigODataEndpoint(bool showLegacyPersistenceOptions)
         {
             InitializeComponent();
+
+            Visibility legacyPersistenceOptionsVisibility = showLegacyPersistenceOptions
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+            StoreCustomHttpHeaders.Visibility = legacyPersistenceOptionsVisibility;
+            StoreWebProxyNetworkCredentials.Visibility = legacyPersistenceOptionsVisibility;
         }
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceHandlerTest.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceHandlerTest.cs
@@ -1,11 +1,15 @@
 ﻿//-----------------------------------------------------------------------------------
 // <copyright file="ODataConnectedServiceHandlerTest.cs" company=".NET Foundation">
-//      Copyright (c) .NET Foundation and Contributors. All rights reserved. 
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
 //-----------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.OData.CodeGen.CodeGeneration;
@@ -23,6 +27,52 @@ namespace Microsoft.OData.ConnectedService.Tests
 {
     public class ODataConnectedServiceHandlerTest
     {
+        public static IEnumerable<object[]> CustomHeaderCases
+        {
+            get
+            {
+                string[] methods = { "AddServiceInstanceAsync", "UpdateServiceInstanceAsync" };
+                string[] values = { null, string.Empty, "X-One: value", "X-One: value\nX-Two: another-value" };
+
+                foreach (string method in methods)
+                {
+                    foreach (bool store in new[] { false, true })
+                    {
+                        foreach (string value in values)
+                        {
+                            yield return new object[] { method, store, value };
+                        }
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> WebProxyCredentialCases
+        {
+            get
+            {
+                string[] methods = { "AddServiceInstanceAsync", "UpdateServiceInstanceAsync" };
+                object[][] values =
+                {
+                    new object[] { null, null },
+                    new object[] { string.Empty, string.Empty },
+                    new object[] { "user", null },
+                    new object[] { "user", "password" }
+                };
+
+                foreach (string method in methods)
+                {
+                    foreach (bool store in new[] { false, true })
+                    {
+                        foreach (object[] value in values)
+                        {
+                            yield return new object[] { method, store, value[0], value[1] };
+                        }
+                    }
+                }
+            }
+        }
+
         [StaTheory]
         [InlineData("AddServiceInstanceAsync", 4, "V4")]
         [InlineData("AddServiceInstanceAsync", 3, "V3")]
@@ -43,30 +93,27 @@ namespace Microsoft.OData.ConnectedService.Tests
                 UseDataServiceCollection = false,
                 MakeTypesInternal = true
             };
-            var tokenSource = new CancellationTokenSource();
             var context = SetupContext(serviceConfig);
-            await (typeof(ODataConnectedServiceHandler).GetMethod(method).Invoke(
-                serviceHandler, new object[] { context, tokenSource.Token }) as Task);
+
+            await InvokeHandlerAsync(serviceHandler, context, method);
+
             var descriptor = descriptorFactory.CreatedInstance as TestCodeGenDescriptor;
             Assert.True(descriptor.AddedClientCode);
             Assert.True(descriptor.AddedNugetPackages);
             Assert.Equal(generatorVersion, descriptor.Version);
-            Assert.Equal(serviceConfig, context.SavedExtendedDesignData);
+            Assert.Same(serviceConfig, context.SavedExtendedDesignData);
+            Assert.Equal(serviceConfig.ServiceName, ((ServiceConfiguration)context.SavedExtendedDesignData).ServiceName);
         }
 
         [StaTheory]
-        [InlineData("AddServiceInstanceAsync", 4, false)]
-        [InlineData("AddServiceInstanceAsync", 4, true)]
-        [InlineData("UpdateServiceInstanceAsync", 4, false)]
-        [InlineData("UpdateServiceInstanceAsync", 4, true)]
-        public async Task TestAddUpdateServiceInstance_SavesCustomHttpHeadersToDesignerDataAccordingToStoreCustomHttpHeadersAsync(string method, int edmxVersion, bool store)
+        [MemberData(nameof(CustomHeaderCases))]
+        public async Task TestAddUpdateServiceInstance_EndToEndDesignerDataOmitsCustomHttpHeadersAsync(string method, bool store, string headerValue)
         {
             var descriptorFactory = new TestCodeGenDescriptorFactory();
             var serviceHandler = new ODataConnectedServiceHandler(descriptorFactory);
-            const string headerValue = @"Authorization: Bearer xyz12345-randomstring";
             var serviceConfig = new ServiceConfiguration()
             {
-                EdmxVersion = new Version(edmxVersion, 0, 0, 0),
+                EdmxVersion = new Version(4, 0, 0, 0),
                 ServiceName = "TestService",
                 UseDataServiceCollection = false,
                 MakeTypesInternal = true,
@@ -74,49 +121,212 @@ namespace Microsoft.OData.ConnectedService.Tests
                 CustomHttpHeaders = headerValue,
                 StoreCustomHttpHeaders = store
             };
-            var tokenSource = new CancellationTokenSource();
             var context = SetupContext(serviceConfig);
-            await (typeof(ODataConnectedServiceHandler).GetMethod(method).Invoke(
-                serviceHandler, new object[] { context, tokenSource.Token }) as Task);
 
-            // CustomHttpHeaders should be null when StoreCustomHttpHeaders is false since we are not saving them to DesignerData
-            Assert.Equal(serviceConfig, context.SavedExtendedDesignData);
-            Assert.Equal(serviceConfig.CustomHttpHeaders, store ? headerValue : null);
+            await InvokeHandlerAsync(serviceHandler, context, method);
+
+            var savedServiceConfig = (ServiceConfiguration)context.SavedExtendedDesignData;
+            var descriptor = (TestCodeGenDescriptor)descriptorFactory.CreatedInstance;
+            AssertPersistedCopyExpected(serviceConfig, savedServiceConfig, headerValue != null || store);
+            Assert.Null(savedServiceConfig.CustomHttpHeaders);
+            Assert.False(savedServiceConfig.StoreCustomHttpHeaders);
+            Assert.Equal(headerValue, serviceConfig.CustomHttpHeaders);
+            Assert.Equal(headerValue, descriptor.GeneratedServiceConfiguration.CustomHttpHeaders);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.CustomHttpHeaders)}\":", context.SavedExtendedDesignDataJson);
+            Assert.Contains($"\"{nameof(ServiceConfiguration.ServiceName)}\":\"TestService\"", context.SavedExtendedDesignDataJson);
         }
 
         [StaTheory]
-        [InlineData("AddServiceInstanceAsync", 4, false)]
-        [InlineData("AddServiceInstanceAsync", 4, true)]
-        [InlineData("UpdateServiceInstanceAsync", 4, false)]
-        [InlineData("UpdateServiceInstanceAsync", 4, true)]
-        public async Task TestAddUpdateServiceInstance_SavesWebProxyDetailsToDesignerDataAccordingToStoreWebProxyNetworkCredentialsAsync(string method, int edmxVersion, bool store)
+        [MemberData(nameof(WebProxyCredentialCases))]
+        public async Task TestAddUpdateServiceInstance_EndToEndDesignerDataOmitsWebProxyCredentialsAsync(
+            string method,
+            bool store,
+            string username,
+            string password)
         {
             var descriptorFactory = new TestCodeGenDescriptorFactory();
             var serviceHandler = new ODataConnectedServiceHandler(descriptorFactory);
-            const string username = "user";
-            const string password = "pass";
             var serviceConfig = new ServiceConfiguration()
             {
-                EdmxVersion = new Version(edmxVersion, 0, 0, 0),
+                EdmxVersion = new Version(4, 0, 0, 0),
                 ServiceName = "TestService",
                 UseDataServiceCollection = false,
                 MakeTypesInternal = true,
                 IncludeWebProxy = true,
                 IncludeWebProxyNetworkCredentials = true,
                 WebProxyHost = "http://example.com:80",
+                WebProxyNetworkCredentialsDomain = "example",
                 WebProxyNetworkCredentialsUsername = username,
                 WebProxyNetworkCredentialsPassword = password,
                 StoreWebProxyNetworkCredentials = store
             };
-            var tokenSource = new CancellationTokenSource();
             var context = SetupContext(serviceConfig);
-            await (typeof(ODataConnectedServiceHandler).GetMethod(method).Invoke(
-                serviceHandler, new object[] { context, tokenSource.Token }) as Task);
 
-            // WebProxy username and password should be null when StoreWebProxyNetworkCredentials is false since we are not saving them to DesignerData
-            Assert.Equal(serviceConfig, context.SavedExtendedDesignData);
-            Assert.Equal(serviceConfig.WebProxyNetworkCredentialsUsername, store ? username : null);
-            Assert.Equal(serviceConfig.WebProxyNetworkCredentialsPassword, store ? password : null);
+            await InvokeHandlerAsync(serviceHandler, context, method);
+
+            var savedServiceConfig = (ServiceConfiguration)context.SavedExtendedDesignData;
+            var descriptor = (TestCodeGenDescriptor)descriptorFactory.CreatedInstance;
+            AssertPersistedCopyExpected(serviceConfig, savedServiceConfig, username != null || password != null || store);
+            Assert.Null(savedServiceConfig.WebProxyNetworkCredentialsUsername);
+            Assert.Null(savedServiceConfig.WebProxyNetworkCredentialsPassword);
+            Assert.False(savedServiceConfig.StoreWebProxyNetworkCredentials);
+            Assert.Equal(username, serviceConfig.WebProxyNetworkCredentialsUsername);
+            Assert.Equal(password, serviceConfig.WebProxyNetworkCredentialsPassword);
+            Assert.Equal(username, descriptor.GeneratedServiceConfiguration.WebProxyNetworkCredentialsUsername);
+            Assert.Equal(password, descriptor.GeneratedServiceConfiguration.WebProxyNetworkCredentialsPassword);
+            Assert.Equal("http://example.com:80", savedServiceConfig.WebProxyHost);
+            Assert.Equal("example", savedServiceConfig.WebProxyNetworkCredentialsDomain);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsUsername)}\":", context.SavedExtendedDesignDataJson);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsPassword)}\":", context.SavedExtendedDesignDataJson);
+            Assert.Contains($"\"{nameof(ServiceConfiguration.WebProxyHost)}\":\"http://example.com:80\"", context.SavedExtendedDesignDataJson);
+            Assert.Contains($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsDomain)}\":\"example\"", context.SavedExtendedDesignDataJson);
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData("", "", "")]
+        [InlineData("X-One: value", "user", null)]
+        [InlineData("X-One: value\nX-Two: another-value", "user", "password")]
+        public void ServiceConfigurationSerialization_OmitsOptionalRequestValues(
+            string customHttpHeaders,
+            string username,
+            string password)
+        {
+            var serviceConfig = new ServiceConfiguration()
+            {
+                ServiceName = "TestService",
+                CustomHttpHeaders = customHttpHeaders,
+                WebProxyNetworkCredentialsUsername = username,
+                WebProxyNetworkCredentialsPassword = password
+            };
+
+            var newtonsoftJson = Newtonsoft.Json.JsonConvert.SerializeObject(serviceConfig);
+            var systemTextJson = System.Text.Json.JsonSerializer.Serialize(serviceConfig);
+            var dataContractXml = SerializeWithDataContract(serviceConfig);
+
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.CustomHttpHeaders)}\":", newtonsoftJson);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsUsername)}\":", newtonsoftJson);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsPassword)}\":", newtonsoftJson);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.CustomHttpHeaders)}\":", systemTextJson);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsUsername)}\":", systemTextJson);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsPassword)}\":", systemTextJson);
+            Assert.DoesNotContain($"<{nameof(ServiceConfiguration.CustomHttpHeaders)}", dataContractXml);
+            Assert.DoesNotContain($"<{nameof(ServiceConfiguration.WebProxyNetworkCredentialsUsername)}", dataContractXml);
+            Assert.DoesNotContain($"<{nameof(ServiceConfiguration.WebProxyNetworkCredentialsPassword)}", dataContractXml);
+            Assert.Contains($"\"{nameof(ServiceConfiguration.ServiceName)}\":\"TestService\"", newtonsoftJson);
+            Assert.Contains($"\"{nameof(ServiceConfiguration.ServiceName)}\":\"TestService\"", systemTextJson);
+            Assert.Contains($"<{nameof(ServiceConfiguration.ServiceName)}>TestService</{nameof(ServiceConfiguration.ServiceName)}>", dataContractXml);
+        }
+
+        [StaTheory]
+        [InlineData("AddServiceInstanceAsync")]
+        [InlineData("UpdateServiceInstanceAsync")]
+        public async Task TestAddUpdateServiceInstance_EndToEndDesignerDataOmitsValuesAfterClearAndReAddAsync(string method)
+        {
+            var descriptorFactory = new TestCodeGenDescriptorFactory();
+            var serviceHandler = new ODataConnectedServiceHandler(descriptorFactory);
+            var serviceConfig = new ServiceConfiguration()
+            {
+                EdmxVersion = new Version(4, 0, 0, 0),
+                ServiceName = "TestService",
+                StoreCustomHttpHeaders = true,
+                CustomHttpHeaders = "X-Old: old-value",
+                StoreWebProxyNetworkCredentials = true,
+                WebProxyNetworkCredentialsUsername = "old-user",
+                WebProxyNetworkCredentialsPassword = "old-password"
+            };
+            var context = SetupContext(serviceConfig);
+
+            await InvokeHandlerAsync(serviceHandler, context, method);
+            AssertPersistedOptionalRequestValuesAreOmitted(context);
+
+            serviceConfig.CustomHttpHeaders = null;
+            serviceConfig.WebProxyNetworkCredentialsUsername = null;
+            serviceConfig.WebProxyNetworkCredentialsPassword = null;
+            await InvokeHandlerAsync(serviceHandler, context, method);
+            AssertPersistedOptionalRequestValuesAreOmitted(context);
+
+            serviceConfig.CustomHttpHeaders = "X-New: new-value";
+            serviceConfig.WebProxyNetworkCredentialsUsername = "new-user";
+            serviceConfig.WebProxyNetworkCredentialsPassword = "new-password";
+            await InvokeHandlerAsync(serviceHandler, context, method);
+            AssertPersistedOptionalRequestValuesAreOmitted(context);
+
+            Assert.Equal("X-New: new-value", serviceConfig.CustomHttpHeaders);
+            Assert.Equal("new-user", serviceConfig.WebProxyNetworkCredentialsUsername);
+            Assert.Equal("new-password", serviceConfig.WebProxyNetworkCredentialsPassword);
+        }
+
+        [StaTheory]
+        [InlineData("AddServiceInstanceAsync")]
+        [InlineData("UpdateServiceInstanceAsync")]
+        public async Task TestAddUpdateServiceInstance_PreservesV4DesignerSettingsAsync(string method)
+        {
+            var descriptorFactory = new TestCodeGenDescriptorFactory();
+            var serviceHandler = new ODataConnectedServiceHandler(descriptorFactory);
+            var serviceConfig = new ServiceConfigurationV4()
+            {
+                EdmxVersion = new Version(4, 0, 0, 0),
+                ServiceName = "TestService",
+                EnableNamingAlias = true,
+                CustomHttpHeaders = "X-One: value"
+            };
+            var context = SetupContext(serviceConfig);
+
+            await InvokeHandlerAsync(serviceHandler, context, method);
+
+            var savedServiceConfig = Assert.IsType<ServiceConfigurationV4>(context.SavedExtendedDesignData);
+            Assert.True(savedServiceConfig.EnableNamingAlias);
+            Assert.Equal("TestService", savedServiceConfig.ServiceName);
+            Assert.Null(savedServiceConfig.CustomHttpHeaders);
+        }
+
+        private static void AssertPersistedCopyExpected(
+            ServiceConfiguration serviceConfig,
+            ServiceConfiguration savedServiceConfig,
+            bool copyExpected)
+        {
+            if (copyExpected)
+            {
+                Assert.NotSame(serviceConfig, savedServiceConfig);
+            }
+            else
+            {
+                Assert.Same(serviceConfig, savedServiceConfig);
+            }
+        }
+
+        private static void AssertPersistedOptionalRequestValuesAreOmitted(TestConnectedServiceHandlerContext context)
+        {
+            var savedServiceConfig = (ServiceConfiguration)context.SavedExtendedDesignData;
+            Assert.Null(savedServiceConfig.CustomHttpHeaders);
+            Assert.Null(savedServiceConfig.WebProxyNetworkCredentialsUsername);
+            Assert.Null(savedServiceConfig.WebProxyNetworkCredentialsPassword);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.CustomHttpHeaders)}\":", context.SavedExtendedDesignDataJson);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsUsername)}\":", context.SavedExtendedDesignDataJson);
+            Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsPassword)}\":", context.SavedExtendedDesignDataJson);
+        }
+
+        private static async Task InvokeHandlerAsync(
+            ODataConnectedServiceHandler serviceHandler,
+            TestConnectedServiceHandlerContext context,
+            string method)
+        {
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                await (typeof(ODataConnectedServiceHandler).GetMethod(method).Invoke(
+                    serviceHandler, new object[] { context, tokenSource.Token }) as Task);
+            }
+        }
+
+        private static string SerializeWithDataContract(ServiceConfiguration serviceConfig)
+        {
+            var serializer = new DataContractSerializer(typeof(ServiceConfiguration));
+            using (var stream = new MemoryStream())
+            {
+                serializer.WriteObject(stream, serviceConfig);
+                return Encoding.UTF8.GetString(stream.ToArray());
+            }
         }
 
         static TestConnectedServiceHandlerContext SetupContext(ServiceConfiguration serviceConfig)
@@ -166,10 +376,12 @@ namespace Microsoft.OData.ConnectedService.Tests
         public string Version { get; set; }
         public bool AddedClientCode { get; private set; }
         public bool AddedNugetPackages { get; private set; }
+        public ServiceConfiguration GeneratedServiceConfiguration { get; private set; }
 
         public override Task AddGeneratedClientCodeAsync(string metadataUri, string outputDirectory, LanguageOption languageOption, ServiceConfiguration serviceConfiguration)
         {
             AddedClientCode = true;
+            GeneratedServiceConfiguration = serviceConfiguration;
             return Task.CompletedTask;
         }
 

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceHandlerTest.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceHandlerTest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.OData.ConnectedService.Tests
             };
             var context = SetupContext(serviceConfig);
 
-            await InvokeHandlerAsync(serviceHandler, context, method);
+            await InvokeHandlerAsync(serviceHandler, context, method).ConfigureAwait(false);
 
             var descriptor = descriptorFactory.CreatedInstance as TestCodeGenDescriptor;
             Assert.True(descriptor.AddedClientCode);
@@ -124,7 +124,7 @@ namespace Microsoft.OData.ConnectedService.Tests
             };
             var context = SetupContext(serviceConfig);
 
-            await InvokeHandlerAsync(serviceHandler, context, method);
+            await InvokeHandlerAsync(serviceHandler, context, method).ConfigureAwait(false);
 
             var savedServiceConfig = (ServiceConfiguration)context.SavedExtendedDesignData;
             var descriptor = (TestCodeGenDescriptor)descriptorFactory.CreatedInstance;
@@ -163,7 +163,7 @@ namespace Microsoft.OData.ConnectedService.Tests
             };
             var context = SetupContext(serviceConfig);
 
-            await InvokeHandlerAsync(serviceHandler, context, method);
+            await InvokeHandlerAsync(serviceHandler, context, method).ConfigureAwait(false);
 
             var savedServiceConfig = (ServiceConfiguration)context.SavedExtendedDesignData;
             var descriptor = (TestCodeGenDescriptor)descriptorFactory.CreatedInstance;
@@ -210,7 +210,7 @@ namespace Microsoft.OData.ConnectedService.Tests
             var serviceHandler = new ODataConnectedServiceHandler(descriptorFactory);
             var context = SetupContext(serviceConfig);
 
-            await InvokeHandlerAsync(serviceHandler, context, method);
+            await InvokeHandlerAsync(serviceHandler, context, method).ConfigureAwait(false);
 
             var descriptor = (TestCodeGenDescriptor)descriptorFactory.CreatedInstance;
             var generatedServiceConfig = descriptor.GeneratedServiceConfiguration;
@@ -284,19 +284,19 @@ namespace Microsoft.OData.ConnectedService.Tests
             };
             var context = SetupContext(serviceConfig);
 
-            await InvokeHandlerAsync(serviceHandler, context, method);
+            await InvokeHandlerAsync(serviceHandler, context, method).ConfigureAwait(false);
             AssertPersistedOptionalRequestValuesAreOmitted(context);
 
             serviceConfig.CustomHttpHeaders = null;
             serviceConfig.WebProxyNetworkCredentialsUsername = null;
             serviceConfig.WebProxyNetworkCredentialsPassword = null;
-            await InvokeHandlerAsync(serviceHandler, context, method);
+            await InvokeHandlerAsync(serviceHandler, context, method).ConfigureAwait(false);
             AssertPersistedOptionalRequestValuesAreOmitted(context);
 
             serviceConfig.CustomHttpHeaders = "X-New: new-value";
             serviceConfig.WebProxyNetworkCredentialsUsername = "new-user";
             serviceConfig.WebProxyNetworkCredentialsPassword = "new-password";
-            await InvokeHandlerAsync(serviceHandler, context, method);
+            await InvokeHandlerAsync(serviceHandler, context, method).ConfigureAwait(false);
             AssertPersistedOptionalRequestValuesAreOmitted(context);
 
             Assert.Equal("X-New: new-value", serviceConfig.CustomHttpHeaders);
@@ -320,7 +320,7 @@ namespace Microsoft.OData.ConnectedService.Tests
             };
             var context = SetupContext(serviceConfig);
 
-            await InvokeHandlerAsync(serviceHandler, context, method);
+            await InvokeHandlerAsync(serviceHandler, context, method).ConfigureAwait(false);
 
             var savedServiceConfig = Assert.IsType<ServiceConfigurationV4>(context.SavedExtendedDesignData);
             Assert.True(savedServiceConfig.EnableNamingAlias);
@@ -362,7 +362,7 @@ namespace Microsoft.OData.ConnectedService.Tests
             using (var tokenSource = new CancellationTokenSource())
             {
                 await (typeof(ODataConnectedServiceHandler).GetMethod(method).Invoke(
-                    serviceHandler, new object[] { context, tokenSource.Token }) as Task);
+                    serviceHandler, new object[] { context, tokenSource.Token }) as Task).ConfigureAwait(false);
             }
         }
 

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceHandlerTest.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceHandlerTest.cs
@@ -18,6 +18,7 @@ using Microsoft.OData.CodeGen.FileHandling;
 using Microsoft.OData.CodeGen.Logging;
 using Microsoft.OData.CodeGen.Models;
 using Microsoft.OData.CodeGen.PackageInstallation;
+using Microsoft.OData.ConnectedService.Common;
 using Microsoft.OData.ConnectedService.Tests.TestHelpers;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
@@ -180,6 +181,52 @@ namespace Microsoft.OData.ConnectedService.Tests
             Assert.DoesNotContain($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsPassword)}\":", context.SavedExtendedDesignDataJson);
             Assert.Contains($"\"{nameof(ServiceConfiguration.WebProxyHost)}\":\"http://example.com:80\"", context.SavedExtendedDesignDataJson);
             Assert.Contains($"\"{nameof(ServiceConfiguration.WebProxyNetworkCredentialsDomain)}\":\"example\"", context.SavedExtendedDesignDataJson);
+        }
+
+        [StaTheory]
+        [InlineData("AddServiceInstanceAsync")]
+        [InlineData("UpdateServiceInstanceAsync")]
+        public async Task TestAddUpdateServiceInstance_UserProvidedRequestValuesReachCodeGenerationAsync(string method)
+        {
+            var userSettings = new UserSettings(configName: $"HandlerTest-{Guid.NewGuid():N}")
+            {
+                ServiceName = "TestService",
+                Endpoint = "http://service/$metadata",
+                IncludeCustomHeaders = true,
+                CustomHttpHeaders = "X-One: value\nX-Two: another-value",
+                IncludeWebProxy = true,
+                WebProxyHost = "http://example.com:80",
+                IncludeWebProxyNetworkCredentials = true,
+                WebProxyNetworkCredentialsDomain = "example",
+                WebProxyNetworkCredentialsUsername = "user",
+                WebProxyNetworkCredentialsPassword = "password"
+            };
+            var serviceConfig = new ServiceConfigurationV4()
+            {
+                EdmxVersion = new Version(4, 0, 0, 0)
+            };
+            serviceConfig.CopyPropertiesFrom(userSettings);
+            var descriptorFactory = new TestCodeGenDescriptorFactory();
+            var serviceHandler = new ODataConnectedServiceHandler(descriptorFactory);
+            var context = SetupContext(serviceConfig);
+
+            await InvokeHandlerAsync(serviceHandler, context, method);
+
+            var descriptor = (TestCodeGenDescriptor)descriptorFactory.CreatedInstance;
+            var generatedServiceConfig = descriptor.GeneratedServiceConfiguration;
+            Assert.Same(serviceConfig, generatedServiceConfig);
+            Assert.Equal("X-One: value\nX-Two: another-value", generatedServiceConfig.CustomHttpHeaders);
+            Assert.Equal("http://example.com:80", generatedServiceConfig.WebProxyHost);
+            Assert.Equal("example", generatedServiceConfig.WebProxyNetworkCredentialsDomain);
+            Assert.Equal("user", generatedServiceConfig.WebProxyNetworkCredentialsUsername);
+            Assert.Equal("password", generatedServiceConfig.WebProxyNetworkCredentialsPassword);
+
+            var savedServiceConfig = Assert.IsType<ServiceConfigurationV4>(context.SavedExtendedDesignData);
+            Assert.Null(savedServiceConfig.CustomHttpHeaders);
+            Assert.Equal("http://example.com:80", savedServiceConfig.WebProxyHost);
+            Assert.Equal("example", savedServiceConfig.WebProxyNetworkCredentialsDomain);
+            Assert.Null(savedServiceConfig.WebProxyNetworkCredentialsUsername);
+            Assert.Null(savedServiceConfig.WebProxyNetworkCredentialsPassword);
         }
 
         [Theory]

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -601,7 +601,7 @@ namespace ODataConnectedService.Tests
                 Assert.True(config.IncludeWebProxy);
                 Assert.Equal("http://localhost:8080", config.WebProxyHost);
                 Assert.True(config.IncludeWebProxyNetworkCredentials);
-                Assert.True(config.StoreCustomHttpHeaders);
+                Assert.True(config.StoreWebProxyNetworkCredentials);
                 Assert.Equal("domain", config.WebProxyNetworkCredentialsDomain);
                 Assert.Equal("user", config.WebProxyNetworkCredentialsUsername);
                 Assert.Equal("pass", config.WebProxyNetworkCredentialsPassword);

--- a/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
+++ b/test/ODataConnectedService.Tests/ODataConnectedServiceWizardTests.cs
@@ -18,6 +18,7 @@ using FluentAssertions;
 using Microsoft.OData.CodeGen.Common;
 using Microsoft.OData.CodeGen.Models;
 using Microsoft.OData.ConnectedService;
+using Microsoft.OData.ConnectedService.Common;
 using Microsoft.OData.ConnectedService.Views;
 using Microsoft.OData.Edm;
 using Microsoft.VisualStudio.ConnectedServices;
@@ -465,6 +466,36 @@ namespace ODataConnectedService.Tests
                 Assert.False(advancedView.IncludeT4File.IsEnabled);
                 Assert.False(advancedView.GenerateMultipleFiles.IsEnabled);
                 Assert.False(advancedView.OmitVersioningInfo.IsEnabled);
+            }
+        }
+
+        [StaTheory]
+        [InlineData(false, Visibility.Collapsed)]
+        [InlineData(true, Visibility.Visible)]
+        public void TestLegacyPersistenceOptionsVisibility(bool flagEnabled, Visibility expectedVisibility)
+        {
+            var endpointView = new ConfigODataEndpoint(flagEnabled);
+
+            Assert.Equal(expectedVisibility, endpointView.StoreCustomHttpHeaders.Visibility);
+            Assert.Equal(expectedVisibility, endpointView.StoreWebProxyNetworkCredentials.Visibility);
+        }
+
+        [Fact]
+        public void TestFeatureFlagUsesAppContextSwitch()
+        {
+            const string switchName = "Microsoft.OData.ConnectedService.Tests.FeatureFlag";
+
+            AppContext.SetSwitch(switchName, false);
+            Assert.False(FeatureFlags.IsEnabled(switchName));
+
+            try
+            {
+                AppContext.SetSwitch(switchName, true);
+                Assert.True(FeatureFlags.IsEnabled(switchName));
+            }
+            finally
+            {
+                AppContext.SetSwitch(switchName, false);
             }
         }
 

--- a/test/ODataConnectedService.Tests/TestHelpers/TestConnectedServiceHandlerContext.cs
+++ b/test/ODataConnectedService.Tests/TestHelpers/TestConnectedServiceHandlerContext.cs
@@ -30,9 +30,12 @@ namespace Microsoft.OData.ConnectedService.Tests.TestHelpers
 
         public object SavedExtendedDesignData { get; private set; }
 
+        public string SavedExtendedDesignDataJson { get; private set; }
+
         public override void SetExtendedDesignerData<TData>(TData data)
         {
             SavedExtendedDesignData = data;
+            SavedExtendedDesignDataJson = Newtonsoft.Json.JsonConvert.SerializeObject(data);
         }
         public override IDictionary<string, object> Args =>
             throw new System.NotImplementedException();


### PR DESCRIPTION
## Summary

Keep custom HTTP headers and web-proxy username/password values available for the active code-generation operation, but omit them from connected-service designer data. The default configuration path remains unchanged and avoids creating a copy when there are no optional values or legacy save flags to remove.

## Changes

- Mark custom HTTP headers and web-proxy username/password properties as ignored by DataContractSerializer, Newtonsoft.Json, and System.Text.Json.
- Persist a sanitized copy only when optional values or legacy save flags are present.
- Preserve the original in-memory configuration passed to code generation.
- Preserve non-optional proxy settings, including host and domain.
- Preserve the concrete `ServiceConfigurationV4` type and V4-specific values.
- Remove the two save controls because these values are no longer written to designer data.
- Capture serialized designer data in handler-path tests.

## Before

Enabling either save control retained the corresponding optional values on the configuration object passed to designer-data persistence.

## After

Designer data omits custom HTTP headers and web-proxy username/password values regardless of legacy save-flag values. The active generation operation still receives the original values. Configurations without those values or flags use the existing object directly.