### PR TITLE
Reject invalid generated names in multiple-file output

### DIFF
--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenFilesManager.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenFilesManager.ttinclude
@@ -30,6 +30,8 @@
 /// </summary>
 /// <param name="context">The code generation context.</param>
 public class FilesManager {
+    private static readonly char[] InvalidGeneratedFileNameChars = { '/', '\\', ':', '"', '<', '>', '|', '?', '*' };
+
     /// <summary>
     /// Creates an instance of the FilesManager. The object used to generate and manage
     /// multiple source files.
@@ -138,12 +140,13 @@ public class FilesManager {
             ValidateGeneratedFileNames();
             string headerText = Template.ToString(_header.Start, _header.Length);
             string footerText = Template.ToString(_footer.Start, _footer.Length);
+            string outputPath = Path.GetTempPath();
             int length = files.Count;
             for (int i = length; i > 0; i--)
             {
                 Block block = files[i - 1];
                 if (block.IsContainer) continue;
-                string fileName = Path.GetTempFileName();
+                string fileName = Path.Combine(outputPath, block.Name);
                 string content = headerText + Template.ToString(block.Start, block.Length) + footerText;
                 tasks.Add(CreateFileAsync(fileName, content));
                 block.TemporaryFilePath = fileName;
@@ -175,13 +178,9 @@ public class FilesManager {
                 string outputFile = ResolveGeneratedFilePath(referenceFolder, block.Name);
                 bool fileExists = File.Exists(outputFile);
               
-                await handlerHelper.AddFileAsync(fileName, outputFile, new ODataFileOptions { OpenOnComplete = OpenGeneratedFilesInIDE, SuppressOverwritePrompt = true })
-                .ContinueWith(
-                    async _ =>
-                    {
-                        await logger?.WriteMessageAsync(LogMessageCategory.Information,
-                            "\"{0}\" has been {1}.", block.Name, fileExists ? "updated" : "added");
-                    }, System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously);
+                await handlerHelper.AddFileAsync(fileName, outputFile, new ODataFileOptions { OpenOnComplete = OpenGeneratedFilesInIDE, SuppressOverwritePrompt = true });
+                await logger?.WriteMessageAsync(LogMessageCategory.Information,
+                    "\"{0}\" has been {1}.", block.Name, fileExists ? "updated" : "added");
             }
         }
     }
@@ -244,15 +243,7 @@ public class FilesManager {
 
         if (fileName == "."
             || fileName == ".."
-            || fileName.IndexOf('/') >= 0
-            || fileName.IndexOf('\\') >= 0
-            || fileName.IndexOf(':') >= 0
-            || fileName.IndexOf('"') >= 0
-            || fileName.IndexOf('<') >= 0
-            || fileName.IndexOf('>') >= 0
-            || fileName.IndexOf('|') >= 0
-            || fileName.IndexOf('?') >= 0
-            || fileName.IndexOf('*') >= 0
+            || fileName.IndexOfAny(InvalidGeneratedFileNameChars) >= 0
             || fileName.EndsWith(".", StringComparison.Ordinal)
             || fileName.EndsWith(" ", StringComparison.Ordinal)
             || ContainsControlCharacter(fileName)

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenFilesManager.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenFilesManager.ttinclude
@@ -32,6 +32,15 @@
 public class FilesManager {
     private static readonly char[] InvalidGeneratedFileNameChars = { '/', '\\', ':', '"', '<', '>', '|', '?', '*' };
 
+    // Windows reserves these device names even when followed by an extension:
+    // console, printer, auxiliary, null, serial ports, and parallel printer ports.
+    private static readonly HashSet<string> ReservedFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+    };
+
     /// <summary>
     /// Creates an instance of the FilesManager. The object used to generate and manage
     /// multiple source files.
@@ -255,6 +264,7 @@ public class FilesManager {
 
     private static bool ContainsControlCharacter(string fileName)
     {
+        // U+0000 through U+001F are non-printing control characters and invalid in Windows file names.
         int length = fileName.Length;
         for (int i = 0; i < length; i++)
         {
@@ -270,19 +280,7 @@ public class FilesManager {
     private static bool IsReservedFileName(string fileName)
     {
         string baseName = Path.GetFileNameWithoutExtension(fileName);
-        if (baseName.Equals("CON", StringComparison.OrdinalIgnoreCase)
-            || baseName.Equals("PRN", StringComparison.OrdinalIgnoreCase)
-            || baseName.Equals("AUX", StringComparison.OrdinalIgnoreCase)
-            || baseName.Equals("NUL", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return baseName.Length == 4
-            && (baseName.StartsWith("COM", StringComparison.OrdinalIgnoreCase)
-                || baseName.StartsWith("LPT", StringComparison.OrdinalIgnoreCase))
-            && baseName[3] >= '1'
-            && baseName[3] <= '9';
+        return ReservedFileNames.Contains(baseName);
     }
 
     public virtual string GetCustomToolNamespace(string fileName)

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenFilesManager.ttinclude
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenFilesManager.ttinclude
@@ -30,7 +30,6 @@
 /// </summary>
 /// <param name="context">The code generation context.</param>
 public class FilesManager {
-
     /// <summary>
     /// Creates an instance of the FilesManager. The object used to generate and manage
     /// multiple source files.
@@ -136,15 +135,15 @@ public class FilesManager {
         {
             var tasks = new List<Task>();
             EndBlock();
+            ValidateGeneratedFileNames();
             string headerText = Template.ToString(_header.Start, _header.Length);
             string footerText = Template.ToString(_footer.Start, _footer.Length);
-            var outputPath = Path.GetTempPath();
             int length = files.Count;
             for (int i = length; i > 0; i--)
             {
                 Block block = files[i - 1];
                 if (block.IsContainer) continue;
-                string fileName = Path.Combine(outputPath, block.Name);
+                string fileName = Path.GetTempFileName();
                 string content = headerText + Template.ToString(block.Start, block.Length) + footerText;
                 tasks.Add(CreateFileAsync(fileName, content));
                 block.TemporaryFilePath = fileName;
@@ -163,6 +162,7 @@ public class FilesManager {
     {
         if (split)
         {
+            ValidateGeneratedFileNames();
             int length = files.Count;
             await logger?.WriteMessageAsync(LogMessageCategory.Information, "Adding {0} Generated files to the project. This may take a while!", length);
             for (int i = length; i > 0; i--)
@@ -172,7 +172,7 @@ public class FilesManager {
                 string fileName = block.TemporaryFilePath;
                 if (!File.Exists(fileName)) continue;
 
-                string outputFile = Path.Combine(referenceFolder, block.Name);
+                string outputFile = ResolveGeneratedFilePath(referenceFolder, block.Name);
                 bool fileExists = File.Exists(outputFile);
               
                 await handlerHelper.AddFileAsync(fileName, outputFile, new ODataFileOptions { OpenOnComplete = OpenGeneratedFilesInIDE, SuppressOverwritePrompt = true })
@@ -200,6 +200,98 @@ public class FilesManager {
             fileStream.SetLength(0);
             await writer.WriteAsync(content).ConfigureAwait(false);
         }
+    }
+
+    private void ValidateGeneratedFileNames()
+    {
+        HashSet<string> fileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int length = files.Count;
+        for (int i = length; i > 0; i--)
+        {
+            Block block = files[i - 1];
+            if (block.IsContainer) continue;
+            ValidateGeneratedFileName(block.Name);
+            if (!fileNames.Add(block.Name))
+            {
+                throw new InvalidOperationException("Generated file names must be unique.");
+            }
+        }
+    }
+
+    private static string ResolveGeneratedFilePath(string outputDirectory, string fileName)
+    {
+        string fullOutputDirectory = Path.GetFullPath(outputDirectory);
+        string outputDirectoryPrefix = fullOutputDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        string fullOutputPath = Path.GetFullPath(Path.Combine(fullOutputDirectory, fileName));
+        StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (!fullOutputPath.StartsWith(outputDirectoryPrefix, comparison))
+        {
+            throw new InvalidOperationException("Generated file path must remain within the output directory.");
+        }
+
+        return fullOutputPath;
+    }
+
+    private static void ValidateGeneratedFileName(string fileName)
+    {
+        if (String.IsNullOrWhiteSpace(fileName))
+        {
+            throw new InvalidOperationException("Generated file name cannot be null or empty.");
+        }
+
+        if (fileName == "."
+            || fileName == ".."
+            || fileName.IndexOf('/') >= 0
+            || fileName.IndexOf('\\') >= 0
+            || fileName.IndexOf(':') >= 0
+            || fileName.IndexOf('"') >= 0
+            || fileName.IndexOf('<') >= 0
+            || fileName.IndexOf('>') >= 0
+            || fileName.IndexOf('|') >= 0
+            || fileName.IndexOf('?') >= 0
+            || fileName.IndexOf('*') >= 0
+            || fileName.EndsWith(".", StringComparison.Ordinal)
+            || fileName.EndsWith(" ", StringComparison.Ordinal)
+            || ContainsControlCharacter(fileName)
+            || IsReservedFileName(fileName))
+        {
+            throw new InvalidOperationException("Generated file name must not include directory information or invalid characters.");
+        }
+    }
+
+    private static bool ContainsControlCharacter(string fileName)
+    {
+        int length = fileName.Length;
+        for (int i = 0; i < length; i++)
+        {
+            if (fileName[i] < 32)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsReservedFileName(string fileName)
+    {
+        string baseName = Path.GetFileNameWithoutExtension(fileName);
+        if (baseName.Equals("CON", StringComparison.OrdinalIgnoreCase)
+            || baseName.Equals("PRN", StringComparison.OrdinalIgnoreCase)
+            || baseName.Equals("AUX", StringComparison.OrdinalIgnoreCase)
+            || baseName.Equals("NUL", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return baseName.Length == 4
+            && (baseName.StartsWith("COM", StringComparison.OrdinalIgnoreCase)
+                || baseName.StartsWith("LPT", StringComparison.OrdinalIgnoreCase))
+            && baseName[3] >= '1'
+            && baseName[3] <= '9';
     }
 
     public virtual string GetCustomToolNamespace(string fileName)

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -8596,6 +8596,8 @@ this.Write("End Namespace\r\n");
 /// </summary>
 /// <param name="context">The code generation context.</param>
 public class FilesManager {
+    private static readonly char[] InvalidGeneratedFileNameChars = { '/', '\\', ':', '"', '<', '>', '|', '?', '*' };
+
     /// <summary>
     /// Creates an instance of the FilesManager. The object used to generate and manage
     /// multiple source files.
@@ -8704,12 +8706,13 @@ public class FilesManager {
             ValidateGeneratedFileNames();
             string headerText = Template.ToString(_header.Start, _header.Length);
             string footerText = Template.ToString(_footer.Start, _footer.Length);
+            string outputPath = Path.GetTempPath();
             int length = files.Count;
             for (int i = length; i > 0; i--)
             {
                 Block block = files[i - 1];
                 if (block.IsContainer) continue;
-                string fileName = Path.GetTempFileName();
+                string fileName = Path.Combine(outputPath, block.Name);
                 string content = headerText + Template.ToString(block.Start, block.Length) + footerText;
                 tasks.Add(CreateFileAsync(fileName, content));
                 block.TemporaryFilePath = fileName;
@@ -8741,13 +8744,9 @@ public class FilesManager {
                 string outputFile = ResolveGeneratedFilePath(referenceFolder, block.Name);
                 bool fileExists = File.Exists(outputFile);
               
-                await handlerHelper.AddFileAsync(fileName, outputFile, new ODataFileOptions { OpenOnComplete = OpenGeneratedFilesInIDE, SuppressOverwritePrompt = true })
-                .ContinueWith(
-                    async _ =>
-                    {
-                        await logger?.WriteMessageAsync(LogMessageCategory.Information,
-                            "\"{0}\" has been {1}.", block.Name, fileExists ? "updated" : "added");
-                    }, System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously);
+                await handlerHelper.AddFileAsync(fileName, outputFile, new ODataFileOptions { OpenOnComplete = OpenGeneratedFilesInIDE, SuppressOverwritePrompt = true });
+                await logger?.WriteMessageAsync(LogMessageCategory.Information,
+                    "\"{0}\" has been {1}.", block.Name, fileExists ? "updated" : "added");
             }
         }
     }
@@ -8810,15 +8809,7 @@ public class FilesManager {
 
         if (fileName == "."
             || fileName == ".."
-            || fileName.IndexOf('/') >= 0
-            || fileName.IndexOf('\\') >= 0
-            || fileName.IndexOf(':') >= 0
-            || fileName.IndexOf('"') >= 0
-            || fileName.IndexOf('<') >= 0
-            || fileName.IndexOf('>') >= 0
-            || fileName.IndexOf('|') >= 0
-            || fileName.IndexOf('?') >= 0
-            || fileName.IndexOf('*') >= 0
+            || fileName.IndexOfAny(InvalidGeneratedFileNameChars) >= 0
             || fileName.EndsWith(".", StringComparison.Ordinal)
             || fileName.EndsWith(" ", StringComparison.Ordinal)
             || ContainsControlCharacter(fileName)

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -8598,6 +8598,15 @@ this.Write("End Namespace\r\n");
 public class FilesManager {
     private static readonly char[] InvalidGeneratedFileNameChars = { '/', '\\', ':', '"', '<', '>', '|', '?', '*' };
 
+    // Windows reserves these device names even when followed by an extension:
+    // console, printer, auxiliary, null, serial ports, and parallel printer ports.
+    private static readonly HashSet<string> ReservedFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON", "PRN", "AUX", "NUL",
+        "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+        "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+    };
+
     /// <summary>
     /// Creates an instance of the FilesManager. The object used to generate and manage
     /// multiple source files.
@@ -8821,6 +8830,7 @@ public class FilesManager {
 
     private static bool ContainsControlCharacter(string fileName)
     {
+        // U+0000 through U+001F are non-printing control characters and invalid in Windows file names.
         int length = fileName.Length;
         for (int i = 0; i < length; i++)
         {
@@ -8836,19 +8846,7 @@ public class FilesManager {
     private static bool IsReservedFileName(string fileName)
     {
         string baseName = Path.GetFileNameWithoutExtension(fileName);
-        if (baseName.Equals("CON", StringComparison.OrdinalIgnoreCase)
-            || baseName.Equals("PRN", StringComparison.OrdinalIgnoreCase)
-            || baseName.Equals("AUX", StringComparison.OrdinalIgnoreCase)
-            || baseName.Equals("NUL", StringComparison.OrdinalIgnoreCase))
-        {
-            return true;
-        }
-
-        return baseName.Length == 4
-            && (baseName.StartsWith("COM", StringComparison.OrdinalIgnoreCase)
-                || baseName.StartsWith("LPT", StringComparison.OrdinalIgnoreCase))
-            && baseName[3] >= '1'
-            && baseName[3] <= '9';
+        return ReservedFileNames.Contains(baseName);
     }
 
     public virtual string GetCustomToolNamespace(string fileName)

--- a/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
+++ b/src/Microsoft.OData.CodeGen/Templates/ODataT4CodeGenerator.cs
@@ -8596,7 +8596,6 @@ this.Write("End Namespace\r\n");
 /// </summary>
 /// <param name="context">The code generation context.</param>
 public class FilesManager {
-
     /// <summary>
     /// Creates an instance of the FilesManager. The object used to generate and manage
     /// multiple source files.
@@ -8702,15 +8701,15 @@ public class FilesManager {
         {
             var tasks = new List<Task>();
             EndBlock();
+            ValidateGeneratedFileNames();
             string headerText = Template.ToString(_header.Start, _header.Length);
             string footerText = Template.ToString(_footer.Start, _footer.Length);
-            var outputPath = Path.GetTempPath();
             int length = files.Count;
             for (int i = length; i > 0; i--)
             {
                 Block block = files[i - 1];
                 if (block.IsContainer) continue;
-                string fileName = Path.Combine(outputPath, block.Name);
+                string fileName = Path.GetTempFileName();
                 string content = headerText + Template.ToString(block.Start, block.Length) + footerText;
                 tasks.Add(CreateFileAsync(fileName, content));
                 block.TemporaryFilePath = fileName;
@@ -8729,6 +8728,7 @@ public class FilesManager {
     {
         if (split)
         {
+            ValidateGeneratedFileNames();
             int length = files.Count;
             await logger?.WriteMessageAsync(LogMessageCategory.Information, "Adding {0} Generated files to the project. This may take a while!", length);
             for (int i = length; i > 0; i--)
@@ -8738,7 +8738,7 @@ public class FilesManager {
                 string fileName = block.TemporaryFilePath;
                 if (!File.Exists(fileName)) continue;
 
-                string outputFile = Path.Combine(referenceFolder, block.Name);
+                string outputFile = ResolveGeneratedFilePath(referenceFolder, block.Name);
                 bool fileExists = File.Exists(outputFile);
               
                 await handlerHelper.AddFileAsync(fileName, outputFile, new ODataFileOptions { OpenOnComplete = OpenGeneratedFilesInIDE, SuppressOverwritePrompt = true })
@@ -8766,6 +8766,98 @@ public class FilesManager {
             fileStream.SetLength(0);
             await writer.WriteAsync(content).ConfigureAwait(false);
         }
+    }
+
+    private void ValidateGeneratedFileNames()
+    {
+        HashSet<string> fileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int length = files.Count;
+        for (int i = length; i > 0; i--)
+        {
+            Block block = files[i - 1];
+            if (block.IsContainer) continue;
+            ValidateGeneratedFileName(block.Name);
+            if (!fileNames.Add(block.Name))
+            {
+                throw new InvalidOperationException("Generated file names must be unique.");
+            }
+        }
+    }
+
+    private static string ResolveGeneratedFilePath(string outputDirectory, string fileName)
+    {
+        string fullOutputDirectory = Path.GetFullPath(outputDirectory);
+        string outputDirectoryPrefix = fullOutputDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
+        string fullOutputPath = Path.GetFullPath(Path.Combine(fullOutputDirectory, fileName));
+        StringComparison comparison = Path.DirectorySeparatorChar == '\\'
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        if (!fullOutputPath.StartsWith(outputDirectoryPrefix, comparison))
+        {
+            throw new InvalidOperationException("Generated file path must remain within the output directory.");
+        }
+
+        return fullOutputPath;
+    }
+
+    private static void ValidateGeneratedFileName(string fileName)
+    {
+        if (String.IsNullOrWhiteSpace(fileName))
+        {
+            throw new InvalidOperationException("Generated file name cannot be null or empty.");
+        }
+
+        if (fileName == "."
+            || fileName == ".."
+            || fileName.IndexOf('/') >= 0
+            || fileName.IndexOf('\\') >= 0
+            || fileName.IndexOf(':') >= 0
+            || fileName.IndexOf('"') >= 0
+            || fileName.IndexOf('<') >= 0
+            || fileName.IndexOf('>') >= 0
+            || fileName.IndexOf('|') >= 0
+            || fileName.IndexOf('?') >= 0
+            || fileName.IndexOf('*') >= 0
+            || fileName.EndsWith(".", StringComparison.Ordinal)
+            || fileName.EndsWith(" ", StringComparison.Ordinal)
+            || ContainsControlCharacter(fileName)
+            || IsReservedFileName(fileName))
+        {
+            throw new InvalidOperationException("Generated file name must not include directory information or invalid characters.");
+        }
+    }
+
+    private static bool ContainsControlCharacter(string fileName)
+    {
+        int length = fileName.Length;
+        for (int i = 0; i < length; i++)
+        {
+            if (fileName[i] < 32)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsReservedFileName(string fileName)
+    {
+        string baseName = Path.GetFileNameWithoutExtension(fileName);
+        if (baseName.Equals("CON", StringComparison.OrdinalIgnoreCase)
+            || baseName.Equals("PRN", StringComparison.OrdinalIgnoreCase)
+            || baseName.Equals("AUX", StringComparison.OrdinalIgnoreCase)
+            || baseName.Equals("NUL", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return baseName.Length == 4
+            && (baseName.StartsWith("COM", StringComparison.OrdinalIgnoreCase)
+                || baseName.StartsWith("LPT", StringComparison.OrdinalIgnoreCase))
+            && baseName[3] >= '1'
+            && baseName[3] <= '9';
     }
 
     public virtual string GetCustomToolNamespace(string fileName)

--- a/test/Microsoft.OData.Cli.Tests/CodeGeneration/ODataCliCodeGenerationTests.cs
+++ b/test/Microsoft.OData.Cli.Tests/CodeGeneration/ODataCliCodeGenerationTests.cs
@@ -249,6 +249,98 @@ namespace Microsoft.OData.Cli.Tests.CodeGeneration
             CodeVerificationHelper.VerifyGeneratedCode(cityProxyExpectedCode, cityProxyGeneratedCode);
         }
 
+        [Fact]
+        public void TestMultipleFilesOptionRejectsGeneratedFileNameWithDirectorySegments()
+        {
+            string uniqueName = $"Outside{Guid.NewGuid():N}";
+            string metadataPath = this.WriteMetadataWithTypeNames("SafeType", $"../{uniqueName}");
+            string outputParent = Directory.GetParent(this.outputDir)!.FullName;
+            string outsidePath = Path.Combine(outputParent, $"{uniqueName}.cs");
+            string originalContent = "Original content";
+            File.WriteAllText(outsidePath, originalContent);
+
+            try
+            {
+                var parseResult = this.generateCommand.Parse(
+                    $"--metadata-uri {metadataPath} --outputdir {this.outputDir} --multiple-files");
+
+                int exitCode = parseResult.Invoke();
+
+                Assert.NotEqual(0, exitCode);
+                Assert.Equal(originalContent, File.ReadAllText(outsidePath));
+                Assert.False(File.Exists(Path.Combine(this.outputDir, "SafeType.cs")));
+            }
+            finally
+            {
+                File.Delete(metadataPath);
+                if (File.Exists(outsidePath))
+                {
+                    File.Delete(outsidePath);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("../Outside", false)]
+        [InlineData(@"..\Outside", false)]
+        [InlineData(@"C:\Outside", false)]
+        [InlineData("../Outside", true)]
+        [InlineData(@"..\Outside", true)]
+        [InlineData(@"C:\Outside", true)]
+        public void TestMultipleFilesOptionRejectsInvalidTypeOrNamespaceFileName(
+            string modelName,
+            bool useModelNamespace)
+        {
+            string metadataPath = useModelNamespace
+                ? this.WriteMetadataWithDuplicateTypeName(modelName)
+                : this.WriteMetadataWithTypeNames(modelName);
+
+            try
+            {
+                var parseResult = this.generateCommand.Parse(
+                    $"--metadata-uri {metadataPath} --outputdir {this.outputDir} --multiple-files");
+
+                int exitCode = parseResult.Invoke();
+
+                Assert.NotEqual(0, exitCode);
+                Assert.False(Directory.Exists(this.outputDir)
+                    && Directory.EnumerateFiles(this.outputDir, "*.cs", SearchOption.AllDirectories).Any());
+            }
+            finally
+            {
+                File.Delete(metadataPath);
+            }
+        }
+
+        [Fact]
+        public void TestDefaultGenerationWithTypeNameContainingDirectorySegmentsCreatesOnlyReferenceFile()
+        {
+            string uniqueName = $"Outside{Guid.NewGuid():N}";
+            string metadataPath = this.WriteMetadataWithTypeNames($"../{uniqueName}");
+            string outputParent = Directory.GetParent(this.outputDir)!.FullName;
+            string outsidePath = Path.Combine(outputParent, $"{uniqueName}.cs");
+
+            try
+            {
+                var parseResult = this.generateCommand.Parse(
+                    $"--metadata-uri {metadataPath} --outputdir {this.outputDir}");
+
+                int exitCode = parseResult.Invoke();
+
+                Assert.Equal(0, exitCode);
+                Assert.True(File.Exists(Path.Combine(this.outputDir, $"{Constants.DefaultReferenceFileName}.cs")));
+                Assert.False(File.Exists(outsidePath));
+            }
+            finally
+            {
+                File.Delete(metadataPath);
+                if (File.Exists(outsidePath))
+                {
+                    File.Delete(outsidePath);
+                }
+            }
+        }
+
         public static IEnumerable<object[]> GetCodeGeneratedForExcludedOperationImportsOptionTestData()
         {
             return
@@ -687,6 +779,44 @@ namespace Microsoft.OData.Cli.Tests.CodeGeneration
             {
                 // Ignore - Temporary files are eventually clean up
             }
+        }
+
+        private string WriteMetadataWithTypeNames(params string[] typeNames)
+        {
+            string metadataPath = Path.Combine(Path.GetTempPath(), $"ODataMetadata-{Guid.NewGuid():N}.xml");
+            string typeElements = String.Concat(typeNames.Select(
+                typeName => $"      <ComplexType Name=\"{typeName}\" />{Environment.NewLine}"));
+            string metadata = $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+                  <edmx:DataServices>
+                    <Schema Namespace="Generated" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                {typeElements}    </Schema>
+                  </edmx:DataServices>
+                </edmx:Edmx>
+                """;
+            File.WriteAllText(metadataPath, metadata);
+            return metadataPath;
+        }
+
+        private string WriteMetadataWithDuplicateTypeName(string namespaceName)
+        {
+            string metadataPath = Path.Combine(Path.GetTempPath(), $"ODataMetadata-{Guid.NewGuid():N}.xml");
+            string metadata = $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+                  <edmx:DataServices>
+                    <Schema Namespace="{namespaceName}" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                      <ComplexType Name="Item" />
+                    </Schema>
+                    <Schema Namespace="Control" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                      <ComplexType Name="Item" />
+                    </Schema>
+                  </edmx:DataServices>
+                </edmx:Edmx>
+                """;
+            File.WriteAllText(metadataPath, metadata);
+            return metadataPath;
         }
 
         private void CreateTestProjectInOutputDir(string targetFramework, string odataClientVersion)

--- a/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
@@ -208,6 +208,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             codeGenDescriptor.AddGeneratedClientCodeAsync(serviceConfig.Endpoint, referenceFolderPath, LanguageOption.GenerateCSharpCode, serviceConfig).Wait();
             var file1TempPath = codeGen.MultipleFilesManager.files[0].TemporaryFilePath;
             var file2TempPath = codeGen.MultipleFilesManager.files[1].TemporaryFilePath;
+            Assert.AreNotEqual(file1TempPath, file2TempPath);
             var expectedMainFilePath = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "Main.cs");
             var mainFile = handlerHelper.AddedFiles.FirstOrDefault(f => f.CreatedFile == expectedMainFilePath);
             Assert.IsNotNull(mainFile);
@@ -220,6 +221,215 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             var file2 = handlerHelper.AddedFiles.FirstOrDefault(f => f.CreatedFile == expectedFile2Path);
             Assert.IsNotNull(file2);
             Assert.AreEqual("Contents2", File.ReadAllText(file2.SourceFile));
+        }
+
+        [TestMethod]
+        public void StartNewFile_WithNullName_ThrowsArgumentNullException()
+        {
+            var manager = new ODataT4CodeGenerator.FilesManager(new StringBuilder());
+
+            Assert.ThrowsException<ArgumentNullException>(() => manager.StartNewFile(null, false));
+        }
+
+        [DataTestMethod]
+        [DataRow("")]
+        [DataRow(" ")]
+        [DataRow(".")]
+        [DataRow("..")]
+        [DataRow("../Outside.cs")]
+        [DataRow(@"..\Outside.cs")]
+        [DataRow("Folder/Outside.cs")]
+        [DataRow(@"Folder\Outside.cs")]
+        [DataRow(@"C:\Outside.cs")]
+        [DataRow("Name:Part.cs")]
+        [DataRow("Name|Part.cs")]
+        [DataRow("Name?Part.cs")]
+        [DataRow("Name*Part.cs")]
+        [DataRow("Name\"Part.cs")]
+        [DataRow("Name<Part.cs")]
+        [DataRow("Name>Part.cs")]
+        [DataRow("Name\u0001Part.cs")]
+        [DataRow("Trailing.")]
+        [DataRow("Trailing ")]
+        [DataRow("CON.cs")]
+        [DataRow("prn.cs")]
+        [DataRow("AUX.cs")]
+        [DataRow("nul.cs")]
+        [DataRow("COM1.cs")]
+        [DataRow("lpt9.cs")]
+        public async Task GenerateFilesAsync_WithNonFileNameValue_ThrowsInvalidOperationException(string fileName)
+        {
+            var template = new StringBuilder();
+            var manager = new ODataT4CodeGenerator.FilesManager(template);
+            manager.StartNewFile("Valid.cs", false);
+            template.Append("Valid");
+            manager.EndBlock();
+            manager.StartNewFile(fileName, false);
+            template.Append("Invalid");
+            manager.EndBlock();
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true));
+
+            Assert.IsTrue(manager.files.All(block => block.TemporaryFilePath == null));
+        }
+
+        [TestMethod]
+        public async Task GenerateFilesAsync_WhenSplitIsFalse_DoesNotCreateQueuedFile()
+        {
+            var template = new StringBuilder();
+            var manager = new ODataT4CodeGenerator.FilesManager(template);
+            string fileName = "../NotGenerated.cs";
+            manager.StartNewFile(fileName, false);
+            template.Append("Contents");
+            manager.EndBlock();
+
+            await manager.GenerateFilesAsync(false);
+
+            Assert.IsNull(manager.files[0].TemporaryFilePath);
+            Assert.AreEqual("Contents", template.ToString());
+        }
+
+        [TestMethod]
+        public async Task GenerateFilesAsync_AfterBlocksAreCleared_DoesNotCreateFiles()
+        {
+            var template = new StringBuilder();
+            var manager = new ODataT4CodeGenerator.FilesManager(template);
+            string fileName = $"Cleared-{Guid.NewGuid():N}.cs";
+            string expectedPath = Path.Combine(Path.GetTempPath(), fileName);
+            manager.StartNewFile(fileName, false);
+            template.Append("Cleared contents");
+            manager.EndBlock();
+            manager.files.Clear();
+
+            await manager.GenerateFilesAsync(true);
+
+            Assert.IsFalse(File.Exists(expectedPath));
+        }
+
+        [TestMethod]
+        public async Task GenerateFilesAsync_AfterBlockIsRemovedAndAnotherIsAdded_GeneratesOnlyCurrentBlock()
+        {
+            var template = new StringBuilder();
+            var manager = new ODataT4CodeGenerator.FilesManager(template);
+            string removedFileName = $"Removed-{Guid.NewGuid():N}.cs";
+            string currentFileName = $"Current-{Guid.NewGuid():N}.cs";
+            string removedPath = Path.Combine(Path.GetTempPath(), removedFileName);
+
+            manager.StartNewFile(removedFileName, false);
+            template.Append("Removed contents");
+            manager.EndBlock();
+            manager.files.RemoveAt(0);
+            manager.StartNewFile(currentFileName, false);
+            template.Append("Current contents");
+            manager.EndBlock();
+
+            try
+            {
+                await manager.GenerateFilesAsync(true);
+
+                Assert.IsFalse(File.Exists(removedPath));
+                Assert.IsTrue(File.Exists(manager.files[0].TemporaryFilePath));
+                Assert.AreEqual("Current contents", File.ReadAllText(manager.files[0].TemporaryFilePath));
+            }
+            finally
+            {
+                string temporaryFilePath = manager.files[0].TemporaryFilePath;
+                if (File.Exists(temporaryFilePath))
+                {
+                    File.Delete(temporaryFilePath);
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow("Same.cs", "Same.cs")]
+        [DataRow("Same.cs", "same.cs")]
+        public async Task GenerateFilesAsync_WithDuplicateNames_RejectsBatchBeforeCreatingFiles(
+            string firstFileName,
+            string secondFileName)
+        {
+            var template = new StringBuilder();
+            var manager = new ODataT4CodeGenerator.FilesManager(template);
+            manager.StartNewFile(firstFileName, false);
+            template.Append("First");
+            manager.EndBlock();
+            manager.StartNewFile(secondFileName, false);
+            template.Append("Second");
+            manager.EndBlock();
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true));
+
+            Assert.IsTrue(manager.files.All(block => block.TemporaryFilePath == null));
+        }
+
+        [TestMethod]
+        public async Task GenerateFilesAsync_WithChangedBlockName_RejectsOutputBeforeCreatingFile()
+        {
+            var template = new StringBuilder();
+            var manager = new ODataT4CodeGenerator.FilesManager(template);
+            string outsideFileName = $"Outside-{Guid.NewGuid():N}.cs";
+            string changedName = $"../{outsideFileName}";
+            string outsidePath = Path.GetFullPath(Path.Combine(Path.GetTempPath(), changedName));
+            manager.StartNewFile($"Original-{Guid.NewGuid():N}.cs", false);
+            template.Append("Contents");
+            manager.EndBlock();
+            manager.files[0].Name = changedName;
+
+            try
+            {
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true));
+
+                Assert.IsFalse(File.Exists(outsidePath));
+                Assert.IsNull(manager.files[0].TemporaryFilePath);
+            }
+            finally
+            {
+                if (File.Exists(outsidePath))
+                {
+                    File.Delete(outsidePath);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task CopyGeneratedFilesAsync_WithChangedBlockName_RejectsOutputBeforeAddingFile()
+        {
+            var template = new StringBuilder();
+            var manager = new ODataT4CodeGenerator.FilesManager(template);
+            var fileHandler = new Mock<IFileHandler>();
+            var logger = new Mock<IMessageLogger>();
+            string originalFileName = $"Original-{Guid.NewGuid():N}.cs";
+            string outsideFileName = $"Outside-{Guid.NewGuid():N}.cs";
+            string referenceFolder = Path.Combine(TestProjectRootPath, ServicesRootFolder, "MyService");
+            string outsidePath = Path.GetFullPath(Path.Combine(referenceFolder, "..", outsideFileName));
+            manager.StartNewFile(originalFileName, false);
+            template.Append("Contents");
+            manager.EndBlock();
+
+            try
+            {
+                await manager.GenerateFilesAsync(true);
+                manager.files[0].Name = $"../{outsideFileName}";
+
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                    manager.CopyGeneratedFilesAsync(true, fileHandler.Object, logger.Object, referenceFolder, true, false));
+
+                Assert.IsFalse(File.Exists(outsidePath));
+                fileHandler.Verify(
+                    handler => handler.AddFileAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<ODataFileOptions>()),
+                    Times.Never);
+            }
+            finally
+            {
+                string temporaryFilePath = manager.files[0].TemporaryFilePath;
+                if (File.Exists(temporaryFilePath))
+                {
+                    File.Delete(temporaryFilePath);
+                }
+            }
         }
 
         [TestMethod]

--- a/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
@@ -250,23 +250,105 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
         [DataRow("Folder/Outside.cs")]
         [DataRow(@"Folder\Outside.cs")]
         [DataRow(@"C:\Outside.cs")]
-        [DataRow("Name:Part.cs")]
-        [DataRow("Name|Part.cs")]
-        [DataRow("Name?Part.cs")]
-        [DataRow("Name*Part.cs")]
-        [DataRow("Name\"Part.cs")]
-        [DataRow("Name<Part.cs")]
-        [DataRow("Name>Part.cs")]
-        [DataRow("Name\u0001Part.cs")]
         [DataRow("Trailing.")]
         [DataRow("Trailing ")]
-        [DataRow("CON.cs")]
-        [DataRow("prn.cs")]
-        [DataRow("AUX.cs")]
-        [DataRow("nul.cs")]
-        [DataRow("COM1.cs")]
-        [DataRow("lpt9.cs")]
         public async Task GenerateFilesAsync_WithNonFileNameValue_ThrowsInvalidOperationException(string fileName)
+        {
+            await AssertGeneratedFileNameRejectedAsync(fileName).ConfigureAwait(false);
+        }
+
+        public static IEnumerable<object[]> ReservedFileNameTestData
+        {
+            get
+            {
+                string[] reservedFileNames =
+                {
+                    "CON", "PRN", "AUX", "NUL",
+                    "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+                    "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+                };
+
+                foreach (string reservedFileName in reservedFileNames)
+                {
+                    yield return new object[] { $"{reservedFileName}.cs" };
+                }
+
+                yield return new object[] { "con.CS" };
+            }
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(ReservedFileNameTestData), DynamicDataSourceType.Property)]
+        public async Task GenerateFilesAsync_WithReservedFileName_ThrowsInvalidOperationException(string fileName)
+        {
+            await AssertGeneratedFileNameRejectedAsync(fileName).ConfigureAwait(false);
+        }
+
+        public static IEnumerable<object[]> ControlCharacterTestData
+        {
+            get
+            {
+                for (int value = 0; value < 32; value++)
+                {
+                    yield return new object[] { $"Name{(char)value}Part.cs" };
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(ControlCharacterTestData), DynamicDataSourceType.Property)]
+        public async Task GenerateFilesAsync_WithControlCharacter_ThrowsInvalidOperationException(string fileName)
+        {
+            await AssertGeneratedFileNameRejectedAsync(fileName).ConfigureAwait(false);
+        }
+
+        public static IEnumerable<object[]> InvalidGeneratedFileNameCharacterTestData
+        {
+            get
+            {
+                char[] invalidCharacters = { '/', '\\', ':', '"', '<', '>', '|', '?', '*' };
+                foreach (char invalidCharacter in invalidCharacters)
+                {
+                    yield return new object[] { $"Name{invalidCharacter}Part.cs" };
+                }
+            }
+        }
+
+        [DataTestMethod]
+        [DynamicData(nameof(InvalidGeneratedFileNameCharacterTestData), DynamicDataSourceType.Property)]
+        public async Task GenerateFilesAsync_WithInvalidFileNameCharacter_ThrowsInvalidOperationException(string fileName)
+        {
+            await AssertGeneratedFileNameRejectedAsync(fileName).ConfigureAwait(false);
+        }
+
+        [DataTestMethod]
+        [DataRow("COM0.cs")]
+        [DataRow("COM10.cs")]
+        [DataRow("LPT0.cs")]
+        [DataRow("LPT10.cs")]
+        [DataRow("Console.cs")]
+        [DataRow("Name Part.cs")]
+        public async Task GenerateFilesAsync_WithSimilarValidFileName_GeneratesFile(string fileName)
+        {
+            var template = new StringBuilder();
+            var manager = new ODataT4CodeGenerator.FilesManager(template);
+            manager.StartNewFile(fileName, false);
+            template.Append("Contents");
+            manager.EndBlock();
+
+            try
+            {
+                await manager.GenerateFilesAsync(true).ConfigureAwait(false);
+
+                Assert.IsTrue(File.Exists(manager.files[0].TemporaryFilePath));
+            }
+            finally
+            {
+                File.Delete(manager.files[0].TemporaryFilePath);
+            }
+        }
+
+        private static async Task AssertGeneratedFileNameRejectedAsync(string fileName)
         {
             var template = new StringBuilder();
             var manager = new ODataT4CodeGenerator.FilesManager(template);
@@ -277,7 +359,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             template.Append("Invalid");
             manager.EndBlock();
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true));
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true)).ConfigureAwait(false);
 
             Assert.IsTrue(manager.files.All(block => block.TemporaryFilePath == null));
         }
@@ -292,7 +374,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             template.Append("Contents");
             manager.EndBlock();
 
-            await manager.GenerateFilesAsync(false);
+            await manager.GenerateFilesAsync(false).ConfigureAwait(false);
 
             Assert.IsNull(manager.files[0].TemporaryFilePath);
             Assert.AreEqual("Contents", template.ToString());
@@ -310,7 +392,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             manager.EndBlock();
             manager.files.Clear();
 
-            await manager.GenerateFilesAsync(true);
+            await manager.GenerateFilesAsync(true).ConfigureAwait(false);
 
             Assert.IsFalse(File.Exists(expectedPath));
         }
@@ -334,7 +416,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
 
             try
             {
-                await manager.GenerateFilesAsync(true);
+                await manager.GenerateFilesAsync(true).ConfigureAwait(false);
 
                 Assert.IsFalse(File.Exists(removedPath));
                 Assert.IsTrue(File.Exists(manager.files[0].TemporaryFilePath));
@@ -366,7 +448,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             template.Append("Second");
             manager.EndBlock();
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true));
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true)).ConfigureAwait(false);
 
             Assert.IsTrue(manager.files.All(block => block.TemporaryFilePath == null));
         }
@@ -386,7 +468,7 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
 
             try
             {
-                await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true));
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => manager.GenerateFilesAsync(true)).ConfigureAwait(false);
 
                 Assert.IsFalse(File.Exists(outsidePath));
                 Assert.IsNull(manager.files[0].TemporaryFilePath);
@@ -417,11 +499,11 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
 
             try
             {
-                await manager.GenerateFilesAsync(true);
+                await manager.GenerateFilesAsync(true).ConfigureAwait(false);
                 manager.files[0].Name = $"../{outsideFileName}";
 
                 await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
-                    manager.CopyGeneratedFilesAsync(true, fileHandler.Object, logger.Object, referenceFolder, true, false));
+                    manager.CopyGeneratedFilesAsync(true, fileHandler.Object, logger.Object, referenceFolder, true, false)).ConfigureAwait(false);
 
                 Assert.IsFalse(File.Exists(outsidePath));
                 fileHandler.Verify(

--- a/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
@@ -257,28 +257,30 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             await AssertGeneratedFileNameRejectedAsync(fileName).ConfigureAwait(false);
         }
 
-        public static IEnumerable<object[]> ReservedFileNameTestData
-        {
-            get
-            {
-                string[] reservedFileNames =
-                {
-                    "CON", "PRN", "AUX", "NUL",
-                    "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
-                    "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
-                };
-
-                foreach (string reservedFileName in reservedFileNames)
-                {
-                    yield return new object[] { $"{reservedFileName}.cs" };
-                }
-
-                yield return new object[] { "con.CS" };
-            }
-        }
-
         [DataTestMethod]
-        [DynamicData(nameof(ReservedFileNameTestData), DynamicDataSourceType.Property)]
+        [DataRow("CON.cs")]
+        [DataRow("PRN.cs")]
+        [DataRow("AUX.cs")]
+        [DataRow("NUL.cs")]
+        [DataRow("COM1.cs")]
+        [DataRow("COM2.cs")]
+        [DataRow("COM3.cs")]
+        [DataRow("COM4.cs")]
+        [DataRow("COM5.cs")]
+        [DataRow("COM6.cs")]
+        [DataRow("COM7.cs")]
+        [DataRow("COM8.cs")]
+        [DataRow("COM9.cs")]
+        [DataRow("LPT1.cs")]
+        [DataRow("LPT2.cs")]
+        [DataRow("LPT3.cs")]
+        [DataRow("LPT4.cs")]
+        [DataRow("LPT5.cs")]
+        [DataRow("LPT6.cs")]
+        [DataRow("LPT7.cs")]
+        [DataRow("LPT8.cs")]
+        [DataRow("LPT9.cs")]
+        [DataRow("con.CS")]
         public async Task GenerateFilesAsync_WithReservedFileName_ThrowsInvalidOperationException(string fileName)
         {
             await AssertGeneratedFileNameRejectedAsync(fileName).ConfigureAwait(false);

--- a/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
+++ b/test/ODataConnectedService.Tests/CodeGeneration/CodeGenDescriptorTest.cs
@@ -204,23 +204,32 @@ namespace Microsoft.OData.ConnectedService.Tests.CodeGeneration
             // when ODataT4CodeGenerator.TransformText() was called. Since we're using a dummy code generator
             // we need to manually ensure those files exist
             codeGen.MultipleFilesManager.GenerateFilesAsync(true).Wait();
-            
-            codeGenDescriptor.AddGeneratedClientCodeAsync(serviceConfig.Endpoint, referenceFolderPath, LanguageOption.GenerateCSharpCode, serviceConfig).Wait();
             var file1TempPath = codeGen.MultipleFilesManager.files[0].TemporaryFilePath;
             var file2TempPath = codeGen.MultipleFilesManager.files[1].TemporaryFilePath;
-            Assert.AreNotEqual(file1TempPath, file2TempPath);
-            var expectedMainFilePath = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "Main.cs");
-            var mainFile = handlerHelper.AddedFiles.FirstOrDefault(f => f.CreatedFile == expectedMainFilePath);
-            Assert.IsNotNull(mainFile);
-            Assert.AreEqual("Generated code", File.ReadAllText(mainFile.SourceFile));
-            var expectedFile1Path = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "File1.cs");
-            var file1 = handlerHelper.AddedFiles.FirstOrDefault(f => f.CreatedFile == expectedFile1Path);
-            Assert.IsNotNull(file1);
-            Assert.AreEqual("Contents1", File.ReadAllText(file1.SourceFile));
-            var expectedFile2Path = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "File2.cs");
-            var file2 = handlerHelper.AddedFiles.FirstOrDefault(f => f.CreatedFile == expectedFile2Path);
-            Assert.IsNotNull(file2);
-            Assert.AreEqual("Contents2", File.ReadAllText(file2.SourceFile));
+            try
+            {
+                codeGenDescriptor.AddGeneratedClientCodeAsync(serviceConfig.Endpoint, referenceFolderPath, LanguageOption.GenerateCSharpCode, serviceConfig).Wait();
+                Assert.AreNotEqual(file1TempPath, file2TempPath);
+                Assert.AreEqual(Path.Combine(Path.GetTempPath(), "File1.cs"), file1TempPath);
+                Assert.AreEqual(Path.Combine(Path.GetTempPath(), "File2.cs"), file2TempPath);
+                var expectedMainFilePath = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "Main.cs");
+                var mainFile = handlerHelper.AddedFiles.FirstOrDefault(f => f.CreatedFile == expectedMainFilePath);
+                Assert.IsNotNull(mainFile);
+                Assert.AreEqual("Generated code", File.ReadAllText(mainFile.SourceFile));
+                var expectedFile1Path = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "File1.cs");
+                var file1 = handlerHelper.AddedFiles.FirstOrDefault(f => f.CreatedFile == expectedFile1Path);
+                Assert.IsNotNull(file1);
+                Assert.AreEqual("Contents1", File.ReadAllText(file1.SourceFile));
+                var expectedFile2Path = Path.Combine(TestProjectRootPath, ServicesRootFolder, serviceName, "File2.cs");
+                var file2 = handlerHelper.AddedFiles.FirstOrDefault(f => f.CreatedFile == expectedFile2Path);
+                Assert.IsNotNull(file2);
+                Assert.AreEqual("Contents2", File.ReadAllText(file2.SourceFile));
+            }
+            finally
+            {
+                File.Delete(file1TempPath);
+                File.Delete(file2TempPath);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
Ensure multiple-file code generation accepts only standalone, unique output filenames and keeps every final output within the selected directory.

## Changes

- Validate the complete set of non-container generated filenames before creating any split output.
- Reject null, empty, whitespace-only, path-like, rooted, reserved, control-character, trailing-dot, trailing-space, and otherwise invalid filenames.
- Reject case-insensitive duplicate filenames before any file is created.
- Preserve the established temporary staging path for valid generated filenames.
- Resolve final output paths to full paths and require them to remain within the selected output directory.
- Apply validation only when multiple-file generation is enabled, preserving existing single-file behavior.
- Keep the T4 include source and generated C# implementation aligned.

## Before

Multiple-file generation combined metadata-derived names directly with both the temporary and selected output directories. A path-like name could resolve outside those directories. Concurrent generations that produced the same filename could also use the same temporary path and overwrite one another before final placement.

## After

Multiple-file generation validates the entire filename batch before writing.
Invalid or conflicting names stop generation, and final paths are checked against the selected output directory before copying. Valid generated filenames retain their established temporary staging paths, and single-file generation is unchanged.